### PR TITLE
Add Weekly Plan Status, empty-week CTAs, and Grocery next-step handoffs

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -1191,6 +1191,12 @@ const NutritionMealPlanner = () => {
     return Array.isArray(val) ? val.length > 0 : Boolean(val);
   }).length, 0);
   const totalSlots = weekDays.length * mealTypes.length;
+  const unplannedDays = weekDays.filter((day) => !mealTypes.some((type) => {
+    const val = weeklyMeals?.[day]?.[type];
+    return Array.isArray(val) ? val.length > 0 : Boolean(val);
+  }));
+  const groceryPendingCount = groceryList.filter((item: any) => !item.checked && !item.isPantryItem).length;
+  const groceryCompletedCount = groceryList.filter((item: any) => item.checked && !item.isPantryItem).length;
   const rawSavingsSummary = savingsReport?.summary || {};
   const rawSavingsPantry = savingsReport?.pantry || {};
   const safeTopSavingCategories = Array.isArray(savingsReport?.topSavingCategories)
@@ -1545,6 +1551,14 @@ const NutritionMealPlanner = () => {
               handleAIRecipe={handleAIRecipe}
               handleUsePantry={handleUsePantry}
               handleLoadTemplate={handleLoadTemplate}
+              plannedSlots={plannedSlots}
+              totalSlots={totalSlots}
+              unplannedDays={unplannedDays}
+              groceryPendingCount={groceryPendingCount}
+              groceryCompletedCount={groceryCompletedCount}
+              switchToGroceryTab={() => setActiveTab('grocery')}
+              switchToPrepTab={() => setActiveTab('prep')}
+              switchToAnalyticsTab={() => setActiveTab('analytics')}
             />
           </TabsContent>
 
@@ -1810,6 +1824,10 @@ const NutritionMealPlanner = () => {
               normalizedSavingsReport={normalizedSavingsReport}
               checkPantryFirst={checkPantryFirst}
               shareWithFamily={shareWithFamily}
+              onGoToPlanner={() => setActiveTab('planner')}
+              onGenerateWeekPlan={generateWeekPlan}
+              isGeneratingWeek={isGeneratingWeek}
+              onGoToPrep={() => setActiveTab('prep')}
             />
           </TabsContent>
 

--- a/client/src/components/meal-planner/sections/GroceryTabSection.tsx
+++ b/client/src/components/meal-planner/sections/GroceryTabSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Camera, CheckCircle, DollarSign, Download, Filter, Package, Plus, ShoppingCart, Star, TrendingUp, Users } from 'lucide-react';
+import { Camera, CheckCircle, DollarSign, Download, Filter, Package, Plus, ShoppingCart, Star, TrendingUp, Users, Zap } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -17,6 +17,10 @@ type GroceryTabSectionProps = {
   normalizedSavingsReport: any;
   checkPantryFirst: () => void;
   shareWithFamily: () => void;
+  onGoToPlanner: () => void;
+  onGenerateWeekPlan: () => void;
+  isGeneratingWeek: boolean;
+  onGoToPrep: () => void;
 };
 
 const GroceryTabSection = ({
@@ -31,10 +35,52 @@ const GroceryTabSection = ({
   normalizedSavingsReport,
   checkPantryFirst,
   shareWithFamily,
+  onGoToPlanner,
+  onGenerateWeekPlan,
+  isGeneratingWeek,
+  onGoToPrep,
 }: GroceryTabSectionProps) => {
+  const buyItems = groceryList.filter((i: any) => !i.isPantryItem);
+  const checkedBuyItems = buyItems.filter((i: any) => i.checked).length;
+  const pendingBuyItems = buyItems.filter((i: any) => !i.checked).length;
+
   return (
     <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
       <div className="lg:col-span-2 space-y-4">
+        <Card className="border-blue-200 bg-gradient-to-r from-blue-50 via-white to-orange-50">
+          <CardContent className="p-4">
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-blue-600 font-semibold mb-1">Next step</p>
+                <h3 className="font-semibold text-gray-900">
+                  {buyItems.length === 0 ? 'No list yet — start from your planner' : pendingBuyItems > 0 ? 'Finish this list, then prep meals' : 'Shopping complete — move to prep'}
+                </h3>
+                <p className="text-sm text-gray-600 mt-1">
+                  {buyItems.length === 0
+                    ? 'Generate a week plan to auto-populate your shopping list.'
+                    : `${checkedBuyItems}/${buyItems.length} shopping items checked off.`}
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button variant="outline" size="sm" onClick={onGoToPlanner}>
+                  Back to Planner
+                </Button>
+                {buyItems.length === 0 && (
+                  <Button size="sm" onClick={onGenerateWeekPlan} disabled={isGeneratingWeek}>
+                    <Zap className="w-4 h-4 mr-2" />
+                    {isGeneratingWeek ? 'Generating...' : 'Auto-Plan Week'}
+                  </Button>
+                )}
+                {buyItems.length > 0 && (
+                  <Button size="sm" onClick={onGoToPrep}>
+                    Plan Prep Session
+                  </Button>
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
         {(() => {
           const pantryOwned = groceryList.filter((i: any) => i.isPantryItem && !i.checked);
           const stillNeeded = groceryList.filter((i: any) => !i.isPantryItem && !i.checked);
@@ -106,7 +152,6 @@ const GroceryTabSection = ({
                 <div className="text-center py-8"><CheckCircle className="w-12 h-12 mx-auto mb-3 text-green-400" /><p className="font-medium text-green-700">Your pantry covers everything!</p><p className="text-sm text-gray-500 mt-1">All items for this week are already in your pantry</p></div>
               ) : (
                 (() => {
-                  const buyItems = groceryList.filter((i: any) => !i.isPantryItem);
                   const categories = Array.from(new Set(buyItems.map((item: any) => item.category || 'Other')));
                   const categoryOrder = ['Protein', 'Produce', 'Grains', 'Dairy', 'From Recipe', 'Other'];
                   const sortedCategories = (categories as string[]).sort((a, b) => {

--- a/client/src/components/meal-planner/sections/PlannerTabSection.tsx
+++ b/client/src/components/meal-planner/sections/PlannerTabSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ChefHat, Package, Plus, Save, Sparkles, Zap } from 'lucide-react';
+import { BarChart3, ChefHat, Clock, Package, Plus, Save, ShoppingCart, Sparkles, Target, Zap } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -40,6 +40,14 @@ type PlannerTabSectionProps = {
   handleAIRecipe: () => void;
   handleUsePantry: () => void;
   handleLoadTemplate: () => void;
+  plannedSlots: number;
+  totalSlots: number;
+  unplannedDays: string[];
+  groceryPendingCount: number;
+  groceryCompletedCount: number;
+  switchToGroceryTab: () => void;
+  switchToPrepTab: () => void;
+  switchToAnalyticsTab: () => void;
 };
 
 const PlannerTabSection = ({
@@ -75,7 +83,22 @@ const PlannerTabSection = ({
   handleAIRecipe,
   handleUsePantry,
   handleLoadTemplate,
+  plannedSlots,
+  totalSlots,
+  unplannedDays,
+  groceryPendingCount,
+  groceryCompletedCount,
+  switchToGroceryTab,
+  switchToPrepTab,
+  switchToAnalyticsTab,
 }: PlannerTabSectionProps) => {
+  const planningProgress = totalSlots > 0 ? Math.round((plannedSlots / totalSlots) * 100) : 0;
+  const completionLabel = plannedSlots === 0
+    ? 'No meals planned yet'
+    : plannedSlots === totalSlots
+      ? 'Week fully planned'
+      : `${plannedSlots}/${totalSlots} slots filled`;
+
   return (
     <div className="space-y-6">
       <Card className="bg-gradient-to-r from-orange-500 to-pink-500 text-white shadow-lg">
@@ -101,6 +124,59 @@ const PlannerTabSection = ({
             <div className="bg-white/15 backdrop-blur rounded-lg p-3 text-center"><p className="text-xs text-white/80">Protein</p><p className="text-lg font-semibold">{proteinCurrent}g</p></div>
             <div className="bg-white/15 backdrop-blur rounded-lg p-3 text-center"><p className="text-xs text-white/80">Carbs</p><p className="text-lg font-semibold">{carbsCurrent}g</p></div>
             <div className="bg-white/15 backdrop-blur rounded-lg p-3 text-center"><p className="text-xs text-white/80">Fat</p><p className="text-lg font-semibold">{fatCurrent}g</p></div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border-orange-200 bg-gradient-to-r from-orange-50 via-white to-amber-50">
+        <CardHeader className="pb-4">
+          <CardTitle className="text-lg">Weekly Plan Status</CardTitle>
+          <CardDescription>
+            {completionLabel}. Keep momentum with the most useful next actions.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <div className="flex items-center justify-between text-sm mb-2">
+              <span className="text-gray-600">Planner Coverage</span>
+              <span className="font-semibold text-gray-900">{planningProgress}%</span>
+            </div>
+            <Progress value={planningProgress} className="h-2" />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+            <div className="rounded-lg border bg-white p-3">
+              <p className="text-xs text-gray-500 mb-1">Unplanned Days</p>
+              <p className="text-lg font-semibold text-gray-900">{unplannedDays.length}</p>
+              <p className="text-xs text-gray-500 mt-1 truncate">
+                {unplannedDays.length > 0 ? unplannedDays.join(', ') : 'All days have meals'}
+              </p>
+            </div>
+            <div className="rounded-lg border bg-white p-3">
+              <p className="text-xs text-gray-500 mb-1">Items to Buy</p>
+              <p className="text-lg font-semibold text-orange-600">{groceryPendingCount}</p>
+              <p className="text-xs text-gray-500 mt-1">{groceryCompletedCount} checked off</p>
+            </div>
+            <div className="rounded-lg border bg-white p-3">
+              <p className="text-xs text-gray-500 mb-1">Focus</p>
+              <p className="text-sm font-semibold text-gray-900">
+                {unplannedDays.length > 0 ? 'Finish your week plan' : groceryPendingCount > 0 ? 'Shop & prep meals' : 'Review performance'}
+              </p>
+              <p className="text-xs text-gray-500 mt-1">Use quick actions below</p>
+            </div>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+            <Button variant="outline" size="sm" className="justify-start" onClick={switchToGroceryTab}>
+              <ShoppingCart className="w-4 h-4 mr-2" />
+              Open Grocery List
+            </Button>
+            <Button variant="outline" size="sm" className="justify-start" onClick={switchToPrepTab}>
+              <Clock className="w-4 h-4 mr-2" />
+              Build Prep Session
+            </Button>
+            <Button variant="outline" size="sm" className="justify-start" onClick={switchToAnalyticsTab}>
+              <BarChart3 className="w-4 h-4 mr-2" />
+              Review Analytics
+            </Button>
           </div>
         </CardContent>
       </Card>
@@ -146,6 +222,32 @@ const PlannerTabSection = ({
 
       {viewMode === 'week' && (
         <>
+          {plannedSlots === 0 && (
+            <Card className="border-dashed border-orange-200 bg-orange-50/40">
+              <CardContent className="p-6 text-center">
+                <Target className="w-8 h-8 text-orange-500 mx-auto mb-2" />
+                <h3 className="font-semibold text-gray-900">Start your week plan</h3>
+                <p className="text-sm text-gray-600 mt-1 mb-4">
+                  Plan your first meals, auto-generate a week, or load a template to skip blank days.
+                </p>
+                <div className="flex flex-wrap justify-center gap-2">
+                  <Button size="sm" onClick={generateWeekPlan} disabled={isGeneratingWeek}>
+                    <Zap className="w-4 h-4 mr-2" />
+                    {isGeneratingWeek ? 'Generating...' : 'Auto-Plan Week'}
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={handleAIRecipe}>
+                    <Sparkles className="w-4 h-4 mr-2" />
+                    AI Suggestions
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={handleLoadTemplate}>
+                    <Save className="w-4 h-4 mr-2" />
+                    Load Template
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
           <div className="hidden md:block bg-white rounded-lg shadow-sm overflow-hidden overflow-x-auto">
             <div className="grid grid-cols-8 border-b min-w-[800px]">
               <div className="p-4 bg-gray-50 border-r"><span className="text-sm font-medium text-gray-500">Meal</span></div>


### PR DESCRIPTION
### Motivation
- Users can stall in the meal-planning flow when a week is empty or when it’s unclear what to do next after partial planning. 
- The Grocery tab already contains useful functionality but lacked clear next-step transitions back to planning or onward to prep. 
- Small, additive UI signals and one-click handoffs reduce friction between Planner → Grocery → Prep → Analytics without touching APIs or data models. 

### Description
- Added a new `Weekly Plan Status` action lane to the planner tab that shows planner coverage, unplanned day visibility, grocery counts, a prioritized focus label, and quick actions to open Grocery, Prep, or Analytics. 
- Implemented a stronger empty-week experience in week view with immediate CTAs: `Auto-Plan Week`, `AI Suggestions`, and `Load Template`. 
- Added a contextual `Next step` card to the Grocery tab which adapts to list state (no list / in-progress / complete) and offers quick transitions back to Planner, auto-generate week, or start a prep session. 
- Wired small, read-only derived metrics and cross-tab callbacks in the orchestrator (`NutritionMealPlanner`) while preserving existing routes, API calls, and data contracts. 
- Files changed: `client/src/components/NutritionMealPlanner.tsx`, `client/src/components/meal-planner/sections/PlannerTabSection.tsx`, and `client/src/components/meal-planner/sections/GroceryTabSection.tsx`. 

### Testing
- Ran `npm run build` which completed successfully. 
- Ran `npm run build:client` which completed successfully. 
- Ran `npm run build:server` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3cb3592088325a06701a8cfca1c4e)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
