### PR TITLE
Fix review create regression for external recipe IDs with null-safe payload handling

### DIFF
--- a/server/routes/reviews.ts
+++ b/server/routes/reviews.ts
@@ -22,6 +22,10 @@ import { sendRecipeReviewNotification } from "../services/notification-service";
 const router = Router();
 
 async function resolveRecipeIdForReview(recipeId: string): Promise<string> {
+  if (typeof recipeId !== "string" || !recipeId.trim()) {
+    throw new Error("Recipe id is required");
+  }
+
   if (!recipeId.includes("_")) return recipeId;
 
   const savedRecipe = await RecipeService.findOrCreateExternalRecipe(db, recipeId);
@@ -130,7 +134,23 @@ router.post("/", requireAuth, async (req: Request, res: Response) => {
     console.log("📝 Request body:", JSON.stringify(req.body, null, 2));
 
     const userId = (req as any).user.id;
-    let { recipeId, rating, reviewText } = req.body;
+    const body = (req.body && typeof req.body === "object") ? req.body : {};
+    let recipeId = typeof body.recipeId === "string" ? body.recipeId.trim() : "";
+    const rating = typeof body.rating === "number" ? body.rating : Number(body.rating);
+    const reviewText = typeof body.reviewText === "string" ? body.reviewText : null;
+
+    // Defensive normalization for optional client payload fields used by some review clients.
+    const media = Array.isArray(body.media) ? body.media : [];
+    const photos = Array.isArray(body.photos) ? body.photos : [];
+    const metadata = body.metadata && typeof body.metadata === "object" ? body.metadata : {};
+    const details = body.details && typeof body.details === "object" ? body.details : {};
+
+    console.log("📝 Optional payload normalized:", {
+      mediaCount: media.length,
+      photosCount: photos.length,
+      metadataKeys: Object.keys(metadata).length,
+      detailsKeys: Object.keys(details).length,
+    });
     console.log("📝 Parsed data:", { userId, recipeId, rating, reviewText, recipeIdType: typeof recipeId });
 
     // Validate rating
@@ -230,25 +250,29 @@ router.post("/", requireAuth, async (req: Request, res: Response) => {
     console.log("📝 ============ CREATE REVIEW SUCCESS ============");
     res.status(201).json({ ...completeReview, photos: [] });
   } catch (error: any) {
+    const errorObj = (error && typeof error === "object")
+      ? error
+      : { message: typeof error === "string" ? error : "Unknown error", raw: error };
+
     console.error("❌ ============ CREATE REVIEW ERROR ============");
-    console.error("❌ Error creating review:", error);
+    console.error("❌ Error creating review:", errorObj);
     console.error("❌ Error details:", {
-      name: error.name,
-      message: error.message,
-      code: error.code,
-      detail: error.detail,
-      constraint: error.constraint,
-      table: error.table,
-      column: error.column,
-      stack: error.stack?.split('\n').slice(0, 5).join('\n')
+      name: (errorObj as any).name,
+      message: (errorObj as any).message,
+      code: (errorObj as any).code,
+      detail: (errorObj as any).detail,
+      constraint: (errorObj as any).constraint,
+      table: (errorObj as any).table,
+      column: (errorObj as any).column,
+      stack: (errorObj as any).stack?.split('\n').slice(0, 5).join('\n')
     });
-    console.error("❌ Full error object:", JSON.stringify(error, Object.getOwnPropertyNames(error), 2));
+    console.error("❌ Full error object:", JSON.stringify(errorObj, Object.getOwnPropertyNames(errorObj), 2));
 
     res.status(500).json({
       error: "Failed to create review",
-      details: error.message,
-      code: error.code,
-      constraint: error.constraint
+      details: (errorObj as any).message || "Unknown error",
+      code: (errorObj as any).code,
+      constraint: (errorObj as any).constraint
     });
   }
 });


### PR DESCRIPTION
### Motivation
- A crash occurred when creating reviews for external recipe IDs (e.g. `mealdb_53124`) with optional/missing fields, surfacing as `cannot convert undefined or null to object` during payload handling or error logging. 
- The intent is to restore review creation while keeping existing route behavior and external-ID canonicalization intact with minimal, additive fixes.

### Description
- Add an input guard in `resolveRecipeIdForReview` to fail fast on missing/empty `recipeId` and preserve `mealdb_*` -> local resolution via `RecipeService.findOrCreateExternalRecipe`.
- Normalize the POST body in `server/routes/reviews.ts` by coercing `req.body` to an object, trimming `recipeId`, converting `rating` to a number, and making `reviewText` nullable. 
- Null-safe optional payload normalization for `media`, `photos`, `metadata`, and `details` so no `Object.keys`/spread/array ops run on null/undefined values. 
- Harden the create-route `catch` block to safely handle non-`Error` throw values when logging/serializing, preventing secondary crashes during error reporting.

### Testing
- Built the project end-to-end with `npm run build` and `npm run build:server`, both completed successfully. 
- Verified route imports with `npx tsx -e "import './server/routes/reviews.ts'; console.log('reviews route import ok');"` which printed success. 
- Performed focused grep/import checks for the POST create path and the new null-safe lines in `server/routes/reviews.ts` to ensure the intended changes are present. 

Outcome: review creation for external recipe IDs like `mealdb_53124` should now work with missing/null optional payload fields while preserving create/read canonicalization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d974e0f198832580c18d9769405450)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1038" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
