### PR TITLE
Stabilize TheMealDB review identity via canonical external recipe resolution

### DIFF
--- a/server/routes/reviews.ts
+++ b/server/routes/reviews.ts
@@ -123,7 +123,7 @@ async function resolveRecipeIdentityForReview(recipeId: string): Promise<Resolve
   return {
     canonicalRecipeId: identity.recipe.id,
     linkedRecipeIds: identity.linkedRecipeIds.length > 0
-      ? identity.linkedRecipeIds
+      ? Array.from(new Set(identity.linkedRecipeIds))
       : [identity.recipe.id],
   };
 }

--- a/server/services/recipe.service.ts
+++ b/server/services/recipe.service.ts
@@ -16,6 +16,19 @@ export class RecipeService {
     return { source, externalId };
   }
 
+  private static pickCanonicalRecipe<T extends { id: string; createdAt?: Date | string | null }>(
+    rows: T[]
+  ): T | null {
+    if (!Array.isArray(rows) || rows.length === 0) return null;
+
+    return [...rows].sort((a, b) => {
+      const aCreatedAt = a.createdAt ? new Date(a.createdAt).getTime() : Number.POSITIVE_INFINITY;
+      const bCreatedAt = b.createdAt ? new Date(b.createdAt).getTime() : Number.POSITIVE_INFINITY;
+      if (aCreatedAt !== bCreatedAt) return aCreatedAt - bCreatedAt;
+      return a.id.localeCompare(b.id);
+    })[0];
+  }
+
   /**
    * Get recipe by ID
    */
@@ -264,26 +277,24 @@ export class RecipeService {
 
     const { source, externalId } = parsedRef;
 
-    // Check if recipe already exists in database
-    const existing = await db
-      .select()
-      .from(recipes)
-      .where(
-        and(
-          eq(recipes.externalSource, source),
-          eq(recipes.externalId, externalId)
-        )
+    const identity = await this.resolveExternalRecipeIdentity(db, externalRecipeId, { createIfMissing: false });
+    if (identity?.recipe) {
+      console.log(
+        "Recipe already exists in DB:",
+        identity.recipe.id,
+        "matches:",
+        identity.linkedRecipeIds.length
       );
-
-    if (existing.length > 0) {
-      const canonical = [...existing].sort((a, b) => a.id.localeCompare(b.id))[0];
-      console.log("Recipe already exists in DB:", canonical.id, "matches:", existing.length);
-      return canonical;
+      return identity.recipe;
     }
 
     // Fetch full recipe details from external source
     if (source === "mealdb") {
-      return await this.fetchAndSaveMealDBRecipe(db, externalId);
+      const created = await this.fetchAndSaveMealDBRecipe(db, externalId);
+      if (!created) return null;
+
+      const hydratedIdentity = await this.resolveExternalRecipeIdentity(db, externalRecipeId, { createIfMissing: false });
+      return hydratedIdentity?.recipe ?? created;
     }
 
     console.error("Unsupported external source:", source);
@@ -296,42 +307,64 @@ export class RecipeService {
    */
   static async resolveExternalRecipeIdentity(
     db: any,
-    externalRecipeId: string
+    externalRecipeId: string,
+    options: { createIfMissing?: boolean } = {}
   ): Promise<{ recipe: Recipe; linkedRecipeIds: string[] } | null> {
-    const recipe = await this.findOrCreateExternalRecipe(db, externalRecipeId);
-    if (!recipe) return null;
+    const parsedRef = this.parseExternalRecipeRef(externalRecipeId);
+    if (!parsedRef) return null;
 
-    if (!recipe.externalSource || !recipe.externalId) {
-      return { recipe, linkedRecipeIds: [recipe.id] };
-    }
+    const { source, externalId } = parsedRef;
 
-    const linked = await db
-      .select({ id: recipes.id })
+    const linkedRecipes = await db
+      .select()
       .from(recipes)
       .where(
         and(
-          eq(recipes.externalSource, recipe.externalSource),
-          eq(recipes.externalId, recipe.externalId)
+          eq(recipes.externalSource, source),
+          eq(recipes.externalId, externalId)
         )
       );
 
-    const linkedRecipeIds = linked
-      .map((row: { id: string }) => row.id)
+    let canonical = this.pickCanonicalRecipe(linkedRecipes);
+    let linkedRecipeIds = linkedRecipes
+      .map((row: Recipe) => row.id)
       .filter((id: string) => typeof id === "string" && id.length > 0)
       .sort((a: string, b: string) => a.localeCompare(b));
 
+    if (!canonical && options.createIfMissing !== false) {
+      if (source !== "mealdb") {
+        console.error("Unsupported external source:", source);
+        return null;
+      }
+
+      const created = await this.fetchAndSaveMealDBRecipe(db, externalId);
+      if (!created) return null;
+
+      const refreshed = await db
+        .select()
+        .from(recipes)
+        .where(
+          and(
+            eq(recipes.externalSource, source),
+            eq(recipes.externalId, externalId)
+          )
+        );
+
+      canonical = this.pickCanonicalRecipe(refreshed) ?? created;
+      linkedRecipeIds = refreshed
+        .map((row: Recipe) => row.id)
+        .filter((id: string) => typeof id === "string" && id.length > 0)
+        .sort((a: string, b: string) => a.localeCompare(b));
+    }
+
+    if (!canonical) return null;
+
     if (!linkedRecipeIds.length) {
-      return { recipe, linkedRecipeIds: [recipe.id] };
+      linkedRecipeIds = [canonical.id];
     }
 
-    const canonicalId = linkedRecipeIds[0];
-    if (recipe.id === canonicalId) {
-      return { recipe, linkedRecipeIds };
-    }
-
-    const canonicalRecipe = await this.getRecipe(db, canonicalId);
     return {
-      recipe: canonicalRecipe ?? recipe,
+      recipe: canonical,
       linkedRecipeIds,
     };
   }


### PR DESCRIPTION
### Motivation
- External TheMealDB recipes could be shadowed by multiple local `recipes` rows with the same `externalSource`/`externalId`, causing review duplicate checks and reads to be unstable across those local rows.
- The existing flow returned a single local row arbitrarily and review routes only checked one local `recipeId`, so reviews could fragment across linked local rows.

### Description
- Implemented deterministic canonical selection by adding `pickCanonicalRecipe` in `server/services/recipe.service.ts` that prefers earliest `createdAt` and falls back to `id` for a stable tiebreaker.
- Reworked external identity handling by adding `resolveExternalRecipeIdentity(db, externalRecipeId, { createIfMissing? })` in `server/services/recipe.service.ts` which returns a canonical local `recipe` plus all linked local recipe IDs for the same external identity and optionally creates a missing MealDB row.
- Updated `findOrCreateExternalRecipe` to route through the new identity resolution so pre-existing duplicates map to the canonical local recipe and newly-created MealDB rows are re-hydrated to the canonical identity.
- Hardened review identity resolution in `server/routes/reviews.ts` by deduplicating `linkedRecipeIds` (`Array.from(new Set(...))`) so duplicate checks, inserts, and read queries operate across all linked local IDs consistently.

### Testing
- Ran the TypeScript checker with `npm run check` (which runs `tsc`); the command completed but the repository contains many pre-existing TypeScript errors unrelated to this backend-focused change, so the overall type-check failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df92bdb5e483259550f08962b88f6f)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
