### PR TITLE
Add prep blocker-to-grocery resolution bridge in meal planner

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -88,6 +88,7 @@ const DEFAULT_PREP_BLOCKERS = [
   { id: 'waiting-on-grocery', label: 'Waiting on grocery', active: false },
   { id: 'kitchen-access', label: 'Kitchen access', active: false },
 ];
+const GROCERY_LINKED_PREP_BLOCKER_IDS = ['missing-ingredient', 'waiting-on-grocery'];
 
 const normalizePrepSession = (session: any): PrepSessionState => {
   const normalizedTasks = Array.isArray(session?.tasks)
@@ -1236,6 +1237,18 @@ const NutritionMealPlanner = () => {
     }));
   };
 
+  const resolvePrepGroceryBlockers = () => {
+    setPrepSession((prev) => ({
+      ...prev,
+      blockers: prev.blockers.map((blocker) => (
+        GROCERY_LINKED_PREP_BLOCKER_IDS.includes(blocker.id)
+          ? { ...blocker, active: false }
+          : blocker
+      )),
+      completedAt: null,
+    }));
+  };
+
   const carryForwardUnfinishedPrepTasks = () => {
     const unfinishedTaskIds = prepSession.tasks.filter((task) => !task.done).map((task) => task.id);
 
@@ -1382,6 +1395,9 @@ const NutritionMealPlanner = () => {
   const prepRecommendationsAvailable = plannedSlots > 0;
   const prepPlanMissing = plannedSlots > 0 && !prepSessionPlanned && !prepSessionCompleted;
   const prepActiveBlockersCount = prepSession.blockers.filter((blocker) => blocker.active).length;
+  const prepGroceryBlockersCount = prepSession.blockers.filter(
+    (blocker) => blocker.active && GROCERY_LINKED_PREP_BLOCKER_IDS.includes(blocker.id),
+  ).length;
   const prepCarryoverCount = prepSession.carryoverTaskIds.filter((taskId) => prepSession.tasks.some((task) => task.id === taskId && !task.done)).length;
   const prepExecutionState = !prepSessionPlanned
     ? 'not_planned'
@@ -1394,6 +1410,7 @@ const NutritionMealPlanner = () => {
           : 'in_progress';
   const prepReadyForWeek = prepSessionCompleted || (prepSessionPlanned && prepActiveBlockersCount === 0);
   const weekReadyNow = plannedSlots === totalSlots && (groceryBuyItemCount === 0 || groceryPendingCount === 0) && prepReadyForWeek;
+  const canResolvePrepGroceryBlockers = prepGroceryBlockersCount > 0 && groceryListCreated && groceryPendingCount === 0;
   const rawSavingsSummary = savingsReport?.summary || {};
   const rawSavingsPantry = savingsReport?.pantry || {};
   const safeTopSavingCategories = Array.isArray(savingsReport?.topSavingCategories)
@@ -1408,6 +1425,31 @@ const NutritionMealPlanner = () => {
         topSavingCategories: safeTopSavingCategories,
       }
     : null;
+
+  useEffect(() => {
+    if (!canResolvePrepGroceryBlockers) {
+      return;
+    }
+
+    setPrepSession((prev) => {
+      const hasActiveLinkedBlocker = prev.blockers.some(
+        (blocker) => blocker.active && GROCERY_LINKED_PREP_BLOCKER_IDS.includes(blocker.id),
+      );
+
+      if (!hasActiveLinkedBlocker) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        blockers: prev.blockers.map((blocker) => (
+          GROCERY_LINKED_PREP_BLOCKER_IDS.includes(blocker.id)
+            ? { ...blocker, active: false }
+            : blocker
+        )),
+      };
+    });
+  }, [canResolvePrepGroceryBlockers]);
 
   const weeklyNutritionData = weekDays.map((day) => {
     const totals = mealTypes.reduce((acc, type) => {
@@ -1729,6 +1771,7 @@ const NutritionMealPlanner = () => {
                 prepSessionCompleted={prepSessionCompleted}
                 prepExecutionState={prepExecutionState}
                 prepActiveBlockersCount={prepActiveBlockersCount}
+                prepGroceryBlockersCount={prepGroceryBlockersCount}
                 prepCarryoverCount={prepCarryoverCount}
                 weekReadyNow={weekReadyNow}
                 onGoToPlanner={() => setActiveTab('planner')}
@@ -2044,6 +2087,7 @@ const NutritionMealPlanner = () => {
                 prepSessionCompleted={prepSessionCompleted}
                 prepExecutionState={prepExecutionState}
                 prepActiveBlockersCount={prepActiveBlockersCount}
+                prepGroceryBlockersCount={prepGroceryBlockersCount}
                 prepCarryoverCount={prepCarryoverCount}
                 weekReadyNow={weekReadyNow}
                 onGoToPlanner={() => setActiveTab('planner')}
@@ -2066,6 +2110,9 @@ const NutritionMealPlanner = () => {
                 onGenerateWeekPlan={generateWeekPlan}
                 isGeneratingWeek={isGeneratingWeek}
                 onGoToPrep={() => setActiveTab('prep')}
+                prepGroceryBlockersCount={prepGroceryBlockersCount}
+                canResolvePrepGroceryBlockers={canResolvePrepGroceryBlockers}
+                onResolvePrepGroceryBlockers={resolvePrepGroceryBlockers}
               />
             </div>
           </TabsContent>
@@ -2086,6 +2133,7 @@ const NutritionMealPlanner = () => {
                 prepSessionCompleted={prepSessionCompleted}
                 prepExecutionState={prepExecutionState}
                 prepActiveBlockersCount={prepActiveBlockersCount}
+                prepGroceryBlockersCount={prepGroceryBlockersCount}
                 prepCarryoverCount={prepCarryoverCount}
                 weekReadyNow={weekReadyNow}
                 onGoToPlanner={() => setActiveTab('planner')}
@@ -2107,6 +2155,8 @@ const NutritionMealPlanner = () => {
                 onMarkPrepComplete={markPrepComplete}
                 onResetPrepCompletion={resetPrepCompletion}
                 onGoToChecklist={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+                prepGroceryBlockersCount={prepGroceryBlockersCount}
+                onResolveBlockersInGrocery={() => setActiveTab('grocery')}
               />
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                 <Card>

--- a/client/src/components/meal-planner/WeeklyReadinessChecklist.tsx
+++ b/client/src/components/meal-planner/WeeklyReadinessChecklist.tsx
@@ -20,6 +20,7 @@ type WeeklyReadinessChecklistProps = {
   prepSessionCompleted: boolean;
   prepExecutionState: PrepExecutionState;
   prepActiveBlockersCount: number;
+  prepGroceryBlockersCount: number;
   prepCarryoverCount: number;
   weekReadyNow: boolean;
   onGoToPlanner: () => void;
@@ -65,6 +66,7 @@ const WeeklyReadinessChecklist = ({
   prepSessionCompleted,
   prepExecutionState,
   prepActiveBlockersCount,
+  prepGroceryBlockersCount,
   prepCarryoverCount,
   weekReadyNow,
   onGoToPlanner,
@@ -131,9 +133,16 @@ const WeeklyReadinessChecklist = ({
                   ? `${groceryPendingCount} items still need to be bought.`
                   : `Shopping complete with ${groceryCompletedCount} items checked off.`}
             </p>
+            {prepGroceryBlockersCount > 0 && (
+              <p className="text-xs text-amber-700 mt-2">
+                {prepGroceryBlockersCount === 1
+                  ? '1 prep blocker can be resolved from this grocery flow.'
+                  : `${prepGroceryBlockersCount} prep blockers can be resolved from this grocery flow.`}
+              </p>
+            )}
             {(groceryPendingCount > 0 || !groceryListCreated) && (
               <Button variant="outline" size="sm" className="mt-2" onClick={onGoToGrocery}>
-                Go to Grocery
+                {prepGroceryBlockersCount > 0 ? 'Resolve in Grocery' : 'Go to Grocery'}
               </Button>
             )}
           </div>

--- a/client/src/components/meal-planner/sections/GroceryTabSection.tsx
+++ b/client/src/components/meal-planner/sections/GroceryTabSection.tsx
@@ -21,6 +21,9 @@ type GroceryTabSectionProps = {
   onGenerateWeekPlan: () => void;
   isGeneratingWeek: boolean;
   onGoToPrep: () => void;
+  prepGroceryBlockersCount: number;
+  onResolvePrepGroceryBlockers: () => void;
+  canResolvePrepGroceryBlockers: boolean;
 };
 
 const GroceryTabSection = ({
@@ -39,6 +42,9 @@ const GroceryTabSection = ({
   onGenerateWeekPlan,
   isGeneratingWeek,
   onGoToPrep,
+  prepGroceryBlockersCount,
+  onResolvePrepGroceryBlockers,
+  canResolvePrepGroceryBlockers,
 }: GroceryTabSectionProps) => {
   const buyItems = groceryList.filter((i: any) => !i.isPantryItem);
   const checkedBuyItems = buyItems.filter((i: any) => i.checked).length;
@@ -80,6 +86,29 @@ const GroceryTabSection = ({
             </div>
           </CardContent>
         </Card>
+
+        {prepGroceryBlockersCount > 0 && (
+          <Card className="border-amber-200 bg-amber-50/60">
+            <CardContent className="p-4">
+              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-amber-700 font-semibold mb-1">Prep blocker bridge</p>
+                  <p className="text-sm font-medium text-amber-900">
+                    {prepGroceryBlockersCount === 1
+                      ? '1 prep blocker is waiting on grocery.'
+                      : `${prepGroceryBlockersCount} prep blockers are waiting on grocery.`}
+                  </p>
+                  <p className="text-xs text-amber-700 mt-1">
+                    Finish shopping, then mark blockers resolved to continue prep.
+                  </p>
+                </div>
+                <Button size="sm" variant="outline" onClick={onResolvePrepGroceryBlockers} disabled={!canResolvePrepGroceryBlockers}>
+                  Mark Grocery Blockers Resolved
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
 
         {(() => {
           const pantryOwned = groceryList.filter((i: any) => i.isPantryItem && !i.checked);

--- a/client/src/components/meal-planner/sections/PrepTabSection.tsx
+++ b/client/src/components/meal-planner/sections/PrepTabSection.tsx
@@ -43,6 +43,8 @@ type PrepTabSectionProps = {
   onMarkPrepComplete: () => void;
   onResetPrepCompletion: () => void;
   onGoToChecklist: () => void;
+  prepGroceryBlockersCount: number;
+  onResolveBlockersInGrocery: () => void;
 };
 
 const PrepTabSection = ({
@@ -60,6 +62,8 @@ const PrepTabSection = ({
   onMarkPrepComplete,
   onResetPrepCompletion,
   onGoToChecklist,
+  prepGroceryBlockersCount,
+  onResolveBlockersInGrocery,
 }: PrepTabSectionProps) => {
   const activeBlockers = prepSession.blockers.filter((blocker) => blocker.active);
   const unfinishedTasks = prepSession.tasks.filter((task) => !task.done);
@@ -137,6 +141,18 @@ const PrepTabSection = ({
             onChange={(e) => onBlockerNoteChange(e.target.value)}
             placeholder="Optional blocker note (ex: chicken still thawing until Monday)"
           />
+          {prepGroceryBlockersCount > 0 && (
+            <div className="rounded-md border border-blue-200 bg-blue-50 p-3 flex flex-wrap items-center justify-between gap-2">
+              <p className="text-xs text-blue-800">
+                {prepGroceryBlockersCount === 1
+                  ? '1 blocker depends on grocery completion.'
+                  : `${prepGroceryBlockersCount} blockers depend on grocery completion.`}
+              </p>
+              <Button size="sm" variant="outline" onClick={onResolveBlockersInGrocery}>
+                Resolve in Grocery
+              </Button>
+            </div>
+          )}
         </div>
 
         <div className="rounded-lg border bg-white p-3">


### PR DESCRIPTION
### Motivation
- Prep blockers like “missing ingredient” and “waiting on grocery” were tracked but users could not resolve them directly from the planner flow, creating a gap between detecting blockers and completing shopping. 
- Provide a lightweight, additive path from Planner → Grocery → Prep that preserves existing routes and API behavior and reduces friction to execution.

### Description
- Added a grocery-linked blocker set (`GROCERY_LINKED_PREP_BLOCKER_IDS`) and computed `prepGroceryBlockersCount` in `NutritionMealPlanner` to surface blockers that can be resolved via the grocery flow. 
- Implemented a resolver function `resolvePrepGroceryBlockers` and an effect that auto-clears grocery-linked blockers when shopping is complete (`groceryListCreated && groceryPendingCount === 0`).
- Threaded the new state/handlers into UI components and added in-context CTAs: Weekly Readiness Checklist shows a blocker message and changes CTA to `Resolve in Grocery`, Prep tab shows a small panel with `Resolve in Grocery` that jumps to Grocery, and Grocery tab adds a “Prep blocker bridge” card with a `Mark Grocery Blockers Resolved` action (enabled only when shopping is complete).
- Files changed: `client/src/components/NutritionMealPlanner.tsx`, `client/src/components/meal-planner/WeeklyReadinessChecklist.tsx`, `client/src/components/meal-planner/sections/PrepTabSection.tsx`, and `client/src/components/meal-planner/sections/GroceryTabSection.tsx`.

### Testing
- Built the project end-to-end with `npm run build` which invokes `npm run build:client` and `npm run build:server`, and both `npm run build:client` and `npm run build:server` were run individually; all commands completed successfully in this environment. 
- No automated unit tests were added or modified as this change is UI/state wiring only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3eb5350808325b13a0fa9b6250216)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
