### PR TITLE
Add lightweight blocker suggestion → resolution tracking to meal planner

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -102,6 +102,14 @@ const BLOCKER_NOTE_STOP_WORDS = new Set([
   'prep', 'meal', 'meals', 'week', 'grocery', 'shopping', 'store', 'list', 'item', 'items', 'to', 'a', 'an',
 ]);
 
+type BlockerSuggestionResolutionLink = {
+  suggestionId: string;
+  name: string;
+  category: string;
+  reason: string;
+  addedAt: string;
+};
+
 const normalizePrepSession = (session: any): PrepSessionState => {
   const normalizedTasks = Array.isArray(session?.tasks)
     ? DEFAULT_PREP_SESSION_TASKS.map((task) => {
@@ -120,6 +128,17 @@ const normalizePrepSession = (session: any): PrepSessionState => {
   const normalizedCarryoverIds = Array.isArray(session?.carryoverTaskIds)
     ? session.carryoverTaskIds.filter((taskId: string) => normalizedTasks.some((task) => task.id === taskId))
     : [];
+  const normalizedSuggestionLinks = Array.isArray(session?.blockerSuggestionLinks)
+    ? session.blockerSuggestionLinks
+        .map((link: any) => ({
+          suggestionId: typeof link?.suggestionId === 'string' ? link.suggestionId : '',
+          name: typeof link?.name === 'string' ? link.name : '',
+          category: typeof link?.category === 'string' ? link.category : 'Other',
+          reason: typeof link?.reason === 'string' ? link.reason : 'from prep blocker',
+          addedAt: typeof link?.addedAt === 'string' ? link.addedAt : '',
+        }))
+        .filter((link: BlockerSuggestionResolutionLink) => link.suggestionId && link.name)
+    : [];
 
   return {
     scheduledAt: typeof session?.scheduledAt === 'string' ? session.scheduledAt : '',
@@ -127,6 +146,7 @@ const normalizePrepSession = (session: any): PrepSessionState => {
     tasks: normalizedTasks,
     blockers: normalizedBlockers,
     blockerNote: typeof session?.blockerNote === 'string' ? session.blockerNote : '',
+    blockerSuggestionLinks: normalizedSuggestionLinks,
     carryoverTaskIds: normalizedCarryoverIds,
     completedAt: typeof session?.completedAt === 'string' ? session.completedAt : null,
   };
@@ -717,6 +737,31 @@ const NutritionMealPlanner = () => {
 
       toast({
         description: `✅ Added "${suggestion.name}" from prep blocker suggestions.`,
+      });
+      setPrepSession((prev) => {
+        const normalizedName = suggestion.name.trim().toLowerCase();
+        const alreadyTracked = prev.blockerSuggestionLinks.some((link) => (
+          link.suggestionId === suggestion.id
+          || link.name.trim().toLowerCase() === normalizedName
+        ));
+
+        if (alreadyTracked) {
+          return prev;
+        }
+
+        return {
+          ...prev,
+          blockerSuggestionLinks: [
+            ...prev.blockerSuggestionLinks,
+            {
+              suggestionId: suggestion.id,
+              name: suggestion.name,
+              category: suggestion.category,
+              reason: suggestion.reason,
+              addedAt: formatLocalDate(new Date()),
+            },
+          ],
+        };
       });
       await fetchGroceryList();
     } catch (error) {
@@ -1520,6 +1565,59 @@ const NutritionMealPlanner = () => {
         };
       });
   }, [groceryList, prepGroceryBlockersCount, prepSession.blockerNote, prepSession.blockers]);
+  const blockerSuggestionResolution = useMemo(() => {
+    const trackedByName = new Map<string, BlockerSuggestionResolutionLink>();
+    prepSession.blockerSuggestionLinks.forEach((link) => {
+      const normalized = link.name.trim().toLowerCase();
+      if (!normalized || trackedByName.has(normalized)) {
+        return;
+      }
+      trackedByName.set(normalized, link);
+    });
+
+    if (trackedByName.size === 0) {
+      return {
+        tracked: [] as Array<BlockerSuggestionResolutionLink & { resolved: boolean }>,
+        trackedCount: 0,
+        resolvedCount: 0,
+        unresolvedNames: [] as string[],
+      };
+    }
+
+    const groceryNameStatus = new Map<string, boolean>();
+    groceryList.forEach((item: any) => {
+      if (item?.isPantryItem) {
+        return;
+      }
+      const normalized = String(item?.name || item?.item || '').trim().toLowerCase();
+      if (!normalized) {
+        return;
+      }
+      const existing = groceryNameStatus.get(normalized) || false;
+      groceryNameStatus.set(normalized, existing || Boolean(item?.checked));
+    });
+
+    const tracked = Array.from(trackedByName.entries()).map(([normalizedName, link]) => ({
+      ...link,
+      resolved: Boolean(groceryNameStatus.get(normalizedName)),
+    }));
+    const resolvedCount = tracked.filter((link) => link.resolved).length;
+    const unresolvedNames = tracked.filter((link) => !link.resolved).map((link) => link.name);
+
+    return {
+      tracked,
+      trackedCount: tracked.length,
+      resolvedCount,
+      unresolvedNames,
+    };
+  }, [groceryList, prepSession.blockerSuggestionLinks]);
+  const blockerSuggestionConfidenceLabel = blockerSuggestionResolution.trackedCount === 0
+    ? 'Not started'
+    : blockerSuggestionResolution.resolvedCount === blockerSuggestionResolution.trackedCount
+      ? 'High'
+      : blockerSuggestionResolution.resolvedCount > 0
+        ? 'Medium'
+        : 'Low';
   const prepCarryoverCount = prepSession.carryoverTaskIds.filter((taskId) => prepSession.tasks.some((task) => task.id === taskId && !task.done)).length;
   const prepExecutionState = !prepSessionPlanned
     ? 'not_planned'
@@ -1894,6 +1992,8 @@ const NutritionMealPlanner = () => {
                 prepExecutionState={prepExecutionState}
                 prepActiveBlockersCount={prepActiveBlockersCount}
                 prepGroceryBlockersCount={prepGroceryBlockersCount}
+                blockerSuggestionResolvedCount={blockerSuggestionResolution.resolvedCount}
+                blockerSuggestionTrackedCount={blockerSuggestionResolution.trackedCount}
                 prepCarryoverCount={prepCarryoverCount}
                 weekReadyNow={weekReadyNow}
                 onGoToPlanner={() => setActiveTab('planner')}
@@ -2210,6 +2310,8 @@ const NutritionMealPlanner = () => {
                 prepExecutionState={prepExecutionState}
                 prepActiveBlockersCount={prepActiveBlockersCount}
                 prepGroceryBlockersCount={prepGroceryBlockersCount}
+                blockerSuggestionResolvedCount={blockerSuggestionResolution.resolvedCount}
+                blockerSuggestionTrackedCount={blockerSuggestionResolution.trackedCount}
                 prepCarryoverCount={prepCarryoverCount}
                 weekReadyNow={weekReadyNow}
                 onGoToPlanner={() => setActiveTab('planner')}
@@ -2237,6 +2339,9 @@ const NutritionMealPlanner = () => {
                 onResolvePrepGroceryBlockers={resolvePrepGroceryBlockers}
                 blockerItemSuggestions={blockerItemSuggestions}
                 onAddBlockerSuggestion={addBlockerSuggestionToGrocery}
+                blockerSuggestionResolvedCount={blockerSuggestionResolution.resolvedCount}
+                blockerSuggestionTrackedCount={blockerSuggestionResolution.trackedCount}
+                unresolvedBlockerSuggestionNames={blockerSuggestionResolution.unresolvedNames}
               />
             </div>
           </TabsContent>
@@ -2258,6 +2363,8 @@ const NutritionMealPlanner = () => {
                 prepExecutionState={prepExecutionState}
                 prepActiveBlockersCount={prepActiveBlockersCount}
                 prepGroceryBlockersCount={prepGroceryBlockersCount}
+                blockerSuggestionResolvedCount={blockerSuggestionResolution.resolvedCount}
+                blockerSuggestionTrackedCount={blockerSuggestionResolution.trackedCount}
                 prepCarryoverCount={prepCarryoverCount}
                 weekReadyNow={weekReadyNow}
                 onGoToPlanner={() => setActiveTab('planner')}
@@ -2284,6 +2391,10 @@ const NutritionMealPlanner = () => {
                 blockerItemSuggestions={blockerItemSuggestions}
                 onAddBlockerSuggestion={addBlockerSuggestionToGrocery}
                 onGoToGrocery={() => setActiveTab('grocery')}
+                blockerSuggestionResolvedCount={blockerSuggestionResolution.resolvedCount}
+                blockerSuggestionTrackedCount={blockerSuggestionResolution.trackedCount}
+                unresolvedBlockerSuggestionNames={blockerSuggestionResolution.unresolvedNames}
+                blockerSuggestionConfidenceLabel={blockerSuggestionConfidenceLabel}
               />
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                 <Card>

--- a/client/src/components/meal-planner/WeeklyReadinessChecklist.tsx
+++ b/client/src/components/meal-planner/WeeklyReadinessChecklist.tsx
@@ -21,6 +21,8 @@ type WeeklyReadinessChecklistProps = {
   prepExecutionState: PrepExecutionState;
   prepActiveBlockersCount: number;
   prepGroceryBlockersCount: number;
+  blockerSuggestionResolvedCount: number;
+  blockerSuggestionTrackedCount: number;
   prepCarryoverCount: number;
   weekReadyNow: boolean;
   onGoToPlanner: () => void;
@@ -67,6 +69,8 @@ const WeeklyReadinessChecklist = ({
   prepExecutionState,
   prepActiveBlockersCount,
   prepGroceryBlockersCount,
+  blockerSuggestionResolvedCount,
+  blockerSuggestionTrackedCount,
   prepCarryoverCount,
   weekReadyNow,
   onGoToPlanner,
@@ -138,6 +142,11 @@ const WeeklyReadinessChecklist = ({
                 {prepGroceryBlockersCount === 1
                   ? '1 prep blocker can be resolved from this grocery flow.'
                   : `${prepGroceryBlockersCount} prep blockers can be resolved from this grocery flow.`}
+              </p>
+            )}
+            {blockerSuggestionTrackedCount > 0 && (
+              <p className="text-xs text-emerald-700 mt-2">
+                {blockerSuggestionResolvedCount}/{blockerSuggestionTrackedCount} blocker suggestions resolved.
               </p>
             )}
             {(groceryPendingCount > 0 || !groceryListCreated) && (

--- a/client/src/components/meal-planner/sections/GroceryTabSection.tsx
+++ b/client/src/components/meal-planner/sections/GroceryTabSection.tsx
@@ -38,6 +38,9 @@ type GroceryTabSectionProps = {
     reason: string;
     alreadyOnList: boolean;
   }) => void;
+  blockerSuggestionResolvedCount: number;
+  blockerSuggestionTrackedCount: number;
+  unresolvedBlockerSuggestionNames: string[];
 };
 
 const GroceryTabSection = ({
@@ -61,6 +64,9 @@ const GroceryTabSection = ({
   canResolvePrepGroceryBlockers,
   blockerItemSuggestions,
   onAddBlockerSuggestion,
+  blockerSuggestionResolvedCount,
+  blockerSuggestionTrackedCount,
+  unresolvedBlockerSuggestionNames,
 }: GroceryTabSectionProps) => {
   const buyItems = groceryList.filter((i: any) => !i.isPantryItem);
   const checkedBuyItems = buyItems.filter((i: any) => i.checked).length;
@@ -122,6 +128,24 @@ const GroceryTabSection = ({
                   Mark Grocery Blockers Resolved
                 </Button>
               </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {blockerSuggestionTrackedCount > 0 && (
+          <Card className="border-emerald-200 bg-emerald-50/50">
+            <CardContent className="p-4 space-y-2">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs uppercase tracking-wide text-emerald-700 font-semibold">Suggestion resolution</p>
+                <Badge variant="outline" className="border-emerald-200 text-emerald-700">
+                  {blockerSuggestionResolvedCount}/{blockerSuggestionTrackedCount} resolved
+                </Badge>
+              </div>
+              <p className="text-sm text-emerald-900">
+                {unresolvedBlockerSuggestionNames.length > 0
+                  ? `Pending blocker-linked items: ${unresolvedBlockerSuggestionNames.join(', ')}.`
+                  : 'All blocker-linked suggestion items are checked off.'}
+              </p>
             </CardContent>
           </Card>
         )}

--- a/client/src/components/meal-planner/sections/PrepTabSection.tsx
+++ b/client/src/components/meal-planner/sections/PrepTabSection.tsx
@@ -24,6 +24,13 @@ export type PrepSessionState = {
   tasks: PrepTask[];
   blockers: PrepBlocker[];
   blockerNote: string;
+  blockerSuggestionLinks: Array<{
+    suggestionId: string;
+    name: string;
+    category: string;
+    reason: string;
+    addedAt: string;
+  }>;
   carryoverTaskIds: string[];
   completedAt: string | null;
 };
@@ -60,6 +67,10 @@ type PrepTabSectionProps = {
     alreadyOnList: boolean;
   }) => void;
   onGoToGrocery: () => void;
+  blockerSuggestionResolvedCount: number;
+  blockerSuggestionTrackedCount: number;
+  unresolvedBlockerSuggestionNames: string[];
+  blockerSuggestionConfidenceLabel: 'Not started' | 'Low' | 'Medium' | 'High';
 };
 
 const PrepTabSection = ({
@@ -82,6 +93,10 @@ const PrepTabSection = ({
   blockerItemSuggestions,
   onAddBlockerSuggestion,
   onGoToGrocery,
+  blockerSuggestionResolvedCount,
+  blockerSuggestionTrackedCount,
+  unresolvedBlockerSuggestionNames,
+  blockerSuggestionConfidenceLabel,
 }: PrepTabSectionProps) => {
   const activeBlockers = prepSession.blockers.filter((blocker) => blocker.active);
   const unfinishedTasks = prepSession.tasks.filter((task) => !task.done);
@@ -206,6 +221,30 @@ const PrepTabSection = ({
               <p className="text-[11px] text-indigo-700">
                 Quick-add items now, then finish shopping to unblock prep.
               </p>
+            </div>
+          )}
+          {blockerSuggestionTrackedCount > 0 && (
+            <div className="rounded-md border border-emerald-200 bg-emerald-50/70 p-3 space-y-2">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs font-medium text-emerald-900">
+                  Suggestion resolution tracker
+                </p>
+                <Badge variant="outline" className="border-emerald-200 text-emerald-700">
+                  {blockerSuggestionResolvedCount}/{blockerSuggestionTrackedCount} resolved
+                </Badge>
+              </div>
+              <p className="text-[11px] text-emerald-700">
+                Blocker confidence: {blockerSuggestionConfidenceLabel}
+              </p>
+              {unresolvedBlockerSuggestionNames.length > 0 ? (
+                <p className="text-[11px] text-emerald-800">
+                  Still pending: {unresolvedBlockerSuggestionNames.join(', ')}.
+                </p>
+              ) : (
+                <p className="text-[11px] text-emerald-800">
+                  All tracked blocker suggestions are completed in Grocery.
+                </p>
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
### Motivation
- Close the gap between prep blockers quick-adds and actual grocery completion by tracking which suggested items were added and whether they're completed so readiness/confidence can improve without changing APIs or workflows.

### Description
- Persist lightweight suggestion links on the weekly prep session via a new `blockerSuggestionLinks` field (compatibility-safe normalization) and record a link whenever a blocker suggestion is successfully quick-added to Grocery.
- Compute derived resolution state in `NutritionMealPlanner` (`trackedCount`, `resolvedCount`, `unresolvedNames`, and a simple confidence label) by matching tracked suggestion names against non-pantry grocery items and their checked state.
- Surface the tracker in UI surfaces by wiring new props through the orchestrator: the Weekly Readiness Checklist now shows `X/Y blocker suggestions resolved`, Grocery shows a “Suggestion resolution” card with unresolved names, and Prep shows a “Suggestion resolution tracker” block with progress and a blocker confidence label.
- Files changed: `client/src/components/NutritionMealPlanner.tsx`, `client/src/components/meal-planner/WeeklyReadinessChecklist.tsx`, `client/src/components/meal-planner/sections/GroceryTabSection.tsx`, `client/src/components/meal-planner/sections/PrepTabSection.tsx`.

### Testing
- Ran production builds: `npm run build`, `npm run build:client`, and `npm run build:server`; all completed successfully (no build errors).
- The change is additive and local (no API contract changes), and the new state is normalized so existing stored sessions remain compatible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4107947f88325b2926b509aced400)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
