### PR TITLE
Fix external recipe review identity resolution for MealDB

### DIFF
--- a/server/routes/reviews.ts
+++ b/server/routes/reviews.ts
@@ -96,21 +96,36 @@ function isExternalRecipeRef(recipeId: string): boolean {
   return /^mealdb_[^_]+$/i.test(recipeId);
 }
 
-async function resolveRecipeIdForReview(recipeId: string): Promise<string> {
+type ResolvedReviewRecipeIdentity = {
+  canonicalRecipeId: string;
+  linkedRecipeIds: string[];
+};
+
+async function resolveRecipeIdentityForReview(recipeId: string): Promise<ResolvedReviewRecipeIdentity> {
   if (typeof recipeId !== "string" || !recipeId.trim()) {
     throw new Error("Recipe id is required");
   }
 
   const normalizedRecipeId = recipeId.trim();
 
-  if (!isExternalRecipeRef(normalizedRecipeId)) return normalizedRecipeId;
+  if (!isExternalRecipeRef(normalizedRecipeId)) {
+    return {
+      canonicalRecipeId: normalizedRecipeId,
+      linkedRecipeIds: [normalizedRecipeId],
+    };
+  }
 
-  const savedRecipe = await RecipeService.findOrCreateExternalRecipe(db, normalizedRecipeId);
-  if (!savedRecipe?.id) {
+  const identity = await RecipeService.resolveExternalRecipeIdentity(db, normalizedRecipeId);
+  if (!identity?.recipe?.id) {
     throw new Error("Failed to resolve external recipe id");
   }
 
-  return savedRecipe.id;
+  return {
+    canonicalRecipeId: identity.recipe.id,
+    linkedRecipeIds: identity.linkedRecipeIds.length > 0
+      ? identity.linkedRecipeIds
+      : [identity.recipe.id],
+  };
 }
 
 // Multer config for review photos
@@ -144,7 +159,10 @@ router.get("/recipe/:recipeId", async (req: Request, res: Response) => {
   try {
     const { recipeId } = req.params;
     const userId = (req as any).user?.id;
-    const resolvedRecipeId = await resolveRecipeIdForReview(recipeId);
+    const identity = await resolveRecipeIdentityForReview(recipeId);
+    const reviewRecipeFilter = identity.linkedRecipeIds.length > 1
+      ? inArray(recipeReviews.recipeId, identity.linkedRecipeIds)
+      : eq(recipeReviews.recipeId, identity.canonicalRecipeId);
 
     const reviews = await db
       .select({
@@ -171,7 +189,7 @@ router.get("/recipe/:recipeId", async (req: Request, res: Response) => {
       })
       .from(recipeReviews)
       .leftJoin(users, eq(recipeReviews.userId, users.id))
-      .where(eq(recipeReviews.recipeId, resolvedRecipeId))
+      .where(reviewRecipeFilter)
       .orderBy(desc(recipeReviews.createdAt));
 
     // Get photos for each review
@@ -216,6 +234,7 @@ router.post("/", requireAuth, async (req: Request, res: Response) => {
     const userId = (req as any).user.id;
     const body = (req.body && typeof req.body === "object") ? req.body : {};
     let recipeId = typeof body.recipeId === "string" ? body.recipeId.trim() : "";
+    let linkedRecipeIdsForIdentity: string[] = [];
     const rating = typeof body.rating === "number" ? body.rating : Number(body.rating);
     const reviewText = typeof body.reviewText === "string" ? body.reviewText : null;
 
@@ -244,8 +263,13 @@ router.post("/", requireAuth, async (req: Request, res: Response) => {
     // Normalize external recipe IDs to local DB IDs so submit + read use the same key.
     try {
       diagnostics.setStage("recipe.resolve");
-      recipeId = await resolveRecipeIdForReview(recipeId);
-      diagnostics.info("recipe.resolved", { recipeId });
+      const identity = await resolveRecipeIdentityForReview(recipeId);
+      recipeId = identity.canonicalRecipeId;
+      linkedRecipeIdsForIdentity = identity.linkedRecipeIds;
+      diagnostics.info("recipe.resolved", {
+        recipeId,
+        linkedRecipeIdsCount: linkedRecipeIdsForIdentity.length,
+      });
     } catch (saveError: any) {
       diagnostics.error("recipe.resolve.failed", {
         error: serializeErrorSafely(saveError),
@@ -261,10 +285,13 @@ router.post("/", requireAuth, async (req: Request, res: Response) => {
     // Check if user already reviewed this recipe
     diagnostics.setStage("duplicate.check");
     diagnostics.info("duplicate.check.start");
+    const duplicateRecipeFilter = linkedRecipeIdsForIdentity.length > 1
+      ? inArray(recipeReviews.recipeId, linkedRecipeIdsForIdentity)
+      : eq(recipeReviews.recipeId, recipeId);
     const existingReview = await db
       .select()
       .from(recipeReviews)
-      .where(and(eq(recipeReviews.recipeId, recipeId), eq(recipeReviews.userId, userId)))
+      .where(and(duplicateRecipeFilter, eq(recipeReviews.userId, userId)))
       .limit(1);
 
     if (existingReview.length > 0) {

--- a/server/services/recipe.service.ts
+++ b/server/services/recipe.service.ts
@@ -6,6 +6,16 @@ import { recipes, posts, users, type Recipe, type InsertRecipe, type PostWithUse
  * RecipeService - Handles all recipe-related database operations
  */
 export class RecipeService {
+  private static parseExternalRecipeRef(externalRecipeId: string): { source: string; externalId: string } | null {
+    const normalized = typeof externalRecipeId === "string" ? externalRecipeId.trim() : "";
+    const match = normalized.match(/^([a-z0-9-]+)_(.+)$/i);
+    if (!match) return null;
+    const source = match[1].toLowerCase();
+    const externalId = match[2].trim();
+    if (!externalId) return null;
+    return { source, externalId };
+  }
+
   /**
    * Get recipe by ID
    */
@@ -246,14 +256,13 @@ export class RecipeService {
     db: any,
     externalRecipeId: string
   ): Promise<Recipe | null> {
-    // Parse external ID (e.g., "mealdb_52772")
-    const parts = externalRecipeId.split("_");
-    if (parts.length !== 2) {
+    const parsedRef = this.parseExternalRecipeRef(externalRecipeId);
+    if (!parsedRef) {
       console.error("Invalid external recipe ID format:", externalRecipeId);
       return null;
     }
 
-    const [source, externalId] = parts;
+    const { source, externalId } = parsedRef;
 
     // Check if recipe already exists in database
     const existing = await db
@@ -264,12 +273,12 @@ export class RecipeService {
           eq(recipes.externalSource, source),
           eq(recipes.externalId, externalId)
         )
-      )
-      .limit(1);
+      );
 
     if (existing.length > 0) {
-      console.log("Recipe already exists in DB:", existing[0].id);
-      return existing[0];
+      const canonical = [...existing].sort((a, b) => a.id.localeCompare(b.id))[0];
+      console.log("Recipe already exists in DB:", canonical.id, "matches:", existing.length);
+      return canonical;
     }
 
     // Fetch full recipe details from external source
@@ -279,6 +288,52 @@ export class RecipeService {
 
     console.error("Unsupported external source:", source);
     return null;
+  }
+
+  /**
+   * Resolve external identity to a canonical local recipe id and all linked local rows.
+   * This is resilient to duplicate local shadow rows for the same external recipe.
+   */
+  static async resolveExternalRecipeIdentity(
+    db: any,
+    externalRecipeId: string
+  ): Promise<{ recipe: Recipe; linkedRecipeIds: string[] } | null> {
+    const recipe = await this.findOrCreateExternalRecipe(db, externalRecipeId);
+    if (!recipe) return null;
+
+    if (!recipe.externalSource || !recipe.externalId) {
+      return { recipe, linkedRecipeIds: [recipe.id] };
+    }
+
+    const linked = await db
+      .select({ id: recipes.id })
+      .from(recipes)
+      .where(
+        and(
+          eq(recipes.externalSource, recipe.externalSource),
+          eq(recipes.externalId, recipe.externalId)
+        )
+      );
+
+    const linkedRecipeIds = linked
+      .map((row: { id: string }) => row.id)
+      .filter((id: string) => typeof id === "string" && id.length > 0)
+      .sort((a: string, b: string) => a.localeCompare(b));
+
+    if (!linkedRecipeIds.length) {
+      return { recipe, linkedRecipeIds: [recipe.id] };
+    }
+
+    const canonicalId = linkedRecipeIds[0];
+    if (recipe.id === canonicalId) {
+      return { recipe, linkedRecipeIds };
+    }
+
+    const canonicalRecipe = await this.getRecipe(db, canonicalId);
+    return {
+      recipe: canonicalRecipe ?? recipe,
+      linkedRecipeIds,
+    };
   }
 
   /**


### PR DESCRIPTION
### Motivation
- External TheMealDB recipes are stored as local shadow rows (`recipes.external_source` + `recipes.external_id`) while `recipe_reviews.recipe_id` stores only local Neon `recipes.id`, causing inconsistent create/read/duplicate behavior when duplicate shadow rows exist.
- The goal is to make review creation, duplicate detection, and readback use a single, consistent identity path for external recipes without broad redesign.

### Description
- Added deterministic external-ref parsing and canonical resolution in `RecipeService` via `parseExternalRecipeRef`, updated `findOrCreateExternalRecipe` to pick a deterministic canonical local row when multiple shadow rows exist, and added `resolveExternalRecipeIdentity` to return the canonical recipe and all linked local IDs. (file: `server/services/recipe.service.ts`).
- Reworked review route identity handling by introducing `resolveRecipeIdentityForReview` and using a consistent identity model end-to-end: read queries aggregate across all linked local ids, duplicate checks check all linked ids, and inserts use the canonical local recipe id. (file: `server/routes/reviews.ts`).
- Kept DB schema and review table shape unchanged: `recipe_reviews` still stores the local `recipe_id` FK and uniqueness remains on `(recipe_id, user_id)`; the routes now resolve external identity to a canonical local id and a set of linked ids before performing checks/queries.
- Files changed: `server/services/recipe.service.ts`, `server/routes/reviews.ts`.

### Testing
- Built the project successfully with `npm run build` and `npm run build:server` (both completed without errors).
- Verified route module imports with `npx tsx -e "import './server/routes/reviews.ts'"` which succeeded (import ok); runtime warnings about missing env vars were expected and non-fatal.
- Verified through code inspection that the canonical review key persisted is still `(recipe_reviews.recipe_id, recipe_reviews.user_id)` and that external identity is now resolved and applied consistently before insert/read/duplicate checks.

After this change, reviewing an external TheMealDB recipe like `mealdb_53124` should reliably create the review in Neon, prevent true duplicates across sibling shadow rows, and have read/display paths return the review consistently.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deeaf0dff88325ac1ceec2c830466f)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
