### PR TITLE
Prevent false review-create failures after successful insert

### DIFF
--- a/client/src/components/RecipeReviews.tsx
+++ b/client/src/components/RecipeReviews.tsx
@@ -38,16 +38,21 @@ interface Review {
 }
 
 function normalizeReview(rawReview: any): Review {
+  const safeRawReview = (rawReview && typeof rawReview === "object") ? rawReview : {};
+  const safeUser = (safeRawReview.user && typeof safeRawReview.user === "object")
+    ? safeRawReview.user
+    : {};
+
   return {
-    ...rawReview,
-    user: rawReview?.user ?? {
-      id: "",
-      username: "Unknown",
-      displayName: null,
-      avatar: null,
-      royalTitle: null,
+    ...safeRawReview,
+    user: {
+      id: typeof safeUser.id === "string" ? safeUser.id : "",
+      username: typeof safeUser.username === "string" ? safeUser.username : "Unknown",
+      displayName: typeof safeUser.displayName === "string" ? safeUser.displayName : null,
+      avatar: typeof safeUser.avatar === "string" ? safeUser.avatar : null,
+      royalTitle: typeof safeUser.royalTitle === "string" ? safeUser.royalTitle : null,
     },
-    photos: Array.isArray(rawReview?.photos) ? rawReview.photos : [],
+    photos: Array.isArray(safeRawReview.photos) ? safeRawReview.photos : [],
   };
 }
 
@@ -125,7 +130,10 @@ export function RecipeReviews({ recipeId, averageRating, reviewCount }: RecipeRe
         // Trigger a page refresh or emit event to update recipe rating
         window.location.reload();
       } else {
-        const errorData = await response.json().catch(() => ({ error: "Unknown error" }));
+        const parsedErrorData = await response.json().catch(() => ({ error: "Unknown error" }));
+        const errorData = (parsedErrorData && typeof parsedErrorData === "object")
+          ? parsedErrorData
+          : { error: "Unknown error" };
         console.error("❌ Review submission failed:", {
           status: response.status,
           statusText: response.statusText,

--- a/server/routes/reviews.ts
+++ b/server/routes/reviews.ts
@@ -205,45 +205,69 @@ router.post("/", requireAuth, async (req: Request, res: Response) => {
     const [review] = await db.insert(recipeReviews).values(newReview).returning();
     console.log("✅ Review inserted successfully with ID:", review.id);
 
-    // Update recipe average rating and count
+    // Update recipe average rating and count (non-fatal)
     console.log("📊 Updating recipe rating statistics...");
-    await updateRecipeRating(recipeId);
-    console.log("✅ Recipe rating updated");
+    try {
+      await updateRecipeRating(recipeId);
+      console.log("✅ Recipe rating updated");
+    } catch (ratingError) {
+      // Do not fail create-review after successful insert.
+      console.error("⚠️ Non-fatal: failed to update recipe rating stats:", ratingError);
+    }
 
     // Fetch the complete review with user data
     console.log("📥 Fetching complete review with user data...");
-    const [completeReview] = await db
-      .select({
-        id: recipeReviews.id,
-        recipeId: recipeReviews.recipeId,
-        userId: recipeReviews.userId,
-        rating: recipeReviews.rating,
-        reviewText: recipeReviews.reviewText,
-        helpfulCount: recipeReviews.helpfulCount,
-        createdAt: recipeReviews.createdAt,
-        updatedAt: recipeReviews.updatedAt,
-        user: {
-          id: users.id,
-          username: users.username,
-          displayName: users.displayName,
-          avatar: users.avatar,
-          royalTitle: users.royalTitle,
-        },
-      })
-      .from(recipeReviews)
-      .leftJoin(users, eq(recipeReviews.userId, users.id))
-      .where(eq(recipeReviews.id, review.id));
+    let completeReview: any = null;
+    try {
+      [completeReview] = await db
+        .select({
+          id: recipeReviews.id,
+          recipeId: recipeReviews.recipeId,
+          userId: recipeReviews.userId,
+          rating: recipeReviews.rating,
+          reviewText: recipeReviews.reviewText,
+          helpfulCount: recipeReviews.helpfulCount,
+          createdAt: recipeReviews.createdAt,
+          updatedAt: recipeReviews.updatedAt,
+          user: {
+            id: users.id,
+            username: users.username,
+            displayName: users.displayName,
+            avatar: users.avatar,
+            royalTitle: users.royalTitle,
+          },
+        })
+        .from(recipeReviews)
+        .leftJoin(users, eq(recipeReviews.userId, users.id))
+        .where(eq(recipeReviews.id, review.id));
+    } catch (fetchReviewError) {
+      // Do not fail create-review after successful insert.
+      console.error("⚠️ Non-fatal: failed to fetch full review row:", fetchReviewError);
+    }
 
-    const safeCompleteReview = completeReview ?? {
-      ...review,
-      user: {
-        id: userId,
-        username: "unknown",
-        displayName: null,
-        avatar: null,
-        royalTitle: null,
-      },
+    const safeReviewBase = (review && typeof review === "object") ? review : {
+      id: "",
+      recipeId,
+      userId,
+      rating,
+      reviewText: reviewText || null,
+      helpfulCount: 0,
+      createdAt: new Date(),
+      updatedAt: new Date(),
     };
+
+    const safeCompleteReview = (completeReview && typeof completeReview === "object")
+      ? completeReview
+      : {
+          ...safeReviewBase,
+          user: {
+            id: userId,
+            username: "unknown",
+            displayName: null,
+            avatar: null,
+            royalTitle: null,
+          },
+        };
 
     console.log("✅ Complete review fetched:", safeCompleteReview.id);
 
@@ -255,15 +279,20 @@ router.post("/", requireAuth, async (req: Request, res: Response) => {
       .limit(1);
 
     if (recipe && recipe.userId && recipe.userId !== userId && safeCompleteReview.user) {
-      sendRecipeReviewNotification(
-        recipe.userId,
-        userId,
-        safeCompleteReview.user.username || safeCompleteReview.user.displayName || 'Someone',
-        safeCompleteReview.user.avatar,
-        recipeId,
-        recipe.title || 'your recipe',
-        rating
-      );
+      try {
+        await sendRecipeReviewNotification(
+          recipe.userId,
+          userId,
+          safeCompleteReview.user.username || safeCompleteReview.user.displayName || "Someone",
+          safeCompleteReview.user.avatar,
+          recipeId,
+          recipe.title || "your recipe",
+          rating
+        );
+      } catch (notificationError) {
+        // Notification delivery should never fail a successful create-review call.
+        console.error("⚠️ Non-fatal: failed to send review notification:", notificationError);
+      }
     }
 
     console.log("📝 ============ CREATE REVIEW SUCCESS ============");


### PR DESCRIPTION
### Motivation
- A successful review row insert could still surface a 500/false-failure to the client when downstream post-insert work (rating stats update, re-fetch of the full review, or notification send) threw and bubbled out of the main `try` block. 
- The client also assumed the returned review payload was always an object with a `user` object and `photos` array, which could cause `Cannot convert undefined or null to object` on success paths or when the server returned unexpected shapes.

### Description
- Found root cause: post-insert side-effects inside the main `try` could throw after a DB insert and cause a false error response even though the review was created. 
- Made post-insert operations non-fatal in `server/routes/reviews.ts` by wrapping `updateRecipeRating`, the full review re-fetch, and `sendRecipeReviewNotification` in local `try/catch` blocks and by providing a defensive fallback review shape before responding. 
- Hardened client-side normalization in `client/src/components/RecipeReviews.tsx` by defensively shaping `rawReview.user` and `rawReview.photos` so spreading or reading keys cannot operate on `null`/`undefined`. 
- Hardened error parsing in the frontend submit path so malformed/non-object JSON error bodies are treated safely when building the alert message.

### Testing
- Built the project successfully with `npm run build`, which runs `generate` tasks and both client and server builds, and the build completed without errors. 
- Built server and client individually with `npm run build:server` and `npm run build:client` and both succeeded. 
- Performed an import check with `npx tsx -e "import './server/routes/reviews.ts'; console.log('import reviews route ok')"` which printed `import reviews route ok` indicating the route file loads.

Files changed: `server/routes/reviews.ts`, `client/src/components/RecipeReviews.tsx`.

Outcome: successful review inserts should now return `201` without being flipped to a false `Failed to create review` error, and the client will no longer crash when normalizing unexpected/missing review payload fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de51aae3b483259a429d00c5a9b291)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
