### PR TITLE
Harden recipe save auth userId normalization in recipes routes

### DIFF
--- a/server/routes/recipes.ts
+++ b/server/routes/recipes.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { searchRecipes } from "../services/recipes-service";
 import { storage } from "../storage";
 import { requireAuth } from "../middleware/auth";
-import { resolveAuthenticatedUserId } from "./recipes/auth";
+import { resolveSaveRouteUserId } from "./recipes/auth";
 import { normalizeIngredients, normalizeInstructions, withItemsFromResults } from "./recipes/serializers";
 import {
   DEFAULT_RECIPES_PAGE_SIZE,
@@ -234,12 +234,9 @@ router.get("/trending", async (req, res) => {
  */
 router.post("/:id/save", requireAuth, async (req, res) => {
   try {
-    const requestedUserId = typeof req.body?.userId === "string" ? req.body.userId : undefined;
     const recipeId = req.params.id;
-    const userId = resolveAuthenticatedUserId(req, requestedUserId);
-    if (!userId) {
-      return res.status(403).json({ ok: false, error: "Not allowed" });
-    }
+    const userId = resolveSaveRouteUserId(req, res);
+    if (!userId) return;
 
     const save = await storage.saveRecipe(userId, recipeId);
     res.status(201).json({ ok: true, save });
@@ -255,12 +252,9 @@ router.post("/:id/save", requireAuth, async (req, res) => {
  */
 router.delete("/:id/save", requireAuth, async (req, res) => {
   try {
-    const requestedUserId = typeof req.query.userId === "string" ? req.query.userId : undefined;
     const recipeId = req.params.id;
-    const userId = resolveAuthenticatedUserId(req, requestedUserId);
-    if (!userId) {
-      return res.status(403).json({ ok: false, error: "Not allowed" });
-    }
+    const userId = resolveSaveRouteUserId(req, res);
+    if (!userId) return;
 
     const ok = await storage.unsaveRecipe(userId, recipeId);
     res.json({ ok });
@@ -275,12 +269,9 @@ router.delete("/:id/save", requireAuth, async (req, res) => {
  */
 router.get("/:id/save-status", requireAuth, async (req, res) => {
   try {
-    const requestedUserId = typeof req.query.userId === "string" ? req.query.userId : undefined;
     const recipeId = req.params.id;
-    const userId = resolveAuthenticatedUserId(req, requestedUserId);
-    if (!userId) {
-      return res.status(403).json({ ok: false, error: "Not allowed" });
-    }
+    const userId = resolveSaveRouteUserId(req, res);
+    if (!userId) return;
 
     const isSaved = await storage.isRecipeSaved(userId, recipeId);
     res.json({ ok: true, isSaved });

--- a/server/routes/recipes/auth.ts
+++ b/server/routes/recipes/auth.ts
@@ -1,4 +1,4 @@
-import type { Request } from "express";
+import type { Request, Response } from "express";
 
 type UserWithId = { id: string };
 
@@ -13,4 +13,22 @@ export function resolveAuthenticatedUserId(req: RequestWithUser, requestedUserId
   }
 
   return authenticatedUserId;
+}
+
+export function extractRequestedUserId(req: Request): string | undefined {
+  const fromBody = typeof req.body?.userId === "string" ? req.body.userId : undefined;
+  if (fromBody !== undefined) return fromBody;
+
+  return typeof req.query?.userId === "string" ? req.query.userId : undefined;
+}
+
+export function resolveSaveRouteUserId(req: RequestWithUser, res: Response): string | null {
+  const requestedUserId = extractRequestedUserId(req);
+  const userId = resolveAuthenticatedUserId(req, requestedUserId);
+  if (!userId) {
+    res.status(403).json({ ok: false, error: "Not allowed" });
+    return null;
+  }
+
+  return userId;
 }


### PR DESCRIPTION
### Motivation
- Normalize and centralize `userId` resolution for save-related endpoints to remove client/server contract drift between `body` vs `query` usage.
- Remove duplicated coercion/403 logic from `server/routes/recipes.ts` while keeping the file as the route orchestrator and preserving existing paths and response shapes.

### Description
- Added `extractRequestedUserId(req)` and `resolveSaveRouteUserId(req, res)` helpers to `server/routes/recipes/auth.ts` to normalize `userId` from either request body or query and centralize the authenticated-owner check.
- Updated `POST /:id/save`, `DELETE /:id/save`, and `GET /:id/save-status` in `server/routes/recipes.ts` to call `resolveSaveRouteUserId` and early-return on a failed check, removing duplicated parsing/403 responses.
- No route paths, successful response shapes, DB/schema/migration logic, or review/external-hydration flows were changed.
- Files changed: `server/routes/recipes.ts`, `server/routes/recipes/auth.ts`; Files created: none; Extracted/hardened: save-route userId normalization and consistent 403 handling.

### Testing
- Ran `npm run build` and it completed successfully.
- Ran `npm run build:server` and it completed successfully.
- Performed targeted imports with `npx tsx` to validate module surface: a first attempt using a top-level-`await` invocation failed due to the eval wrapper (expected tool invocation error), and a corrected async-wrapped import of `./server/routes/recipes.ts` succeeded.
- Imported `./server/app.ts` with the async wrapper and it succeeded (with expected local env warnings about missing `DATABASE_URL`/OAuth secrets unrelated to these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d961ab6e008325b5924a8302aa5eff)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
