### PR TITLE
Harden POST /api/reviews against null-object error during submission

### DIFF
--- a/server/routes/reviews.ts
+++ b/server/routes/reviews.ts
@@ -21,6 +21,35 @@ import { sendRecipeReviewNotification } from "../services/notification-service";
 
 const router = Router();
 
+function safeObjectKeyCount(value: unknown): number {
+  if (!value || typeof value !== "object") return 0;
+  try {
+    return Object.keys(value as Record<string, unknown>).length;
+  } catch {
+    return 0;
+  }
+}
+
+function serializeErrorSafely(error: unknown): string {
+  const normalized = (error && typeof error === "object")
+    ? error
+    : { message: typeof error === "string" ? error : "Unknown error", raw: error };
+
+  try {
+    return JSON.stringify(normalized, Object.getOwnPropertyNames(normalized), 2);
+  } catch {
+    try {
+      return JSON.stringify({
+        name: (normalized as any)?.name,
+        message: (normalized as any)?.message,
+        code: (normalized as any)?.code,
+      });
+    } catch {
+      return "{\"message\":\"Unserializable error\"}";
+    }
+  }
+}
+
 function isExternalRecipeRef(recipeId: string): boolean {
   // Only treat known external provider IDs as external refs.
   // This avoids misclassifying local IDs that happen to contain underscores.
@@ -156,8 +185,8 @@ router.post("/", requireAuth, async (req: Request, res: Response) => {
     console.log("📝 Optional payload normalized:", {
       mediaCount: media.length,
       photosCount: photos.length,
-      metadataKeys: Object.keys(metadata).length,
-      detailsKeys: Object.keys(details).length,
+      metadataKeys: safeObjectKeyCount(metadata),
+      detailsKeys: safeObjectKeyCount(details),
     });
     console.log("📝 Parsed data:", { userId, recipeId, rating, reviewText, recipeIdType: typeof recipeId });
 
@@ -314,7 +343,7 @@ router.post("/", requireAuth, async (req: Request, res: Response) => {
       column: (errorObj as any).column,
       stack: (errorObj as any).stack?.split('\n').slice(0, 5).join('\n')
     });
-    console.error("❌ Full error object:", JSON.stringify(errorObj, Object.getOwnPropertyNames(errorObj), 2));
+    console.error("❌ Full error object:", serializeErrorSafely(errorObj));
 
     res.status(500).json({
       error: "Failed to create review",


### PR DESCRIPTION
### Motivation
- A `Cannot convert undefined or null to object` error was still surfacing during live recipe review submissions due to unguarded object-introspection and error serialization in the POST review flow. 
- The goal is a minimal regression fix so successful inserts return 2xx and the frontend no longer shows the false error alert while preserving duplicate blocking and external `mealdb_*` handling.

### Description
- Added `safeObjectKeyCount(value)` to avoid direct `Object.keys(...)` on possibly null/unserializable values and replaced the request diagnostics usage with this guard. 
- Added `serializeErrorSafely(error)` to make catch-path logging/jsonification resilient and replaced the previous `JSON.stringify(..., Object.getOwnPropertyNames(...))` call with it. 
- Kept all route paths and logic intact (duplicate blocking, `resolveRecipeIdForReview`, non-fatal post-insert steps, and success response shaping) and only made defensive, additive changes to `server/routes/reviews.ts`.
- Files changed: `server/routes/reviews.ts` (added helpers and swapped unsafe introspection/serialization points).

### Testing
- Ran full build: `npm run build` which completed successfully. 
- Ran server and client builds individually: `npm run build:server` and `npm run build:client` which both completed successfully. 
- Verified module import with `npx tsx -e "import './server/routes/reviews.ts'; console.log('import-ok')"` which succeeded and printed `import-ok`. 
- Searched for remaining risky patterns (`Object.keys/values/entries`, `Object.getOwnPropertyNames`, and the exact error text) across the review flow with `rg` and confirmed the unsafe call sites in the POST path were replaced; the code should no longer produce the exact `Cannot convert undefined or null to object` detail from these introspection points.
- Conclusion: automated builds and import checks passed and the change ensures review creation success-path and error logging are robust against null/unserializable objects, so the specific live alert should stop occurring once this code is deployed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de570d7b348325b1488d6b6eb8af9a)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
