### PR TITLE
Add backend-compatible weekly share metadata + public link foundation

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -163,6 +163,7 @@ type BlockerItemSuggestion = {
 };
 
 type MealPlanVisibility = 'private' | 'friends' | 'public';
+type ShareMetadataSaveState = 'idle' | 'saving' | 'saved' | 'error';
 
 const NutritionMealPlanner = () => {
   const { user, updateUser } = useUser();
@@ -201,6 +202,9 @@ const NutritionMealPlanner = () => {
   const [calcResult, setCalcResult] = useState<any>(null);
   const [prepSession, setPrepSession] = useState<PrepSessionState>(() => createDefaultPrepSession());
   const [shareVisibility, setShareVisibility] = useState<MealPlanVisibility>('private');
+  const [sharePublicToken, setSharePublicToken] = useState<string | null>(null);
+  const [shareMetadataLoaded, setShareMetadataLoaded] = useState(false);
+  const [shareMetadataSaveState, setShareMetadataSaveState] = useState<ShareMetadataSaveState>('idle');
 
   // Add Meal modal — controlled fields
   const [mealForm, setMealForm] = useState(INITIAL_MEAL_FORM);
@@ -264,18 +268,49 @@ const NutritionMealPlanner = () => {
   }, [prepSession, user?.id, selectedDate]);
 
   useEffect(() => {
-    try {
-      const stored = localStorage.getItem(getShareVisibilityStorageKey());
-      if (stored === 'private' || stored === 'friends' || stored === 'public') {
-        setShareVisibility(stored);
-      } else {
-        setShareVisibility('private');
+    const loadShareMetadata = async () => {
+      setShareMetadataLoaded(false);
+      try {
+        const response = await fetch(`/api/meal-planner/week/share-metadata?date=${getCurrentWeekAnchor()}`, {
+          credentials: 'include',
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+
+        const data = await response.json();
+        const visibility = data?.visibility;
+        if (visibility === 'private' || visibility === 'friends' || visibility === 'public') {
+          setShareVisibility(visibility);
+        } else {
+          setShareVisibility('private');
+        }
+        setSharePublicToken(typeof data?.publicShareToken === 'string' ? data.publicShareToken : null);
+        setShareMetadataSaveState('saved');
+        setShareMetadataLoaded(true);
+        return;
+      } catch (error) {
+        console.error('Error loading meal plan share metadata from backend, falling back to local:', error);
       }
-    } catch (error) {
-      console.error('Error loading meal plan share visibility:', error);
-      setShareVisibility('private');
-    }
-  }, [user?.id]);
+
+      try {
+        const stored = localStorage.getItem(getShareVisibilityStorageKey());
+        if (stored === 'private' || stored === 'friends' || stored === 'public') {
+          setShareVisibility(stored);
+        } else {
+          setShareVisibility('private');
+        }
+      } catch (error) {
+        console.error('Error loading meal plan share visibility:', error);
+        setShareVisibility('private');
+      } finally {
+        setSharePublicToken(null);
+        setShareMetadataLoaded(true);
+      }
+    };
+
+    loadShareMetadata();
+  }, [user?.id, selectedDate]);
 
   useEffect(() => {
     try {
@@ -284,6 +319,68 @@ const NutritionMealPlanner = () => {
       console.error('Error saving meal plan share visibility:', error);
     }
   }, [shareVisibility, user?.id]);
+
+  useEffect(() => {
+    if (!shareMetadataLoaded) return;
+    if (!user?.id) return;
+
+    let cancelled = false;
+    const persistShareMetadata = async () => {
+      setShareMetadataSaveState('saving');
+      try {
+        const summaryFingerprint = [
+          getCurrentWeekAnchor(),
+          shareVisibility,
+          Object.keys(weeklyMeals || {}).length,
+          groceryList.length,
+          prepSession.tasks.filter((task) => task.done).length,
+          prepSession.blockers.filter((blocker) => blocker.active).length,
+        ].join('|');
+
+        const response = await fetch('/api/meal-planner/week/share-metadata', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            date: getCurrentWeekAnchor(),
+            visibility: shareVisibility,
+            summaryFingerprint,
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+
+        const data = await response.json();
+        if (!cancelled) {
+          const token = typeof data?.publicShareToken === 'string' ? data.publicShareToken : null;
+          setSharePublicToken(token);
+          setShareMetadataSaveState('saved');
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.error('Error saving meal plan share metadata to backend:', error);
+          setShareMetadataSaveState('error');
+        }
+      }
+    };
+
+    persistShareMetadata();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    shareMetadataLoaded,
+    shareVisibility,
+    user?.id,
+    selectedDate,
+    weeklyMeals,
+    groceryList,
+    prepSession.tasks,
+    prepSession.blockers,
+  ]);
 
   const fetchSavingsReport = async () => {
     try {
@@ -1806,6 +1903,10 @@ const NutritionMealPlanner = () => {
   const weekLabel = weekRange?.weekStart && weekRange?.weekEnd
     ? `${weekRange.weekStart} to ${weekRange.weekEnd}`
     : `${getCurrentWeekAnchor()} week`;
+  const origin = typeof window !== 'undefined' ? window.location.origin : '';
+  const publicShareUrl = sharePublicToken
+    ? `${origin}/meal-planner/shared/${sharePublicToken}`
+    : '';
   const weeklyShareSummaryText = useMemo(() => {
     const lines = [
       `Chefsire Meal Plan • Week of ${weekLabel}`,
@@ -1909,6 +2010,29 @@ const NutritionMealPlanner = () => {
         console.error('Error sharing weekly summary:', error);
         await copyWeeklyShareSummary();
       }
+    }
+  };
+
+  const copyWeeklyPublicShareLink = async () => {
+    if (!publicShareUrl) {
+      toast({
+        variant: 'destructive',
+        description: 'Public share link is still preparing. Try again in a moment.',
+      });
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(publicShareUrl);
+      toast({
+        description: '✅ Public weekly share link copied to clipboard.',
+      });
+    } catch (error) {
+      console.error('Error copying weekly public share link:', error);
+      toast({
+        variant: 'destructive',
+        description: 'Unable to copy the public share link right now.',
+      });
     }
   };
 
@@ -2227,7 +2351,13 @@ const NutritionMealPlanner = () => {
                       })}
                     </div>
                     <p className="text-xs text-gray-500 mt-2">
-                      Visibility preference is currently saved locally for this account on this device.
+                      {shareMetadataSaveState === 'saving'
+                        ? 'Saving visibility to your account...'
+                        : shareMetadataSaveState === 'saved'
+                          ? 'Visibility preference saved to your account with local fallback.'
+                          : shareMetadataSaveState === 'error'
+                            ? 'Could not reach backend; using local fallback on this device.'
+                            : 'Visibility preference is currently saved locally for this account on this device.'}
                     </p>
                   </div>
 
@@ -2250,7 +2380,18 @@ const NutritionMealPlanner = () => {
                       <Share2 className="w-4 h-4 mr-2" />
                       Share / Export
                     </Button>
+                    {shareVisibility === 'public' && (
+                      <Button variant="outline" onClick={copyWeeklyPublicShareLink} disabled={!publicShareUrl}>
+                        <Globe className="w-4 h-4 mr-2" />
+                        Copy Public Link
+                      </Button>
+                    )}
                   </div>
+                  {shareVisibility === 'public' && (
+                    <p className="text-xs text-gray-500">
+                      Public link foundation: {publicShareUrl || 'generating secure link token...'}
+                    </p>
+                  )}
                 </CardContent>
               </Card>
             </div>

--- a/server/routes/meal-planner-week.ts
+++ b/server/routes/meal-planner-week.ts
@@ -1,4 +1,5 @@
 import express, { type NextFunction, type Request, type Response } from "express";
+import { randomUUID } from "crypto";
 import { and, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
 import { db } from "../db/index.js";
 import {
@@ -26,6 +27,7 @@ import {
 } from "./meal-planner-week/utils.js";
 
 const router = express.Router();
+const MEAL_SHARE_VISIBILITY = ["private", "friends", "public"] as const;
 
 router.use(async (_req: Request, res: Response, next: NextFunction) => {
   try {
@@ -183,6 +185,114 @@ router.get("/week", requireAuth, async (req: Request, res: Response) => {
   } catch (error) {
     console.error("Error fetching week plan:", error);
     res.status(500).json({ message: "Failed to load week plan" });
+  }
+});
+
+// ============================================================
+// GET /api/meal-planner/week/share-metadata?date=YYYY-MM-DD
+// Lightweight persistence layer for weekly sharing foundation.
+// ============================================================
+router.get("/week/share-metadata", requireAuth, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.id;
+    const rawDate = String(req.query.date || "");
+    const parsed = rawDate ? new Date(rawDate) : new Date();
+    if (isNaN(parsed.getTime())) {
+      return res.status(400).json({ message: "Invalid date" });
+    }
+
+    const weekAnchor = fmtISODate(startOfWeekMonday(parsed));
+    const result = await db.execute(sql`
+      SELECT visibility, summary_fingerprint, public_share_token, updated_at
+      FROM meal_plan_week_shares
+      WHERE user_id = ${userId} AND week_anchor = ${weekAnchor}::date
+      LIMIT 1
+    `);
+    const row = (result as any).rows?.[0];
+
+    res.json({
+      weekAnchor,
+      visibility: row?.visibility || "private",
+      summaryFingerprint: row?.summary_fingerprint || null,
+      publicShareToken: row?.public_share_token || null,
+      updatedAt: row?.updated_at || null,
+    });
+  } catch (error) {
+    console.error("Error loading weekly share metadata:", error);
+    res.status(500).json({ message: "Failed to load weekly share metadata" });
+  }
+});
+
+// ============================================================
+// POST /api/meal-planner/week/share-metadata
+// Persist visibility + summary fingerprint, and generate token for public links.
+// ============================================================
+router.post("/week/share-metadata", requireAuth, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.id;
+    const rawDate = String(req.body?.date || "");
+    const parsed = rawDate ? new Date(rawDate) : new Date();
+    if (isNaN(parsed.getTime())) {
+      return res.status(400).json({ message: "Invalid date" });
+    }
+
+    const visibility = String(req.body?.visibility || "private").toLowerCase();
+    if (!MEAL_SHARE_VISIBILITY.includes(visibility as (typeof MEAL_SHARE_VISIBILITY)[number])) {
+      return res.status(400).json({ message: "Invalid visibility value" });
+    }
+
+    const summaryFingerprintRaw = String(req.body?.summaryFingerprint || "").trim();
+    const summaryFingerprint = summaryFingerprintRaw ? summaryFingerprintRaw.slice(0, 200) : null;
+    const weekAnchor = fmtISODate(startOfWeekMonday(parsed));
+
+    const existingResult = await db.execute(sql`
+      SELECT public_share_token
+      FROM meal_plan_week_shares
+      WHERE user_id = ${userId} AND week_anchor = ${weekAnchor}::date
+      LIMIT 1
+    `);
+    const existing = (existingResult as any).rows?.[0];
+    const token =
+      visibility === "public"
+        ? existing?.public_share_token || `mws_${randomUUID().replace(/-/g, "").slice(0, 20)}`
+        : existing?.public_share_token || null;
+
+    await db.execute(sql`
+      INSERT INTO meal_plan_week_shares (
+        user_id,
+        week_anchor,
+        visibility,
+        summary_fingerprint,
+        public_share_token,
+        created_at,
+        updated_at
+      ) VALUES (
+        ${userId},
+        ${weekAnchor}::date,
+        ${visibility},
+        ${summaryFingerprint},
+        ${token},
+        NOW(),
+        NOW()
+      )
+      ON CONFLICT (user_id, week_anchor)
+      DO UPDATE SET
+        visibility = EXCLUDED.visibility,
+        summary_fingerprint = EXCLUDED.summary_fingerprint,
+        public_share_token = EXCLUDED.public_share_token,
+        updated_at = NOW()
+    `);
+
+    res.json({
+      ok: true,
+      weekAnchor,
+      visibility,
+      summaryFingerprint,
+      publicShareToken: token,
+    });
+  } catch (error) {
+    console.error("Error saving weekly share metadata:", error);
+    res.status(500).json({ message: "Failed to save weekly share metadata" });
   }
 });
 

--- a/server/routes/meal-planner-week/schema.ts
+++ b/server/routes/meal-planner-week/schema.ts
@@ -11,6 +11,21 @@ export async function ensureMealPlannerWeekSchema() {
     await db.execute(sql`ALTER TABLE meal_plan_entries ADD COLUMN IF NOT EXISTS custom_carbs INTEGER;`);
     await db.execute(sql`ALTER TABLE meal_plan_entries ADD COLUMN IF NOT EXISTS custom_fat INTEGER;`);
     await db.execute(sql`ALTER TABLE meal_plan_entries ADD COLUMN IF NOT EXISTS source VARCHAR(50);`);
+    await db.execute(sql`
+      CREATE TABLE IF NOT EXISTS meal_plan_week_shares (
+        id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id VARCHAR NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        week_anchor DATE NOT NULL,
+        visibility VARCHAR(20) NOT NULL DEFAULT 'private',
+        summary_fingerprint VARCHAR(200),
+        public_share_token VARCHAR(80),
+        created_at TIMESTAMP DEFAULT NOW(),
+        updated_at TIMESTAMP DEFAULT NOW(),
+        UNIQUE(user_id, week_anchor),
+        UNIQUE(public_share_token)
+      );
+    `);
+    await db.execute(sql`CREATE INDEX IF NOT EXISTS idx_meal_plan_week_shares_user_week ON meal_plan_week_shares(user_id, week_anchor);`);
   })();
 
   return mealPlannerWeekSchemaReady;


### PR DESCRIPTION
### Motivation

- Move the existing local-only “Share This Week” UI state to a lightweight, backend-compatible metadata layer so sharing preferences are account-scoped and ready for future friend/public discovery without building a feed now.
- Keep changes strictly additive and non-disruptive: preserve current behavior with a localStorage fallback and avoid redesigning the meal planner surface.

### Description

- Added a compact DB bootstrap inside `ensureMealPlannerWeekSchema` to create `meal_plan_week_shares` (columns: `user_id`, `week_anchor`, `visibility`, optional `summary_fingerprint`, optional `public_share_token`, timestamps, and indexes) to safely enable metadata persistence. (`server/routes/meal-planner-week/schema.ts`)
- Added two authenticated endpoints to the week router: `GET /api/meal-planner/week/share-metadata?date=YYYY-MM-DD` to load metadata and `POST /api/meal-planner/week/share-metadata` to upsert metadata and provision a stable `public_share_token` when visibility is `public`. Token generation is stable-per-week-per-user and upserted, enabling safe future public links without a feed. (`server/routes/meal-planner-week.ts`)
- Updated the meal planner orchestrator `NutritionMealPlanner` to be backend-first with local fallback by: loading persisted share metadata for the current week, POSTing lightweight `summaryFingerprint` + `visibility` when available, preserving existing localStorage save behavior if the backend is unreachable, displaying save-state messaging, and surfacing a `Copy Public Link` action that uses the persisted token to build `/meal-planner/shared/:token`. (`client/src/components/NutritionMealPlanner.tsx`)
- Files changed: `server/routes/meal-planner-week/schema.ts`, `server/routes/meal-planner-week.ts`, and `client/src/components/NutritionMealPlanner.tsx`.

### Testing

- Built the project to validate integration and types with: `npm run build`. This completed successfully.
- Built client separately with `npm run build:client`. This completed successfully.
- Built server separately with `npm run build:server`. This completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e55c9009e48325822b9e766b2f6537)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
