### PR TITLE
Prep-tab blocker suggestion quick-add actions

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -2281,6 +2281,9 @@ const NutritionMealPlanner = () => {
                 onGoToChecklist={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
                 prepGroceryBlockersCount={prepGroceryBlockersCount}
                 onResolveBlockersInGrocery={() => setActiveTab('grocery')}
+                blockerItemSuggestions={blockerItemSuggestions}
+                onAddBlockerSuggestion={addBlockerSuggestionToGrocery}
+                onGoToGrocery={() => setActiveTab('grocery')}
               />
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                 <Card>

--- a/client/src/components/meal-planner/sections/PrepTabSection.tsx
+++ b/client/src/components/meal-planner/sections/PrepTabSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AlertTriangle, CalendarClock, CheckCircle2, Clock, ListChecks, MoveRight } from 'lucide-react';
+import { AlertTriangle, CalendarClock, CheckCircle2, Clock, Lightbulb, ListChecks, MoveRight, ShoppingCart } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -45,6 +45,21 @@ type PrepTabSectionProps = {
   onGoToChecklist: () => void;
   prepGroceryBlockersCount: number;
   onResolveBlockersInGrocery: () => void;
+  blockerItemSuggestions: Array<{
+    id: string;
+    name: string;
+    category: string;
+    reason: string;
+    alreadyOnList: boolean;
+  }>;
+  onAddBlockerSuggestion: (suggestion: {
+    id: string;
+    name: string;
+    category: string;
+    reason: string;
+    alreadyOnList: boolean;
+  }) => void;
+  onGoToGrocery: () => void;
 };
 
 const PrepTabSection = ({
@@ -64,6 +79,9 @@ const PrepTabSection = ({
   onGoToChecklist,
   prepGroceryBlockersCount,
   onResolveBlockersInGrocery,
+  blockerItemSuggestions,
+  onAddBlockerSuggestion,
+  onGoToGrocery,
 }: PrepTabSectionProps) => {
   const activeBlockers = prepSession.blockers.filter((blocker) => blocker.active);
   const unfinishedTasks = prepSession.tasks.filter((task) => !task.done);
@@ -151,6 +169,43 @@ const PrepTabSection = ({
               <Button size="sm" variant="outline" onClick={onResolveBlockersInGrocery}>
                 Resolve in Grocery
               </Button>
+            </div>
+          )}
+          {blockerItemSuggestions.length > 0 && (
+            <div className="rounded-md border border-indigo-200 bg-indigo-50/70 p-3 space-y-2">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs font-medium text-indigo-900 flex items-center gap-1.5">
+                  <Lightbulb className="w-3.5 h-3.5 text-indigo-600" />
+                  Blocker item suggestions
+                </p>
+                <Button variant="ghost" size="sm" className="h-7 px-2 text-xs text-indigo-700" onClick={onGoToGrocery}>
+                  View in Grocery
+                </Button>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {blockerItemSuggestions.map((suggestion) => (
+                  suggestion.alreadyOnList ? (
+                    <Badge key={suggestion.id} variant="outline" className="bg-green-50 border-green-200 text-green-700">
+                      {suggestion.name} • On list
+                    </Badge>
+                  ) : (
+                    <Button
+                      key={suggestion.id}
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-7 text-xs border-indigo-200 text-indigo-800"
+                      onClick={() => onAddBlockerSuggestion(suggestion)}
+                    >
+                      <ShoppingCart className="w-3.5 h-3.5 mr-1" />
+                      Add {suggestion.name}
+                    </Button>
+                  )
+                ))}
+              </div>
+              <p className="text-[11px] text-indigo-700">
+                Quick-add items now, then finish shopping to unblock prep.
+              </p>
             </div>
           )}
         </div>


### PR DESCRIPTION
### Motivation
- Enable users to convert prep blockers into concrete grocery actions without leaving the Prep context by leveraging existing blocker suggestion state and add-to-grocery flows.
- Keep changes additive and low-risk while preserving `NutritionMealPlanner` as orchestrator and existing Grocery tab behavior.

### Description
- Added a lightweight `Blocker item suggestions` panel inside the existing Prep blockers card that shows inferred suggestions from active grocery-linked blockers and blocker notes, with `Add <item>` one-click buttons and `On list` badges for items already present. The UI also offers a `View in Grocery` handoff. This is the exact blocker-item suggestion improvement added.
- Reused existing computed `blockerItemSuggestions` and the existing `addBlockerSuggestionToGrocery` function by passing them from `NutritionMealPlanner` into `PrepTabSection` so no API contract changes were required and state remains consistent.
- Files changed: `client/src/components/meal-planner/sections/PrepTabSection.tsx` and `client/src/components/NutritionMealPlanner.tsx`.
- Next best improvement: add a lightweight suggestion-to-resolution tracker that marks which blocker suggestions were added and surface “X of Y blocker suggestions purchased” in Grocery/Readiness.

### Testing
- Ran `npm run build`, `npm run build:client`, and `npm run build:server` as validation steps. All three succeeded without errors (build warnings from chunk sizes noted but no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40c577b80832593e39de73e7f5f87)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
