### PR TITLE
Add blocker-driven grocery item suggestions to meal planner

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import {
   Calendar, Plus, Target, TrendingUp, Clock, ChefHat, Star, Lock, Crown,
   ShoppingCart, CheckCircle, BarChart3, Download, Filter, Save,
@@ -89,6 +89,18 @@ const DEFAULT_PREP_BLOCKERS = [
   { id: 'kitchen-access', label: 'Kitchen access', active: false },
 ];
 const GROCERY_LINKED_PREP_BLOCKER_IDS = ['missing-ingredient', 'waiting-on-grocery'];
+const BLOCKER_SUGGESTION_CATEGORY_BY_ID: Record<string, string> = {
+  'missing-ingredient': 'From Recipe',
+  'waiting-on-grocery': 'Other',
+};
+const BLOCKER_SUGGESTION_SEEDS_BY_ID: Record<string, string[]> = {
+  'missing-ingredient': ['Meal prep protein', 'Fresh vegetables', 'Breakfast staples'],
+  'waiting-on-grocery': ['Weekly produce refill', 'Protein restock', 'Quick snack options'],
+};
+const BLOCKER_NOTE_STOP_WORDS = new Set([
+  'and', 'the', 'for', 'with', 'need', 'needs', 'needed', 'still', 'more', 'from', 'into', 'this', 'that',
+  'prep', 'meal', 'meals', 'week', 'grocery', 'shopping', 'store', 'list', 'item', 'items', 'to', 'a', 'an',
+]);
 
 const normalizePrepSession = (session: any): PrepSessionState => {
   const normalizedTasks = Array.isArray(session?.tasks)
@@ -121,6 +133,14 @@ const normalizePrepSession = (session: any): PrepSessionState => {
 };
 
 const createDefaultPrepSession = (): PrepSessionState => normalizePrepSession({});
+
+type BlockerItemSuggestion = {
+  id: string;
+  name: string;
+  category: string;
+  reason: string;
+  alreadyOnList: boolean;
+};
 
 const NutritionMealPlanner = () => {
   const { user, updateUser } = useUser();
@@ -672,6 +692,40 @@ const NutritionMealPlanner = () => {
       credentials: 'include',
       body: JSON.stringify(payload),
     });
+  };
+
+  const addBlockerSuggestionToGrocery = async (suggestion: BlockerItemSuggestion) => {
+    if (suggestion.alreadyOnList) {
+      toast({
+        description: `“${suggestion.name}” is already on your grocery list.`,
+      });
+      return;
+    }
+
+    try {
+      const response = await addGroceryListItem({
+        ingredientName: suggestion.name,
+        quantity: '1',
+        unit: '',
+        category: suggestion.category,
+        notes: `Prep blocker suggestion: ${suggestion.reason}`,
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to add blocker suggestion item');
+      }
+
+      toast({
+        description: `✅ Added "${suggestion.name}" from prep blocker suggestions.`,
+      });
+      await fetchGroceryList();
+    } catch (error) {
+      console.error('Error adding blocker suggestion:', error);
+      toast({
+        variant: 'destructive',
+        description: 'Failed to add suggested blocker item',
+      });
+    }
   };
 
   const closeAddMealModal = () => {
@@ -1398,6 +1452,74 @@ const NutritionMealPlanner = () => {
   const prepGroceryBlockersCount = prepSession.blockers.filter(
     (blocker) => blocker.active && GROCERY_LINKED_PREP_BLOCKER_IDS.includes(blocker.id),
   ).length;
+  const blockerItemSuggestions = useMemo<BlockerItemSuggestion[]>(() => {
+    if (prepGroceryBlockersCount === 0) {
+      return [];
+    }
+
+    const activeGroceryBlockers = prepSession.blockers.filter(
+      (blocker) => blocker.active && GROCERY_LINKED_PREP_BLOCKER_IDS.includes(blocker.id),
+    );
+    const existingItemNames = new Set(
+      groceryList
+        .map((item: any) => String(item?.name || item?.item || '').trim().toLowerCase())
+        .filter(Boolean),
+    );
+
+    const noteCandidates = prepSession.blockerNote
+      .split(/[\n,;|]/)
+      .flatMap((part) => part.split(/\band\b/i))
+      .map((part) => part.trim())
+      .filter((part) => part.length > 1)
+      .map((part) => part.replace(/^[\-\d.)\s]+/, '').replace(/\s{2,}/g, ' '))
+      .filter((part) => {
+        const normalized = part.toLowerCase();
+        return normalized.length > 2 && !BLOCKER_NOTE_STOP_WORDS.has(normalized);
+      });
+
+    const suggestionRows: Array<{ name: string; category: string; reason: string }> = [];
+
+    noteCandidates.forEach((candidate) => {
+      suggestionRows.push({
+        name: candidate,
+        category: 'From Recipe',
+        reason: 'from prep blocker note',
+      });
+    });
+
+    activeGroceryBlockers.forEach((blocker) => {
+      const seedItems = BLOCKER_SUGGESTION_SEEDS_BY_ID[blocker.id] || [];
+      seedItems.forEach((seed) => {
+        suggestionRows.push({
+          name: seed,
+          category: BLOCKER_SUGGESTION_CATEGORY_BY_ID[blocker.id] || 'Other',
+          reason: blocker.label.toLowerCase(),
+        });
+      });
+    });
+
+    const uniqueByName = new Map<string, { name: string; category: string; reason: string }>();
+    suggestionRows.forEach((row) => {
+      const normalized = row.name.trim().toLowerCase();
+      if (!normalized) return;
+      if (!uniqueByName.has(normalized)) {
+        uniqueByName.set(normalized, row);
+      }
+    });
+
+    return Array.from(uniqueByName.values())
+      .slice(0, 6)
+      .map((row) => {
+        const normalizedName = row.name.trim().toLowerCase();
+        return {
+          id: normalizedName.replace(/[^a-z0-9]+/g, '-'),
+          name: row.name,
+          category: row.category,
+          reason: row.reason,
+          alreadyOnList: existingItemNames.has(normalizedName),
+        };
+      });
+  }, [groceryList, prepGroceryBlockersCount, prepSession.blockerNote, prepSession.blockers]);
   const prepCarryoverCount = prepSession.carryoverTaskIds.filter((taskId) => prepSession.tasks.some((task) => task.id === taskId && !task.done)).length;
   const prepExecutionState = !prepSessionPlanned
     ? 'not_planned'
@@ -2113,6 +2235,8 @@ const NutritionMealPlanner = () => {
                 prepGroceryBlockersCount={prepGroceryBlockersCount}
                 canResolvePrepGroceryBlockers={canResolvePrepGroceryBlockers}
                 onResolvePrepGroceryBlockers={resolvePrepGroceryBlockers}
+                blockerItemSuggestions={blockerItemSuggestions}
+                onAddBlockerSuggestion={addBlockerSuggestionToGrocery}
               />
             </div>
           </TabsContent>

--- a/client/src/components/meal-planner/sections/GroceryTabSection.tsx
+++ b/client/src/components/meal-planner/sections/GroceryTabSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Camera, CheckCircle, DollarSign, Download, Filter, Package, Plus, ShoppingCart, Star, TrendingUp, Users, Zap } from 'lucide-react';
+import { Camera, CheckCircle, DollarSign, Download, Filter, Lightbulb, Package, Plus, ShoppingCart, Star, TrendingUp, Users, Zap } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -24,6 +24,20 @@ type GroceryTabSectionProps = {
   prepGroceryBlockersCount: number;
   onResolvePrepGroceryBlockers: () => void;
   canResolvePrepGroceryBlockers: boolean;
+  blockerItemSuggestions: Array<{
+    id: string;
+    name: string;
+    category: string;
+    reason: string;
+    alreadyOnList: boolean;
+  }>;
+  onAddBlockerSuggestion: (suggestion: {
+    id: string;
+    name: string;
+    category: string;
+    reason: string;
+    alreadyOnList: boolean;
+  }) => void;
 };
 
 const GroceryTabSection = ({
@@ -45,6 +59,8 @@ const GroceryTabSection = ({
   prepGroceryBlockersCount,
   onResolvePrepGroceryBlockers,
   canResolvePrepGroceryBlockers,
+  blockerItemSuggestions,
+  onAddBlockerSuggestion,
 }: GroceryTabSectionProps) => {
   const buyItems = groceryList.filter((i: any) => !i.isPantryItem);
   const checkedBuyItems = buyItems.filter((i: any) => i.checked).length;
@@ -106,6 +122,41 @@ const GroceryTabSection = ({
                   Mark Grocery Blockers Resolved
                 </Button>
               </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {blockerItemSuggestions.length > 0 && (
+          <Card className="border-indigo-200 bg-indigo-50/40">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2 text-indigo-800">
+                <Lightbulb className="w-4 h-4 text-indigo-600" />
+                Blocker item suggestions
+              </CardTitle>
+              <CardDescription className="text-xs text-indigo-700">
+                Quick-add likely grocery items from active prep blockers and blocker notes.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {blockerItemSuggestions.map((suggestion) => (
+                <div key={suggestion.id} className="rounded-lg border border-indigo-100 bg-white p-3 flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <p className="text-sm font-medium text-gray-900">{suggestion.name}</p>
+                    <p className="text-xs text-gray-500">
+                      {suggestion.category} • Suggested {suggestion.reason}
+                    </p>
+                  </div>
+                  {suggestion.alreadyOnList ? (
+                    <Badge variant="outline" className="text-green-700 border-green-200 bg-green-50">
+                      Already on list
+                    </Badge>
+                  ) : (
+                    <Button size="sm" variant="outline" onClick={() => onAddBlockerSuggestion(suggestion)}>
+                      Add to Grocery
+                    </Button>
+                  )}
+                </div>
+              ))}
             </CardContent>
           </Card>
         )}


### PR DESCRIPTION
### Motivation
- Prep blockers can already route users into Grocery but there was no lightweight way to translate blocker intent into concrete shopping actions. 
- Provide quick, low-friction suggestions derived from blocker type and blocker note text while avoiding duplicate adds and preserving existing flows.

### Description
- Added a small suggestion pipeline and constants in `NutritionMealPlanner.tsx` that derives candidate grocery items from active grocery-linked blockers and free-text `prepSession.blockerNote`, with stop-word filtering and a capped deduplicated result set. (new constants, `useMemo` suggestion list).
- Implemented `addBlockerSuggestionToGrocery` which reuses the existing `addGroceryListItem` POST flow, attaches a prep-blocker note for traceability, and refreshes the grocery list on success.
- Wired suggestions into the grocery UI by passing `blockerItemSuggestions` and `onAddBlockerSuggestion` to `GroceryTabSection` and added an additive “Blocker item suggestions” card in `client/src/components/meal-planner/sections/GroceryTabSection.tsx` that shows suggested items, duplicate state, and a one-click `Add to Grocery` button.
- Changes are additive only and preserve existing prep/grocery behavior and API usage; no breaking contract changes were introduced.

### Testing
- Ran TypeScript check with `npm run -s check`; the command was executed but the repo contains multiple unrelated, pre-existing TypeScript errors and the check failed (errors are repository-wide and not caused by this small additive change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3ed29d474832590a198326e5042ad)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
