### PR TITLE
Add lightweight prep blockers and carryover to meal-planner readiness

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -81,12 +81,45 @@ const DEFAULT_PREP_SESSION_TASKS = [
   { id: 'container-labels', label: 'Pack containers and label day/meal', done: false },
 ];
 
-const createDefaultPrepSession = (): PrepSessionState => ({
-  scheduledAt: '',
-  notes: '',
-  tasks: DEFAULT_PREP_SESSION_TASKS.map((task) => ({ ...task })),
-  completedAt: null,
-});
+const DEFAULT_PREP_BLOCKERS = [
+  { id: 'missing-ingredient', label: 'Missing ingredient', active: false },
+  { id: 'missing-containers', label: 'Missing containers', active: false },
+  { id: 'time-conflict', label: 'Time conflict', active: false },
+  { id: 'waiting-on-grocery', label: 'Waiting on grocery', active: false },
+  { id: 'kitchen-access', label: 'Kitchen access', active: false },
+];
+
+const normalizePrepSession = (session: any): PrepSessionState => {
+  const normalizedTasks = Array.isArray(session?.tasks)
+    ? DEFAULT_PREP_SESSION_TASKS.map((task) => {
+        const match = session.tasks.find((candidate: any) => candidate?.id === task.id);
+        return { ...task, done: Boolean(match?.done) };
+      })
+    : DEFAULT_PREP_SESSION_TASKS.map((task) => ({ ...task }));
+
+  const normalizedBlockers = Array.isArray(session?.blockers)
+    ? DEFAULT_PREP_BLOCKERS.map((blocker) => {
+        const match = session.blockers.find((candidate: any) => candidate?.id === blocker.id);
+        return { ...blocker, active: Boolean(match?.active) };
+      })
+    : DEFAULT_PREP_BLOCKERS.map((blocker) => ({ ...blocker }));
+
+  const normalizedCarryoverIds = Array.isArray(session?.carryoverTaskIds)
+    ? session.carryoverTaskIds.filter((taskId: string) => normalizedTasks.some((task) => task.id === taskId))
+    : [];
+
+  return {
+    scheduledAt: typeof session?.scheduledAt === 'string' ? session.scheduledAt : '',
+    notes: typeof session?.notes === 'string' ? session.notes : '',
+    tasks: normalizedTasks,
+    blockers: normalizedBlockers,
+    blockerNote: typeof session?.blockerNote === 'string' ? session.blockerNote : '',
+    carryoverTaskIds: normalizedCarryoverIds,
+    completedAt: typeof session?.completedAt === 'string' ? session.completedAt : null,
+  };
+};
+
+const createDefaultPrepSession = (): PrepSessionState => normalizePrepSession({});
 
 const NutritionMealPlanner = () => {
   const { user, updateUser } = useUser();
@@ -141,6 +174,7 @@ const NutritionMealPlanner = () => {
 
   const getDateForWeekday = (weekday: string) => getDateForWeekdayFromAnchor(getCurrentWeekAnchor(), weekday);
   const getPrepSessionStorageKey = () => `meal-planner-prep-session-v1:${user?.id || 'anon'}:${getCurrentWeekAnchor()}`;
+  const getPrepSessionStorageKeyForAnchor = (anchorDate: string) => `meal-planner-prep-session-v1:${user?.id || 'anon'}:${anchorDate}`;
 
   useEffect(() => {
     fetchUserData();
@@ -169,18 +203,7 @@ const NutritionMealPlanner = () => {
         return;
       }
       const parsed = JSON.parse(stored);
-      const normalizedTasks = Array.isArray(parsed?.tasks)
-        ? DEFAULT_PREP_SESSION_TASKS.map((task) => {
-            const match = parsed.tasks.find((candidate: any) => candidate?.id === task.id);
-            return { ...task, done: Boolean(match?.done) };
-          })
-        : DEFAULT_PREP_SESSION_TASKS.map((task) => ({ ...task }));
-      setPrepSession({
-        scheduledAt: typeof parsed?.scheduledAt === 'string' ? parsed.scheduledAt : '',
-        notes: typeof parsed?.notes === 'string' ? parsed.notes : '',
-        tasks: normalizedTasks,
-        completedAt: typeof parsed?.completedAt === 'string' ? parsed.completedAt : null,
-      });
+      setPrepSession(normalizePrepSession(parsed));
     } catch (error) {
       console.error('Error loading prep session:', error);
       setPrepSession(createDefaultPrepSession());
@@ -1191,8 +1214,69 @@ const NutritionMealPlanner = () => {
     setPrepSession((prev) => ({
       ...prev,
       tasks: prev.tasks.map((task) => task.id === taskId ? { ...task, done: !task.done } : task),
+      carryoverTaskIds: prev.tasks.find((task) => task.id === taskId)?.done
+        ? [...new Set([...prev.carryoverTaskIds, taskId])]
+        : prev.carryoverTaskIds.filter((id) => id !== taskId),
       completedAt: prev.completedAt,
     }));
+  };
+
+  const togglePrepBlocker = (blockerId: string) => {
+    setPrepSession((prev) => ({
+      ...prev,
+      blockers: prev.blockers.map((blocker) => blocker.id === blockerId ? { ...blocker, active: !blocker.active } : blocker),
+      completedAt: null,
+    }));
+  };
+
+  const updatePrepBlockerNote = (value: string) => {
+    setPrepSession((prev) => ({
+      ...prev,
+      blockerNote: value,
+    }));
+  };
+
+  const carryForwardUnfinishedPrepTasks = () => {
+    const unfinishedTaskIds = prepSession.tasks.filter((task) => !task.done).map((task) => task.id);
+
+    if (unfinishedTaskIds.length === 0) {
+      toast({
+        description: 'No unfinished prep tasks to carry forward.',
+      });
+      return;
+    }
+
+    const nextWeekDate = parseDateOnly(getCurrentWeekAnchor());
+    nextWeekDate.setDate(nextWeekDate.getDate() + 7);
+    const nextWeekAnchor = formatLocalDate(nextWeekDate);
+
+    try {
+      const nextWeekStorageKey = getPrepSessionStorageKeyForAnchor(nextWeekAnchor);
+      const stored = localStorage.getItem(nextWeekStorageKey);
+      const parsed = stored ? JSON.parse(stored) : {};
+      const nextWeekSession = normalizePrepSession(parsed);
+      const mergedCarryoverIds = [...new Set([...nextWeekSession.carryoverTaskIds, ...unfinishedTaskIds])];
+
+      localStorage.setItem(nextWeekStorageKey, JSON.stringify({
+        ...nextWeekSession,
+        carryoverTaskIds: mergedCarryoverIds,
+      }));
+
+      setPrepSession((prev) => ({
+        ...prev,
+        carryoverTaskIds: [...new Set([...prev.carryoverTaskIds, ...unfinishedTaskIds])],
+      }));
+
+      toast({
+        description: `Carried ${unfinishedTaskIds.length} unfinished prep tasks to next week.`,
+      });
+    } catch (error) {
+      console.error('Error carrying prep tasks forward:', error);
+      toast({
+        variant: 'destructive',
+        description: 'Unable to carry forward prep tasks right now.',
+      });
+    }
   };
 
   const markPrepComplete = () => {
@@ -1297,7 +1381,18 @@ const NutritionMealPlanner = () => {
   const prepProgress = Math.round((prepSession.tasks.filter((task) => task.done).length / Math.max(1, prepSession.tasks.length)) * 100);
   const prepRecommendationsAvailable = plannedSlots > 0;
   const prepPlanMissing = plannedSlots > 0 && !prepSessionPlanned && !prepSessionCompleted;
-  const prepReadyForWeek = prepSessionCompleted || prepSessionPlanned;
+  const prepActiveBlockersCount = prepSession.blockers.filter((blocker) => blocker.active).length;
+  const prepCarryoverCount = prepSession.carryoverTaskIds.filter((taskId) => prepSession.tasks.some((task) => task.id === taskId && !task.done)).length;
+  const prepExecutionState = !prepSessionPlanned
+    ? 'not_planned'
+    : prepSessionCompleted
+      ? 'complete'
+      : prepActiveBlockersCount > 0
+        ? 'blocked'
+        : prepProgress > 0
+          ? 'in_progress'
+          : 'in_progress';
+  const prepReadyForWeek = prepSessionCompleted || (prepSessionPlanned && prepActiveBlockersCount === 0);
   const weekReadyNow = plannedSlots === totalSlots && (groceryBuyItemCount === 0 || groceryPendingCount === 0) && prepReadyForWeek;
   const rawSavingsSummary = savingsReport?.summary || {};
   const rawSavingsPantry = savingsReport?.pantry || {};
@@ -1632,6 +1727,9 @@ const NutritionMealPlanner = () => {
                 prepRecommendationsAvailable={prepRecommendationsAvailable}
                 prepSessionPlanned={prepSessionPlanned}
                 prepSessionCompleted={prepSessionCompleted}
+                prepExecutionState={prepExecutionState}
+                prepActiveBlockersCount={prepActiveBlockersCount}
+                prepCarryoverCount={prepCarryoverCount}
                 weekReadyNow={weekReadyNow}
                 onGoToPlanner={() => setActiveTab('planner')}
                 onGoToGrocery={() => setActiveTab('grocery')}
@@ -1944,6 +2042,9 @@ const NutritionMealPlanner = () => {
                 prepRecommendationsAvailable={prepRecommendationsAvailable}
                 prepSessionPlanned={prepSessionPlanned}
                 prepSessionCompleted={prepSessionCompleted}
+                prepExecutionState={prepExecutionState}
+                prepActiveBlockersCount={prepActiveBlockersCount}
+                prepCarryoverCount={prepCarryoverCount}
                 weekReadyNow={weekReadyNow}
                 onGoToPlanner={() => setActiveTab('planner')}
                 onGoToGrocery={() => setActiveTab('grocery')}
@@ -1983,6 +2084,9 @@ const NutritionMealPlanner = () => {
                 prepRecommendationsAvailable={prepRecommendationsAvailable}
                 prepSessionPlanned={prepSessionPlanned}
                 prepSessionCompleted={prepSessionCompleted}
+                prepExecutionState={prepExecutionState}
+                prepActiveBlockersCount={prepActiveBlockersCount}
+                prepCarryoverCount={prepCarryoverCount}
                 weekReadyNow={weekReadyNow}
                 onGoToPlanner={() => setActiveTab('planner')}
                 onGoToGrocery={() => setActiveTab('grocery')}
@@ -1997,6 +2101,9 @@ const NutritionMealPlanner = () => {
                 onScheduleChange={updatePrepSchedule}
                 onNotesChange={updatePrepNotes}
                 onToggleTask={togglePrepTask}
+                onToggleBlocker={togglePrepBlocker}
+                onBlockerNoteChange={updatePrepBlockerNote}
+                onCarryForwardUnfinished={carryForwardUnfinishedPrepTasks}
                 onMarkPrepComplete={markPrepComplete}
                 onResetPrepCompletion={resetPrepCompletion}
                 onGoToChecklist={() => window.scrollTo({ top: 0, behavior: 'smooth' })}

--- a/client/src/components/meal-planner/WeeklyReadinessChecklist.tsx
+++ b/client/src/components/meal-planner/WeeklyReadinessChecklist.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
 type ChecklistStatus = 'ready' | 'attention';
+type PrepExecutionState = 'not_planned' | 'blocked' | 'in_progress' | 'complete';
 
 type WeeklyReadinessChecklistProps = {
   unplannedMealSlots: number;
@@ -17,6 +18,9 @@ type WeeklyReadinessChecklistProps = {
   prepRecommendationsAvailable: boolean;
   prepSessionPlanned: boolean;
   prepSessionCompleted: boolean;
+  prepExecutionState: PrepExecutionState;
+  prepActiveBlockersCount: number;
+  prepCarryoverCount: number;
   weekReadyNow: boolean;
   onGoToPlanner: () => void;
   onGoToGrocery: () => void;
@@ -24,6 +28,29 @@ type WeeklyReadinessChecklistProps = {
 };
 
 const statusLabel = (status: ChecklistStatus) => status === 'ready' ? 'Ready' : 'Needs attention';
+
+const prepStateMessage = (
+  prepExecutionState: PrepExecutionState,
+  prepActiveBlockersCount: number,
+  prepCarryoverCount: number,
+) => {
+  if (prepExecutionState === 'complete') {
+    return 'Prep session completed for this week.';
+  }
+
+  if (prepExecutionState === 'blocked') {
+    const blockerLabel = prepActiveBlockersCount === 1 ? 'blocker' : 'blockers';
+    const carryoverText = prepCarryoverCount > 0 ? ` ${prepCarryoverCount} carryover tasks still need attention.` : '';
+    return `Prep session is planned but blocked by ${prepActiveBlockersCount} ${blockerLabel}.${carryoverText}`;
+  }
+
+  if (prepExecutionState === 'in_progress') {
+    const carryoverText = prepCarryoverCount > 0 ? ` ${prepCarryoverCount} tasks were carried in.` : '';
+    return `Prep is in progress.${carryoverText}`;
+  }
+
+  return 'Prep is not scheduled yet for this week.';
+};
 
 const WeeklyReadinessChecklist = ({
   unplannedMealSlots,
@@ -36,6 +63,9 @@ const WeeklyReadinessChecklist = ({
   prepRecommendationsAvailable,
   prepSessionPlanned,
   prepSessionCompleted,
+  prepExecutionState,
+  prepActiveBlockersCount,
+  prepCarryoverCount,
   weekReadyNow,
   onGoToPlanner,
   onGoToGrocery,
@@ -43,7 +73,7 @@ const WeeklyReadinessChecklist = ({
 }: WeeklyReadinessChecklistProps) => {
   const plannerStatus: ChecklistStatus = unplannedMealSlots === 0 ? 'ready' : 'attention';
   const groceryStatus: ChecklistStatus = groceryListCreated && groceryPendingCount === 0 ? 'ready' : 'attention';
-  const prepStatus: ChecklistStatus = prepPlanMissing ? 'attention' : 'ready';
+  const prepStatus: ChecklistStatus = prepExecutionState === 'complete' ? 'ready' : 'attention';
   const overallStatus: ChecklistStatus = weekReadyNow ? 'ready' : 'attention';
 
   return (
@@ -117,15 +147,9 @@ const WeeklyReadinessChecklist = ({
               <Badge variant="outline">{statusLabel(prepStatus)}</Badge>
             </div>
             <p className="text-xs text-gray-600">
-              {prepSessionCompleted
-                ? 'Prep session completed for this week.'
-                : prepSessionPlanned
-                  ? 'Prep session is scheduled and ready to execute.'
-                  : prepPlanMissing
-                    ? 'Planned meals are ready for a prep session.'
-                    : 'Prep guidance is available for your planned meals.'}
+              {prepStateMessage(prepExecutionState, prepActiveBlockersCount, prepCarryoverCount)}
             </p>
-            {prepRecommendationsAvailable && (
+            {(prepRecommendationsAvailable || prepPlanMissing) && (
               <Button variant="outline" size="sm" className="mt-2" onClick={onGoToPrep}>
                 {prepSessionCompleted ? 'Review Prep Session' : prepSessionPlanned ? 'Open Prep Session' : 'Go to Prep'}
               </Button>

--- a/client/src/components/meal-planner/sections/PrepTabSection.tsx
+++ b/client/src/components/meal-planner/sections/PrepTabSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CalendarClock, CheckCircle2, Clock, ListChecks } from 'lucide-react';
+import { AlertTriangle, CalendarClock, CheckCircle2, Clock, ListChecks, MoveRight } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -12,10 +12,19 @@ export type PrepTask = {
   done: boolean;
 };
 
+export type PrepBlocker = {
+  id: string;
+  label: string;
+  active: boolean;
+};
+
 export type PrepSessionState = {
   scheduledAt: string;
   notes: string;
   tasks: PrepTask[];
+  blockers: PrepBlocker[];
+  blockerNote: string;
+  carryoverTaskIds: string[];
   completedAt: string | null;
 };
 
@@ -28,6 +37,9 @@ type PrepTabSectionProps = {
   onScheduleChange: (value: string) => void;
   onNotesChange: (value: string) => void;
   onToggleTask: (taskId: string) => void;
+  onToggleBlocker: (blockerId: string) => void;
+  onBlockerNoteChange: (value: string) => void;
+  onCarryForwardUnfinished: () => void;
   onMarkPrepComplete: () => void;
   onResetPrepCompletion: () => void;
   onGoToChecklist: () => void;
@@ -42,10 +54,16 @@ const PrepTabSection = ({
   onScheduleChange,
   onNotesChange,
   onToggleTask,
+  onToggleBlocker,
+  onBlockerNoteChange,
+  onCarryForwardUnfinished,
   onMarkPrepComplete,
   onResetPrepCompletion,
   onGoToChecklist,
 }: PrepTabSectionProps) => {
+  const activeBlockers = prepSession.blockers.filter((blocker) => blocker.active);
+  const unfinishedTasks = prepSession.tasks.filter((task) => !task.done);
+
   return (
     <Card className="border-indigo-200 bg-gradient-to-r from-indigo-50 via-white to-orange-50">
       <CardHeader>
@@ -56,7 +74,7 @@ const PrepTabSection = ({
               Weekly Prep Session Tracker
             </CardTitle>
             <CardDescription>
-              Schedule prep, check off tasks, and mark the week execution-ready.
+              Schedule prep, resolve blockers, and carry unfinished tasks into the next session.
             </CardDescription>
           </div>
           <Badge variant={prepSessionCompleted ? 'default' : prepSessionPlanned ? 'outline' : 'secondary'} className={prepSessionCompleted ? 'bg-green-600 hover:bg-green-600' : ''}>
@@ -90,6 +108,37 @@ const PrepTabSection = ({
           </div>
         </div>
 
+        <div className="rounded-lg border bg-white p-3 space-y-3">
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-sm font-medium text-gray-900 flex items-center gap-2">
+              <AlertTriangle className="w-4 h-4 text-amber-500" />
+              Prep blockers
+            </p>
+            <Badge variant={activeBlockers.length > 0 ? 'secondary' : 'outline'}>
+              {activeBlockers.length > 0 ? `${activeBlockers.length} active` : 'No blockers'}
+            </Badge>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {prepSession.blockers.map((blocker) => (
+              <Button
+                key={blocker.id}
+                type="button"
+                variant={blocker.active ? 'default' : 'outline'}
+                size="sm"
+                className={blocker.active ? 'bg-amber-600 hover:bg-amber-600' : ''}
+                onClick={() => onToggleBlocker(blocker.id)}
+              >
+                {blocker.label}
+              </Button>
+            ))}
+          </div>
+          <Input
+            value={prepSession.blockerNote}
+            onChange={(e) => onBlockerNoteChange(e.target.value)}
+            placeholder="Optional blocker note (ex: chicken still thawing until Monday)"
+          />
+        </div>
+
         <div className="rounded-lg border bg-white p-3">
           <div className="flex items-center justify-between gap-2 mb-2">
             <p className="text-sm font-medium text-gray-900 flex items-center gap-2">
@@ -99,19 +148,41 @@ const PrepTabSection = ({
             <p className="text-xs text-gray-600">{prepSession.tasks.filter((task) => task.done).length}/{prepSession.tasks.length} tasks</p>
           </div>
           <div className="space-y-2">
-            {prepSession.tasks.map((task) => (
-              <label key={task.id} className="flex items-center gap-2 text-sm text-gray-700">
-                <Checkbox checked={task.done} onCheckedChange={() => onToggleTask(task.id)} />
-                <span className={task.done ? 'line-through text-gray-500' : ''}>{task.label}</span>
-              </label>
-            ))}
+            {prepSession.tasks.map((task) => {
+              const carriedOver = prepSession.carryoverTaskIds.includes(task.id);
+              return (
+                <label key={task.id} className="flex items-center justify-between gap-2 text-sm text-gray-700">
+                  <div className="flex items-center gap-2">
+                    <Checkbox checked={task.done} onCheckedChange={() => onToggleTask(task.id)} />
+                    <span className={task.done ? 'line-through text-gray-500' : ''}>{task.label}</span>
+                  </div>
+                  {carriedOver && !task.done && <Badge variant="secondary" className="text-[10px]">Carryover</Badge>}
+                </label>
+              );
+            })}
           </div>
+        </div>
+
+        <div className="rounded-lg border bg-white p-3">
+          <div className="flex items-center justify-between gap-2 mb-2">
+            <p className="text-sm font-medium text-gray-900 flex items-center gap-2">
+              <MoveRight className="w-4 h-4 text-indigo-500" />
+              Carryover to next prep session
+            </p>
+            <Badge variant="outline">{unfinishedTasks.length} unfinished</Badge>
+          </div>
+          <p className="text-xs text-gray-600 mb-3">
+            Carry unfinished tasks forward so next week's prep starts with what slipped.
+          </p>
+          <Button variant="outline" size="sm" onClick={onCarryForwardUnfinished} disabled={unfinishedTasks.length === 0}>
+            Carry Forward Unfinished Tasks
+          </Button>
         </div>
 
         <div className="flex flex-wrap gap-2">
           <Button
             onClick={onMarkPrepComplete}
-            disabled={!prepSessionPlanned || !prepRecommendationsAvailable || prepSessionCompleted}
+            disabled={!prepSessionPlanned || !prepRecommendationsAvailable || prepSessionCompleted || activeBlockers.length > 0}
           >
             <CheckCircle2 className="w-4 h-4 mr-2" />
             Mark Prep Complete


### PR DESCRIPTION
### Motivation
- Prep sessions previously tracked schedule and completion but not real-world friction or spillover, making the Weekly Readiness state over-optimistic.  
- We need a lightweight, additive way to capture why prep is blocked and let unfinished prep tasks carry forward so readiness reflects execution friction.  
- Changes must be local, backward-compatible with existing localStorage session payloads, and keep `NutritionMealPlanner.tsx` as the orchestrator.

### Description
- Extend prep session state with blockers, an optional `blockerNote`, and `carryoverTaskIds`, and add `normalizePrepSession` so existing saved sessions remain compatible; default blocker set includes `missing-ingredient`, `missing-containers`, `time-conflict`, `waiting-on-grocery`, and `kitchen-access` (`client/src/components/NutritionMealPlanner.tsx`).
- Add page-local handlers in `NutritionMealPlanner.tsx` to toggle blockers, save blocker notes, update task carryover when tasks change, and a one-click `carryForwardUnfinishedPrepTasks` that writes carryover IDs into next week’s prep session key in `localStorage`.
- Compute new readiness signals in `NutritionMealPlanner.tsx`: `prepActiveBlockersCount`, `prepCarryoverCount`, and `prepExecutionState` (`not_planned | blocked | in_progress | complete`), and tighten the prep readiness gate so blocked prep is not considered ready.
- Update UI: `PrepTabSection.tsx` now shows blocker chips, blocker-note input, carryover badges on unfinished tasks, a “Carry Forward Unfinished Tasks” action, and disables “Mark Prep Complete” while blockers are active; `WeeklyReadinessChecklist.tsx` now receives prep execution props and renders explicit messages for `not_planned`, `blocked`, `in_progress`, and `complete` states.
- Additive-only change set; no API contract changes and persistence is limited to the page via `localStorage` keys per-week.

### Testing
- Ran `npm run build` and the full build succeeded (client + server build steps executed).  
- Ran `npm run build:client` and `npm run build:server` individually and both completed successfully.  
- Builds displayed non-fatal bundle warnings but finished without errors (no unit/integration tests were modified or required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e198b62c832594f7498be53a817b)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
