### PR TITLE
Unify source label display and allow configurable count for /api/recipes/random

### DIFF
--- a/client/src/pages/recipes/components/RecipeCard.tsx
+++ b/client/src/pages/recipes/components/RecipeCard.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { SpoonRating } from "@/components/SpoonRating";
 import { Clock, Users } from "lucide-react";
 import type { RecipeItem } from "../lib/recipeList.types";
-import { getImage, getInstructionPreview } from "../lib/recipeDisplay";
+import { getImage, getInstructionPreview, getSourceLabel } from "../lib/recipeDisplay";
 
 export function RecipeCard({ r, onCardClick }: { r: RecipeItem; onCardClick: (recipe: RecipeItem) => void }) {
   const img = getImage(r);
@@ -55,7 +55,7 @@ export function RecipeCard({ r, onCardClick }: { r: RecipeItem; onCardClick: (re
         <div className="flex flex-wrap gap-1">
           {r.cuisine ? <Badge variant="secondary">{r.cuisine}</Badge> : null}
           {r.mealType ? <Badge variant="outline">{r.mealType}</Badge> : null}
-          <Badge variant="secondary">{r.source === "chefsire" ? "ChefSire" : "External"}</Badge>
+          <Badge variant="secondary">{getSourceLabel(r)}</Badge>
           {(r.dietTags || []).slice(0, 3).map((t) => (
             <Badge key={t} variant="outline" className="capitalize">
               {t}

--- a/client/src/pages/recipes/components/RecipeModal.tsx
+++ b/client/src/pages/recipes/components/RecipeModal.tsx
@@ -4,7 +4,7 @@ import { SpoonRating } from "@/components/SpoonRating";
 import { RecipeReviews } from "@/components/RecipeReviews";
 import { Clock, ExternalLink, Users } from "lucide-react";
 import type { RecipeItem } from "../lib/recipeList.types";
-import { extractInstructions, getImage, getSourceUrl } from "../lib/recipeDisplay";
+import { extractInstructions, getImage, getSourceLabel, getSourceUrl } from "../lib/recipeDisplay";
 
 export function RecipeModal({ r, isOpen, onClose }: { r: RecipeItem | null; isOpen: boolean; onClose: () => void }) {
   if (!isOpen || !r) return null;
@@ -41,7 +41,7 @@ export function RecipeModal({ r, isOpen, onClose }: { r: RecipeItem | null; isOp
           <div className="flex flex-wrap gap-2 mb-4">
             {r.cuisine && <Badge variant="secondary">{r.cuisine}</Badge>}
             {r.mealType && <Badge variant="outline">{r.mealType}</Badge>}
-            <Badge variant="secondary">{r.source === "chefsire" ? "ChefSire" : "External"}</Badge>
+            <Badge variant="secondary">{getSourceLabel(r)}</Badge>
             {(r.dietTags || []).map((t) => (
               <Badge key={t} variant="outline" className="capitalize">
                 {t}

--- a/client/src/pages/recipes/lib/recipeDisplay.ts
+++ b/client/src/pages/recipes/lib/recipeDisplay.ts
@@ -65,3 +65,10 @@ export function getSourceUrl(r: RecipeItem): string | null {
   }
   return null;
 }
+
+export function getSourceLabel(r: RecipeItem): string {
+  if (r.source === "chefsire") return "ChefSire";
+  if (r.source === "external") return "External";
+  if (r.source === "all") return "ChefSire + External";
+  return "External";
+}

--- a/server/routes/recipes.ts
+++ b/server/routes/recipes.ts
@@ -204,7 +204,15 @@ router.get("/random", async (req, res) => {
   noStore(res);
   try {
     const { source } = parseRecipeSearchParams(req.query as Record<string, unknown>);
-    const result = await searchRecipes({ pageSize: DEFAULT_RECIPES_PAGE_SIZE, source });
+    const requestedCount = parseNumberParam(
+      typeof req.query.count === "string" || typeof req.query.count === "number"
+        ? req.query.count
+        : req.query.pageSize,
+      DEFAULT_RECIPES_PAGE_SIZE,
+    );
+    const pageSize =
+      Number.isFinite(requestedCount) && requestedCount > 0 ? requestedCount : DEFAULT_RECIPES_PAGE_SIZE;
+    const result = await searchRecipes({ pageSize, source });
     res.json({ ok: true, ...withItemsFromResults(result) });
   } catch (err: any) {
     console.error("recipes random error:", err);


### PR DESCRIPTION
### Motivation
- Standardize how recipe source labels are rendered in the UI so multiple components show the same text.
- Surface a small UX improvement to allow clients to request a custom number of random recipes via query parameters.

### Description
- Added `getSourceLabel` to `client/src/pages/recipes/lib/recipeDisplay.ts` to centralize source label logic and return user-facing labels like `ChefSire`, `External`, or `ChefSire + External`.
- Updated `RecipeCard` and `RecipeModal` to import and use `getSourceLabel` instead of inline source ternaries.
- Enhanced the server `GET /api/recipes/random` handler to accept a `count` (or `pageSize`) query parameter, parse it with `parseNumberParam`, and pass a validated `pageSize` into `searchRecipes` with a fallback to `DEFAULT_RECIPES_PAGE_SIZE`.

### Testing
- Ran the project type-check with `tsc --noEmit` and the TypeScript build passed without errors.
- Ran the test suite with `npm test` and lint with `npm run lint`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d855086cf08325895b12c1cb6778e3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
