### PR TITLE
Add lightweight persisted weekly prep-session tracker to Meal Planner readiness flow

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -16,6 +16,7 @@ import BarcodeScanner from '@/components/BarcodeScanner';
 import AdvancedFeaturesPanel from '@/components/meal-planner/AdvancedFeaturesPanel';
 import PlannerTabSection from '@/components/meal-planner/sections/PlannerTabSection';
 import GroceryTabSection from '@/components/meal-planner/sections/GroceryTabSection';
+import PrepTabSection, { type PrepSessionState } from '@/components/meal-planner/sections/PrepTabSection';
 import WeeklyReadinessChecklist from '@/components/meal-planner/WeeklyReadinessChecklist';
 import GoalCalculatorDialog from '@/components/meal-planner/modals/GoalCalculatorDialog';
 import PantryModal from '@/components/meal-planner/modals/PantryModal';
@@ -73,6 +74,20 @@ const INITIAL_MEAL_FORM = {
   servingQty: 1,
 };
 
+const DEFAULT_PREP_SESSION_TASKS = [
+  { id: 'review-plan', label: 'Review planned meals and serving counts', done: false },
+  { id: 'portion-protein', label: 'Batch-cook and portion protein bases', done: false },
+  { id: 'prep-produce', label: 'Prep vegetables, fruit, and grab-and-go snacks', done: false },
+  { id: 'container-labels', label: 'Pack containers and label day/meal', done: false },
+];
+
+const createDefaultPrepSession = (): PrepSessionState => ({
+  scheduledAt: '',
+  notes: '',
+  tasks: DEFAULT_PREP_SESSION_TASKS.map((task) => ({ ...task })),
+  completedAt: null,
+});
+
 const NutritionMealPlanner = () => {
   const { user, updateUser } = useUser();
   const { toast } = useToast();
@@ -108,6 +123,7 @@ const NutritionMealPlanner = () => {
   const [showCalcModal, setShowCalcModal] = useState(false);
   const [calcForm, setCalcForm] = useState({ age: 30, gender: 'male', heightUnit: 'ft', feet: 5, inches: 10, cm: 178, weightUnit: 'lbs', weight: 180, activity: 'moderately active', goal: 'maintain' });
   const [calcResult, setCalcResult] = useState<any>(null);
+  const [prepSession, setPrepSession] = useState<PrepSessionState>(() => createDefaultPrepSession());
 
   // Add Meal modal — controlled fields
   const [mealForm, setMealForm] = useState(INITIAL_MEAL_FORM);
@@ -124,6 +140,7 @@ const NutritionMealPlanner = () => {
   const getCurrentWeekAnchor = () => getWeekAnchorForDate(selectedDate);
 
   const getDateForWeekday = (weekday: string) => getDateForWeekdayFromAnchor(getCurrentWeekAnchor(), weekday);
+  const getPrepSessionStorageKey = () => `meal-planner-prep-session-v1:${user?.id || 'anon'}:${getCurrentWeekAnchor()}`;
 
   useEffect(() => {
     fetchUserData();
@@ -143,6 +160,40 @@ const NutritionMealPlanner = () => {
       fetchDailyNutrition();
     }
   }, [weeklyMeals]);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(getPrepSessionStorageKey());
+      if (!stored) {
+        setPrepSession(createDefaultPrepSession());
+        return;
+      }
+      const parsed = JSON.parse(stored);
+      const normalizedTasks = Array.isArray(parsed?.tasks)
+        ? DEFAULT_PREP_SESSION_TASKS.map((task) => {
+            const match = parsed.tasks.find((candidate: any) => candidate?.id === task.id);
+            return { ...task, done: Boolean(match?.done) };
+          })
+        : DEFAULT_PREP_SESSION_TASKS.map((task) => ({ ...task }));
+      setPrepSession({
+        scheduledAt: typeof parsed?.scheduledAt === 'string' ? parsed.scheduledAt : '',
+        notes: typeof parsed?.notes === 'string' ? parsed.notes : '',
+        tasks: normalizedTasks,
+        completedAt: typeof parsed?.completedAt === 'string' ? parsed.completedAt : null,
+      });
+    } catch (error) {
+      console.error('Error loading prep session:', error);
+      setPrepSession(createDefaultPrepSession());
+    }
+  }, [user?.id, selectedDate]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(getPrepSessionStorageKey(), JSON.stringify(prepSession));
+    } catch (error) {
+      console.error('Error saving prep session:', error);
+    }
+  }, [prepSession, user?.id, selectedDate]);
 
   const fetchSavingsReport = async () => {
     try {
@@ -1121,6 +1172,46 @@ const NutritionMealPlanner = () => {
     setShowAIRecipeModal(false);
   };
 
+  const updatePrepSchedule = (value: string) => {
+    setPrepSession((prev) => ({
+      ...prev,
+      scheduledAt: value,
+      completedAt: value ? prev.completedAt : null,
+    }));
+  };
+
+  const updatePrepNotes = (value: string) => {
+    setPrepSession((prev) => ({
+      ...prev,
+      notes: value,
+    }));
+  };
+
+  const togglePrepTask = (taskId: string) => {
+    setPrepSession((prev) => ({
+      ...prev,
+      tasks: prev.tasks.map((task) => task.id === taskId ? { ...task, done: !task.done } : task),
+      completedAt: prev.completedAt,
+    }));
+  };
+
+  const markPrepComplete = () => {
+    setPrepSession((prev) => ({
+      ...prev,
+      completedAt: formatLocalDate(new Date()),
+    }));
+    toast({
+      description: 'Prep session marked complete. Your readiness checklist is now execution-aware.',
+    });
+  };
+
+  const resetPrepCompletion = () => {
+    setPrepSession((prev) => ({
+      ...prev,
+      completedAt: null,
+    }));
+  };
+
   const PremiumUpgrade = () => (
     <div className="bg-gradient-to-r from-orange-500 via-red-500 to-pink-500 text-white rounded-xl shadow-2xl overflow-hidden">
       <div className="p-8">
@@ -1201,9 +1292,13 @@ const NutritionMealPlanner = () => {
   const groceryBuyItemCount = groceryList.filter((item: any) => !item.isPantryItem).length;
   const groceryListCreated = groceryList.length > 0;
   const unplannedMealSlots = Math.max(0, totalSlots - plannedSlots);
+  const prepSessionPlanned = Boolean(prepSession.scheduledAt);
+  const prepSessionCompleted = Boolean(prepSession.completedAt);
+  const prepProgress = Math.round((prepSession.tasks.filter((task) => task.done).length / Math.max(1, prepSession.tasks.length)) * 100);
   const prepRecommendationsAvailable = plannedSlots > 0;
-  const prepPlanMissing = plannedSlots > 0;
-  const weekReadyNow = plannedSlots === totalSlots && (groceryBuyItemCount === 0 || groceryPendingCount === 0);
+  const prepPlanMissing = plannedSlots > 0 && !prepSessionPlanned && !prepSessionCompleted;
+  const prepReadyForWeek = prepSessionCompleted || prepSessionPlanned;
+  const weekReadyNow = plannedSlots === totalSlots && (groceryBuyItemCount === 0 || groceryPendingCount === 0) && prepReadyForWeek;
   const rawSavingsSummary = savingsReport?.summary || {};
   const rawSavingsPantry = savingsReport?.pantry || {};
   const safeTopSavingCategories = Array.isArray(savingsReport?.topSavingCategories)
@@ -1535,6 +1630,8 @@ const NutritionMealPlanner = () => {
                 groceryCompletedCount={groceryCompletedCount}
                 prepPlanMissing={prepPlanMissing}
                 prepRecommendationsAvailable={prepRecommendationsAvailable}
+                prepSessionPlanned={prepSessionPlanned}
+                prepSessionCompleted={prepSessionCompleted}
                 weekReadyNow={weekReadyNow}
                 onGoToPlanner={() => setActiveTab('planner')}
                 onGoToGrocery={() => setActiveTab('grocery')}
@@ -1845,6 +1942,8 @@ const NutritionMealPlanner = () => {
                 groceryCompletedCount={groceryCompletedCount}
                 prepPlanMissing={prepPlanMissing}
                 prepRecommendationsAvailable={prepRecommendationsAvailable}
+                prepSessionPlanned={prepSessionPlanned}
+                prepSessionCompleted={prepSessionCompleted}
                 weekReadyNow={weekReadyNow}
                 onGoToPlanner={() => setActiveTab('planner')}
                 onGoToGrocery={() => setActiveTab('grocery')}
@@ -1882,10 +1981,25 @@ const NutritionMealPlanner = () => {
                 groceryCompletedCount={groceryCompletedCount}
                 prepPlanMissing={prepPlanMissing}
                 prepRecommendationsAvailable={prepRecommendationsAvailable}
+                prepSessionPlanned={prepSessionPlanned}
+                prepSessionCompleted={prepSessionCompleted}
                 weekReadyNow={weekReadyNow}
                 onGoToPlanner={() => setActiveTab('planner')}
                 onGoToGrocery={() => setActiveTab('grocery')}
                 onGoToPrep={() => setActiveTab('prep')}
+              />
+              <PrepTabSection
+                prepSession={prepSession}
+                prepProgress={prepProgress}
+                prepSessionPlanned={prepSessionPlanned}
+                prepSessionCompleted={prepSessionCompleted}
+                prepRecommendationsAvailable={prepRecommendationsAvailable}
+                onScheduleChange={updatePrepSchedule}
+                onNotesChange={updatePrepNotes}
+                onToggleTask={togglePrepTask}
+                onMarkPrepComplete={markPrepComplete}
+                onResetPrepCompletion={resetPrepCompletion}
+                onGoToChecklist={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
               />
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                 <Card>

--- a/client/src/components/meal-planner/WeeklyReadinessChecklist.tsx
+++ b/client/src/components/meal-planner/WeeklyReadinessChecklist.tsx
@@ -15,6 +15,8 @@ type WeeklyReadinessChecklistProps = {
   groceryCompletedCount: number;
   prepPlanMissing: boolean;
   prepRecommendationsAvailable: boolean;
+  prepSessionPlanned: boolean;
+  prepSessionCompleted: boolean;
   weekReadyNow: boolean;
   onGoToPlanner: () => void;
   onGoToGrocery: () => void;
@@ -32,6 +34,8 @@ const WeeklyReadinessChecklist = ({
   groceryCompletedCount,
   prepPlanMissing,
   prepRecommendationsAvailable,
+  prepSessionPlanned,
+  prepSessionCompleted,
   weekReadyNow,
   onGoToPlanner,
   onGoToGrocery,
@@ -113,13 +117,17 @@ const WeeklyReadinessChecklist = ({
               <Badge variant="outline">{statusLabel(prepStatus)}</Badge>
             </div>
             <p className="text-xs text-gray-600">
-              {prepPlanMissing
-                ? 'Planned meals are ready for a prep session.'
-                : 'Prep guidance is available for your planned meals.'}
+              {prepSessionCompleted
+                ? 'Prep session completed for this week.'
+                : prepSessionPlanned
+                  ? 'Prep session is scheduled and ready to execute.'
+                  : prepPlanMissing
+                    ? 'Planned meals are ready for a prep session.'
+                    : 'Prep guidance is available for your planned meals.'}
             </p>
             {prepRecommendationsAvailable && (
               <Button variant="outline" size="sm" className="mt-2" onClick={onGoToPrep}>
-                Go to Prep
+                {prepSessionCompleted ? 'Review Prep Session' : prepSessionPlanned ? 'Open Prep Session' : 'Go to Prep'}
               </Button>
             )}
           </div>

--- a/client/src/components/meal-planner/sections/PrepTabSection.tsx
+++ b/client/src/components/meal-planner/sections/PrepTabSection.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { CalendarClock, CheckCircle2, Clock, ListChecks } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+
+export type PrepTask = {
+  id: string;
+  label: string;
+  done: boolean;
+};
+
+export type PrepSessionState = {
+  scheduledAt: string;
+  notes: string;
+  tasks: PrepTask[];
+  completedAt: string | null;
+};
+
+type PrepTabSectionProps = {
+  prepSession: PrepSessionState;
+  prepProgress: number;
+  prepSessionPlanned: boolean;
+  prepSessionCompleted: boolean;
+  prepRecommendationsAvailable: boolean;
+  onScheduleChange: (value: string) => void;
+  onNotesChange: (value: string) => void;
+  onToggleTask: (taskId: string) => void;
+  onMarkPrepComplete: () => void;
+  onResetPrepCompletion: () => void;
+  onGoToChecklist: () => void;
+};
+
+const PrepTabSection = ({
+  prepSession,
+  prepProgress,
+  prepSessionPlanned,
+  prepSessionCompleted,
+  prepRecommendationsAvailable,
+  onScheduleChange,
+  onNotesChange,
+  onToggleTask,
+  onMarkPrepComplete,
+  onResetPrepCompletion,
+  onGoToChecklist,
+}: PrepTabSectionProps) => {
+  return (
+    <Card className="border-indigo-200 bg-gradient-to-r from-indigo-50 via-white to-orange-50">
+      <CardHeader>
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardTitle className="text-lg flex items-center gap-2">
+              <CalendarClock className="w-5 h-5 text-indigo-600" />
+              Weekly Prep Session Tracker
+            </CardTitle>
+            <CardDescription>
+              Schedule prep, check off tasks, and mark the week execution-ready.
+            </CardDescription>
+          </div>
+          <Badge variant={prepSessionCompleted ? 'default' : prepSessionPlanned ? 'outline' : 'secondary'} className={prepSessionCompleted ? 'bg-green-600 hover:bg-green-600' : ''}>
+            {prepSessionCompleted ? 'Completed' : prepSessionPlanned ? 'Scheduled' : 'Not Scheduled'}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-gray-900">Prep session time</p>
+            <Input
+              type="datetime-local"
+              value={prepSession.scheduledAt}
+              onChange={(e) => onScheduleChange(e.target.value)}
+            />
+            <p className="text-xs text-gray-600">
+              {prepSessionPlanned ? 'Session saved for this week.' : 'Pick a time to lock in your prep session.'}
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-gray-900">Prep notes</p>
+            <textarea
+              className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+              placeholder="Optional: session focus, who is helping, or container plan"
+              value={prepSession.notes}
+              onChange={(e) => onNotesChange(e.target.value)}
+            />
+            <p className="text-xs text-gray-600">Notes are saved with this week's prep session.</p>
+          </div>
+        </div>
+
+        <div className="rounded-lg border bg-white p-3">
+          <div className="flex items-center justify-between gap-2 mb-2">
+            <p className="text-sm font-medium text-gray-900 flex items-center gap-2">
+              <ListChecks className="w-4 h-4 text-indigo-500" />
+              Prep checklist ({prepProgress}% done)
+            </p>
+            <p className="text-xs text-gray-600">{prepSession.tasks.filter((task) => task.done).length}/{prepSession.tasks.length} tasks</p>
+          </div>
+          <div className="space-y-2">
+            {prepSession.tasks.map((task) => (
+              <label key={task.id} className="flex items-center gap-2 text-sm text-gray-700">
+                <Checkbox checked={task.done} onCheckedChange={() => onToggleTask(task.id)} />
+                <span className={task.done ? 'line-through text-gray-500' : ''}>{task.label}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            onClick={onMarkPrepComplete}
+            disabled={!prepSessionPlanned || !prepRecommendationsAvailable || prepSessionCompleted}
+          >
+            <CheckCircle2 className="w-4 h-4 mr-2" />
+            Mark Prep Complete
+          </Button>
+          {prepSessionCompleted && (
+            <Button variant="outline" onClick={onResetPrepCompletion}>
+              <Clock className="w-4 h-4 mr-2" />
+              Reopen Session
+            </Button>
+          )}
+          <Button variant="ghost" onClick={onGoToChecklist}>
+            Back to Weekly Readiness
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default PrepTabSection;


### PR DESCRIPTION
### Motivation
- Readiness was partly inferred from planned meals and groceries, so add an explicit, lightweight execution signal for prep to improve weekly readiness accuracy. 
- Keep changes small and additive while preserving the current planner orchestration and UI flow.

### Description
- Added a new `PrepTabSection` component that exposes a minimal weekly prep-session tracker with `scheduledAt`, `notes`, a small fixed checklist of tasks, and a `completedAt` marker; the component supports scheduling, task toggles, complete/reopen actions, and a CTA back to the checklist (`client/src/components/meal-planner/sections/PrepTabSection.tsx`).
- Kept `NutritionMealPlanner.tsx` as the orchestrator by adding a compact prep-session model, week/user-scoped persistence in `localStorage` (`meal-planner-prep-session-v1:<userId>:<weekAnchor>`), handlers (`updatePrepSchedule`, `updatePrepNotes`, `togglePrepTask`, `markPrepComplete`, `resetPrepCompletion`), and derived signals `prepSessionPlanned`, `prepSessionCompleted`, and `prepProgress` that feed readiness logic and UI (`client/src/components/NutritionMealPlanner.tsx`).
- Made readiness execution-aware by changing `prepPlanMissing` semantics and requiring prep readiness (planned or completed) when computing `weekReadyNow`, and wired the new prep signals through all `WeeklyReadinessChecklist` usages in Planner/Grocery/Prep tabs (`client/src/components/NutritionMealPlanner.tsx`).
- Updated `WeeklyReadinessChecklist` to accept `prepSessionPlanned` and `prepSessionCompleted`, adjust copy and CTA labels (`Go to Prep` / `Open Prep Session` / `Review Prep Session`), and show completed vs scheduled text (`client/src/components/meal-planner/WeeklyReadinessChecklist.tsx`).
- Files changed: `client/src/components/NutritionMealPlanner.tsx`, `client/src/components/meal-planner/WeeklyReadinessChecklist.tsx`, and new `client/src/components/meal-planner/sections/PrepTabSection.tsx`.

### Testing
- Ran `npm run build` and the full build completed successfully in this environment. 
- Ran `npm run build:client` and the client build completed successfully. 
- Ran `npm run build:server` and the server build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d666274c8325a0a5eeaa8149d608)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
