### PR TITLE
Fix authenticated recipe review create regressions

### DIFF
--- a/server/routes/reviews.ts
+++ b/server/routes/reviews.ts
@@ -21,14 +21,22 @@ import { sendRecipeReviewNotification } from "../services/notification-service";
 
 const router = Router();
 
+function isExternalRecipeRef(recipeId: string): boolean {
+  // Only treat known external provider IDs as external refs.
+  // This avoids misclassifying local IDs that happen to contain underscores.
+  return /^mealdb_[^_]+$/i.test(recipeId);
+}
+
 async function resolveRecipeIdForReview(recipeId: string): Promise<string> {
   if (typeof recipeId !== "string" || !recipeId.trim()) {
     throw new Error("Recipe id is required");
   }
 
-  if (!recipeId.includes("_")) return recipeId;
+  const normalizedRecipeId = recipeId.trim();
 
-  const savedRecipe = await RecipeService.findOrCreateExternalRecipe(db, recipeId);
+  if (!isExternalRecipeRef(normalizedRecipeId)) return normalizedRecipeId;
+
+  const savedRecipe = await RecipeService.findOrCreateExternalRecipe(db, normalizedRecipeId);
   if (!savedRecipe?.id) {
     throw new Error("Failed to resolve external recipe id");
   }
@@ -226,7 +234,12 @@ router.post("/", requireAuth, async (req: Request, res: Response) => {
       .leftJoin(users, eq(recipeReviews.userId, users.id))
       .where(eq(recipeReviews.id, review.id));
 
-    console.log("✅ Complete review fetched:", completeReview.id);
+    const safeCompleteReview = completeReview ?? {
+      ...review,
+      user: null,
+    };
+
+    console.log("✅ Complete review fetched:", safeCompleteReview.id);
 
     // Send notification to recipe author
     const [recipe] = await db
@@ -235,12 +248,12 @@ router.post("/", requireAuth, async (req: Request, res: Response) => {
       .where(eq(recipes.id, recipeId))
       .limit(1);
 
-    if (recipe && recipe.userId && recipe.userId !== userId && completeReview.user) {
+    if (recipe && recipe.userId && recipe.userId !== userId && safeCompleteReview.user) {
       sendRecipeReviewNotification(
         recipe.userId,
         userId,
-        completeReview.user.username || completeReview.user.displayName || 'Someone',
-        completeReview.user.avatar,
+        safeCompleteReview.user.username || safeCompleteReview.user.displayName || 'Someone',
+        safeCompleteReview.user.avatar,
         recipeId,
         recipe.title || 'your recipe',
         rating
@@ -248,7 +261,7 @@ router.post("/", requireAuth, async (req: Request, res: Response) => {
     }
 
     console.log("📝 ============ CREATE REVIEW SUCCESS ============");
-    res.status(201).json({ ...completeReview, photos: [] });
+    res.status(201).json({ ...safeCompleteReview, photos: [] });
   } catch (error: any) {
     const errorObj = (error && typeof error === "object")
       ? error


### PR DESCRIPTION
### Motivation
- Restore authenticated review creation and eliminate two regressions: a runtime `cannot convert undefined or null to object` crash and false “already reviewed” blocking for brand‑new recipes. 
- Identify and keep recipe identity normalization single‑sourced so duplicate checks and reads use the same key while preserving external recipe support (e.g. `mealdb_*`).

### Description
- Tighten external ID detection by adding `isExternalRecipeRef()` and only resolving external recipes for canonical external refs (pattern `mealdb_<id>`), and trim/localize non‑external IDs to avoid misclassifying local IDs that contain underscores. (changed in `server/routes/reviews.ts`).
- Use a single normalized recipe id (`normalizedRecipeId`) when calling `RecipeService.findOrCreateExternalRecipe()` so create + read use the same identity. (changed in `server/routes/reviews.ts`).
- Harden post‑insert readback by introducing `safeCompleteReview = completeReview ?? { ...review, user: null }` and return/spread `safeCompleteReview` to prevent spreading `undefined` and the null/object crash. (changed in `server/routes/reviews.ts`).
- Preserved existing duplicate check `where(and(eq(recipeReviews.recipeId, recipeId), eq(recipeReviews.userId, userId)))` behavior so true duplicates are still blocked while avoiding false positives caused by identity drift. (behavior maintained in `server/routes/reviews.ts`).

### Testing
- Ran `npm run build` and the full build completed successfully. (passed)
- Ran `npm run build:server` and server bundle built successfully. (passed)
- Executed `npx tsx -e "import './server/routes/reviews.ts'; console.log('import ok')"` to validate module-level imports and the updated route file loaded without errors. (passed)
- Grepped the updated code paths to confirm the duplicate‑check query and the null‑spread fix are present in `server/routes/reviews.ts`. (inspection passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2fff09d08325a5c559029494a2ce)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
