### PR TITLE
Add lightweight public meal-plan inspiration browse page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -45,6 +45,7 @@ const CreatorAnalytics = React.lazy(() => import("@/pages/nutrition/CreatorAnaly
 const MealPlanDetailsPage = React.lazy(() => import("@/pages/nutrition/MealPlanDetailsPage"));
 const MyPurchasesPage = React.lazy(() => import("@/pages/nutrition/MyPurchasesPage"));
 const MealPlannerSharedWeekPage = React.lazy(() => import("@/pages/nutrition/MealPlannerSharedWeekPage"));
+const MealPlannerSharedBrowsePage = React.lazy(() => import("@/pages/nutrition/MealPlannerSharedBrowsePage"));
 const AnalyticsPage = React.lazy(() => import("@/pages/analytics/AnalyticsPage"));
 const CateringMarketplace = React.lazy(() => import("@/pages/services/catering"));
 const WeddingPlanning = React.lazy(() => import("@/pages/services/wedding-planning"));
@@ -259,6 +260,7 @@ export default function App() {
                 {/* =========================================================
                     Meal Planner aliases (✅ fixes 404 for meal-planner + subs)
                    ========================================================= */}
+                <Route path="/meal-planner/shared" component={MealPlannerSharedBrowsePage} />
                 <Route path="/meal-planner/shared/:token" component={MealPlannerSharedWeekPage} />
                 <Route path="/meal-planner">
                   <Redirect to="/nutrition" />

--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -2386,6 +2386,10 @@ const NutritionMealPlanner = () => {
                         Copy Public Link
                       </Button>
                     )}
+                    <Button variant="outline" onClick={() => window.location.assign('/meal-planner/shared')}>
+                      <Sparkles className="w-4 h-4 mr-2" />
+                      Browse Public Week Ideas
+                    </Button>
                   </div>
                   {shareVisibility === 'public' && (
                     <p className="text-xs text-gray-500">

--- a/client/src/pages/nutrition/MealPlannerSharedBrowsePage.tsx
+++ b/client/src/pages/nutrition/MealPlannerSharedBrowsePage.tsx
@@ -1,0 +1,183 @@
+import React, { useEffect, useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import { Button } from '@/components/ui/button';
+import { CalendarDays, ShoppingCart, ShieldCheck, Activity, Globe, ArrowRight } from 'lucide-react';
+
+type SharedBrowseItem = {
+  token: string;
+  weekAnchor: string;
+  weekStart: string;
+  weekEnd: string;
+  sharedAt: string | null;
+  sharer: {
+    displayName: string | null;
+    username: string | null;
+  };
+  readiness: {
+    status: string;
+    plannedSlots: number;
+    totalSlots: number;
+    plannedCoveragePct: number;
+  };
+  grocery: {
+    totalItems: number;
+    purchasedItems: number;
+    completionPct: number;
+  };
+  nutritionHighlights: {
+    plannedMealsCount: number;
+    totalCalories: number;
+    totalProtein: number;
+    avgCaloriesPerPlannedDay: number;
+    avgProteinPerPlannedDay: number;
+  };
+};
+
+export default function MealPlannerSharedBrowsePage() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [items, setItems] = useState<SharedBrowseItem[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch('/api/meal-planner/week/shared');
+        if (!response.ok) {
+          throw new Error(`Failed to load public shared weeks (HTTP ${response.status}).`);
+        }
+
+        const payload = await response.json();
+        if (!cancelled) {
+          setItems(Array.isArray(payload?.items) ? payload.items : []);
+        }
+      } catch (loadError: any) {
+        if (!cancelled) {
+          setError(loadError?.message || 'Unable to load public shared weeks.');
+          setItems([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return <div className="p-6 text-sm text-muted-foreground">Loading public shared meal-planner weeks…</div>;
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 p-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-xl">
+            <Globe className="h-5 w-5" />
+            Public Meal Plan Inspiration
+          </CardTitle>
+          <CardDescription>
+            Browse recently shared public weekly plans for meal-planning and nutrition ideas.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-2">
+          <Badge variant="secondary">Read-only public snapshots</Badge>
+          <Badge variant="outline">Recent public shares</Badge>
+        </CardContent>
+      </Card>
+
+      {error && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Unable to load public shares</CardTitle>
+            <CardDescription>{error}</CardDescription>
+          </CardHeader>
+        </Card>
+      )}
+
+      {!error && items.length === 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>No public shared weeks yet</CardTitle>
+            <CardDescription>
+              Once users set a week to public, it will appear here for discovery.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {items.map((item) => {
+          const byline = item.sharer.displayName
+            ? `Shared by ${item.sharer.displayName}`
+            : item.sharer.username
+              ? `Shared by @${item.sharer.username}`
+              : 'Shared by Chefsire member';
+
+          return (
+            <Card key={item.token}>
+              <CardHeader className="space-y-1">
+                <CardTitle className="text-base">Week of {item.weekStart} to {item.weekEnd}</CardTitle>
+                <CardDescription>{byline}</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4 text-sm">
+                <div className="grid gap-3">
+                  <div>
+                    <div className="mb-1 flex items-center gap-2 font-medium">
+                      <ShieldCheck className="h-4 w-4" /> Readiness
+                    </div>
+                    <div className="text-muted-foreground">
+                      {item.readiness.plannedSlots}/{item.readiness.totalSlots} slots planned • {item.readiness.status}
+                    </div>
+                    <Progress value={item.readiness.plannedCoveragePct} className="mt-2" />
+                  </div>
+
+                  <div>
+                    <div className="mb-1 flex items-center gap-2 font-medium">
+                      <ShoppingCart className="h-4 w-4" /> Grocery
+                    </div>
+                    <div className="text-muted-foreground">
+                      {item.grocery.purchasedItems}/{item.grocery.totalItems} purchased • {item.grocery.completionPct}% complete
+                    </div>
+                  </div>
+
+                  <div>
+                    <div className="mb-1 flex items-center gap-2 font-medium">
+                      <Activity className="h-4 w-4" /> Nutrition highlights
+                    </div>
+                    <div className="text-muted-foreground">
+                      {item.nutritionHighlights.plannedMealsCount} planned meals • Avg/day {item.nutritionHighlights.avgCaloriesPerPlannedDay} kcal • {item.nutritionHighlights.avgProteinPerPlannedDay}g protein
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex items-center justify-between border-t pt-3">
+                  <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                    <CalendarDays className="h-3.5 w-3.5" />
+                    {item.sharedAt ? `Updated ${new Date(item.sharedAt).toLocaleDateString()}` : 'Recently shared'}
+                  </div>
+                  <Button asChild size="sm" variant="outline">
+                    <a href={`/meal-planner/shared/${item.token}`}>
+                      View week <ArrowRight className="ml-2 h-4 w-4" />
+                    </a>
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx
+++ b/client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx
@@ -3,6 +3,7 @@ import { useRoute } from 'wouter';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
+import { Button } from '@/components/ui/button';
 import { CalendarDays, ShoppingCart, ShieldCheck, Utensils, Activity } from 'lucide-react';
 
 type SharedMeal = {
@@ -139,6 +140,9 @@ export default function MealPlannerSharedWeekPage() {
         <CardContent className="flex flex-wrap gap-2">
           <Badge variant="secondary">Read-only public view</Badge>
           <Badge variant="outline">Token shared</Badge>
+          <Button asChild size="sm" variant="outline" className="ml-auto">
+            <a href="/meal-planner/shared">Browse more public weeks</a>
+          </Button>
         </CardContent>
       </Card>
 

--- a/server/routes/meal-planner-week.ts
+++ b/server/routes/meal-planner-week.ts
@@ -29,6 +29,8 @@ import {
 const router = express.Router();
 const MEAL_SHARE_VISIBILITY = ["private", "friends", "public"] as const;
 const SHARED_WEEK_TOKEN_PATTERN = /^[a-zA-Z0-9_-]{8,80}$/;
+const PUBLIC_SHARED_WEEKS_LIMIT_DEFAULT = 20;
+const PUBLIC_SHARED_WEEKS_LIMIT_MAX = 50;
 
 router.use(async (_req: Request, res: Response, next: NextFunction) => {
   try {
@@ -68,6 +70,113 @@ async function buildRecipePool(args: {
     .limit(150);
 
   return rows.filter((r) => !excludeRecipeIds.has(r.id));
+}
+
+type PublicWeekSummary = {
+  weekAnchor: string;
+  weekStart: string;
+  weekEnd: string;
+  plannedSlots: number;
+  totalSlots: number;
+  plannedCoveragePct: number;
+  readinessStatus: "not-started" | "in-progress" | "week-ready";
+  groceryTotalItems: number;
+  groceryPurchasedItems: number;
+  groceryCompletionPct: number;
+  plannedMealsCount: number;
+  totalCalories: number;
+  totalProtein: number;
+  avgCaloriesPerPlannedDay: number;
+  avgProteinPerPlannedDay: number;
+};
+
+async function buildPublicWeekSummary(userId: string, weekAnchorRaw: Date | string): Promise<PublicWeekSummary> {
+  const weekStart = startOfWeekMonday(new Date(weekAnchorRaw));
+  const weekEnd = endOfDay(addDays(weekStart, 6));
+
+  const [plan] = await db
+    .select()
+    .from(mealPlans)
+    .where(
+      and(
+        eq(mealPlans.userId, userId),
+        lte(mealPlans.startDate, weekEnd),
+        gte(mealPlans.endDate, weekStart),
+        eq(mealPlans.isTemplate, false)
+      )
+    )
+    .orderBy(desc(mealPlans.createdAt))
+    .limit(1);
+
+  let entries: any[] = [];
+  let groceryItems: Array<{ purchased: boolean | null }> = [];
+
+  if (plan) {
+    entries = await db
+      .select({
+        id: mealPlanEntries.id,
+        recipeId: mealPlanEntries.recipeId,
+        date: mealPlanEntries.date,
+        mealType: mealPlanEntries.mealType,
+        servings: mealPlanEntries.servings,
+        customName: mealPlanEntries.customName,
+        customCalories: mealPlanEntries.customCalories,
+        customProtein: mealPlanEntries.customProtein,
+        customCarbs: mealPlanEntries.customCarbs,
+        customFat: mealPlanEntries.customFat,
+        source: mealPlanEntries.source,
+        recipe: recipes,
+      })
+      .from(mealPlanEntries)
+      .leftJoin(recipes, eq(mealPlanEntries.recipeId, recipes.id))
+      .where(eq(mealPlanEntries.mealPlanId, plan.id))
+      .orderBy(mealPlanEntries.date);
+
+    groceryItems = await db
+      .select({ purchased: groceryListItems.purchased })
+      .from(groceryListItems)
+      .where(and(eq(groceryListItems.userId, userId), eq(groceryListItems.mealPlanId, plan.id)));
+  }
+
+  const plannedSlots = entries.length;
+  const totalSlots = 28; // 7 days x 4 meal types
+  const plannedCoveragePct = Math.round((plannedSlots / Math.max(1, totalSlots)) * 100);
+  const readinessStatus: PublicWeekSummary["readinessStatus"] =
+    plannedSlots > 0 ? (plannedCoveragePct >= 70 ? "week-ready" : "in-progress") : "not-started";
+
+  const groceryTotalItems = groceryItems.length;
+  const groceryPurchasedItems = groceryItems.filter((item) => Boolean(item.purchased)).length;
+  const groceryCompletionPct = groceryTotalItems > 0
+    ? Math.round((groceryPurchasedItems / groceryTotalItems) * 100)
+    : 0;
+
+  const totalCalories = entries.reduce(
+    (sum, entry) => sum + Number(entry?.recipe?.calories || entry?.customCalories || 0),
+    0
+  );
+  const totalProtein = entries.reduce(
+    (sum, entry) => sum + Number(entry?.recipe?.protein || entry?.customProtein || 0),
+    0
+  );
+  const activePlannedDays = new Set(entries.map((entry) => fmtISODate(new Date(entry.date)))).size;
+
+  return {
+    weekAnchor: fmtISODate(weekStart),
+    weekStart: fmtISODate(weekStart),
+    weekEnd: fmtISODate(weekEnd),
+    plannedSlots,
+    totalSlots,
+    plannedCoveragePct,
+    readinessStatus,
+    groceryTotalItems,
+    groceryPurchasedItems,
+    groceryCompletionPct,
+    plannedMealsCount: plannedSlots,
+    totalCalories,
+    totalProtein,
+    avgCaloriesPerPlannedDay: activePlannedDays > 0 ? Math.round(totalCalories / activePlannedDays) : 0,
+    avgProteinPerPlannedDay: activePlannedDays > 0 ? Math.round(totalProtein / activePlannedDays) : 0,
+  };
 }
 
 // ============================================================
@@ -298,6 +407,74 @@ router.post("/week/share-metadata", requireAuth, async (req: Request, res: Respo
 });
 
 // ============================================================
+// GET /api/meal-planner/week/shared
+// Public browse surface: recent public shared weeks.
+// ============================================================
+router.get("/week/shared", async (req: Request, res: Response) => {
+  try {
+    const parsedLimit = Number(req.query.limit ?? PUBLIC_SHARED_WEEKS_LIMIT_DEFAULT);
+    const limit = Math.max(1, Math.min(PUBLIC_SHARED_WEEKS_LIMIT_MAX, Number.isFinite(parsedLimit) ? parsedLimit : PUBLIC_SHARED_WEEKS_LIMIT_DEFAULT));
+
+    const shareResult = await db.execute(sql`
+      SELECT s.user_id, s.week_anchor, s.public_share_token, s.updated_at, u.display_name, u.username
+      FROM meal_plan_week_shares s
+      LEFT JOIN users u ON u.id = s.user_id
+      WHERE s.visibility = 'public' AND s.public_share_token IS NOT NULL
+      ORDER BY s.updated_at DESC
+      LIMIT ${limit}
+    `);
+    const shareRows = ((shareResult as any).rows || []) as Array<{
+      user_id: string;
+      week_anchor: Date | string;
+      public_share_token: string;
+      updated_at: string | null;
+      display_name: string | null;
+      username: string | null;
+    }>;
+
+    const items = await Promise.all(
+      shareRows.map(async (row) => {
+        const summary = await buildPublicWeekSummary(row.user_id, row.week_anchor);
+        return {
+          token: row.public_share_token,
+          weekAnchor: summary.weekAnchor,
+          weekStart: summary.weekStart,
+          weekEnd: summary.weekEnd,
+          sharedAt: row.updated_at || null,
+          sharer: {
+            displayName: row.display_name || null,
+            username: row.username || null,
+          },
+          readiness: {
+            status: summary.readinessStatus,
+            plannedSlots: summary.plannedSlots,
+            totalSlots: summary.totalSlots,
+            plannedCoveragePct: summary.plannedCoveragePct,
+          },
+          grocery: {
+            totalItems: summary.groceryTotalItems,
+            purchasedItems: summary.groceryPurchasedItems,
+            completionPct: summary.groceryCompletionPct,
+          },
+          nutritionHighlights: {
+            plannedMealsCount: summary.plannedMealsCount,
+            totalCalories: summary.totalCalories,
+            totalProtein: summary.totalProtein,
+            avgCaloriesPerPlannedDay: summary.avgCaloriesPerPlannedDay,
+            avgProteinPerPlannedDay: summary.avgProteinPerPlannedDay,
+          },
+        };
+      })
+    );
+
+    res.json({ items });
+  } catch (error) {
+    console.error("Error fetching public shared weeks list:", error);
+    res.status(500).json({ message: "Failed to load public shared weeks" });
+  }
+});
+
+// ============================================================
 // GET /api/meal-planner/week/shared/:token
 // Public, read-only weekly summary for token-based sharing.
 // ============================================================
@@ -320,10 +497,11 @@ router.get("/week/shared/:token", async (req: Request, res: Response) => {
       return res.status(404).json({ message: "Shared week not found" });
     }
 
+    const summary = await buildPublicWeekSummary(shareRow.user_id, shareRow.week_anchor);
+
     const weekStart = startOfWeekMonday(new Date(shareRow.week_anchor));
     const weekEnd = endOfDay(addDays(weekStart, 6));
-    const weekAnchor = fmtISODate(weekStart);
-
+    const weekAnchor = summary.weekAnchor;
     const [plan] = await db
       .select()
       .from(mealPlans)
@@ -337,57 +515,29 @@ router.get("/week/shared/:token", async (req: Request, res: Response) => {
       )
       .orderBy(desc(mealPlans.createdAt))
       .limit(1);
-
-    let entries: any[] = [];
-    let groceryItems: Array<{ purchased: boolean | null }> = [];
-
-    if (plan) {
-      entries = await db
-        .select({
-          id: mealPlanEntries.id,
-          recipeId: mealPlanEntries.recipeId,
-          date: mealPlanEntries.date,
-          mealType: mealPlanEntries.mealType,
-          servings: mealPlanEntries.servings,
-          customName: mealPlanEntries.customName,
-          customCalories: mealPlanEntries.customCalories,
-          customProtein: mealPlanEntries.customProtein,
-          customCarbs: mealPlanEntries.customCarbs,
-          customFat: mealPlanEntries.customFat,
-          source: mealPlanEntries.source,
-          recipe: recipes,
-        })
-        .from(mealPlanEntries)
-        .leftJoin(recipes, eq(mealPlanEntries.recipeId, recipes.id))
-        .where(eq(mealPlanEntries.mealPlanId, plan.id))
-        .orderBy(mealPlanEntries.date);
-
-      groceryItems = await db
-        .select({ purchased: groceryListItems.purchased })
-        .from(groceryListItems)
-        .where(and(eq(groceryListItems.userId, shareRow.user_id), eq(groceryListItems.mealPlanId, plan.id)));
-    }
+    const entries = plan
+      ? await db
+          .select({
+            id: mealPlanEntries.id,
+            recipeId: mealPlanEntries.recipeId,
+            date: mealPlanEntries.date,
+            mealType: mealPlanEntries.mealType,
+            servings: mealPlanEntries.servings,
+            customName: mealPlanEntries.customName,
+            customCalories: mealPlanEntries.customCalories,
+            customProtein: mealPlanEntries.customProtein,
+            customCarbs: mealPlanEntries.customCarbs,
+            customFat: mealPlanEntries.customFat,
+            source: mealPlanEntries.source,
+            recipe: recipes,
+          })
+          .from(mealPlanEntries)
+          .leftJoin(recipes, eq(mealPlanEntries.recipeId, recipes.id))
+          .where(eq(mealPlanEntries.mealPlanId, plan.id))
+          .orderBy(mealPlanEntries.date)
+      : [];
 
     const weeklyMeals = mapEntriesToWeeklyMeals(entries);
-    const plannedSlots = entries.length;
-    const totalSlots = 28; // 7 days x 4 meal types
-    const plannedCoveragePct = Math.round((plannedSlots / Math.max(1, totalSlots)) * 100);
-
-    const groceryTotalItems = groceryItems.length;
-    const groceryPurchasedItems = groceryItems.filter((item) => Boolean(item.purchased)).length;
-    const groceryCompletionPct = groceryTotalItems > 0
-      ? Math.round((groceryPurchasedItems / groceryTotalItems) * 100)
-      : 0;
-
-    const totalCalories = entries.reduce(
-      (sum, entry) => sum + Number(entry?.recipe?.calories || entry?.customCalories || 0),
-      0
-    );
-    const totalProtein = entries.reduce(
-      (sum, entry) => sum + Number(entry?.recipe?.protein || entry?.customProtein || 0),
-      0
-    );
-    const activePlannedDays = new Set(entries.map((entry) => fmtISODate(new Date(entry.date)))).size;
 
     const publicWeeklyMeals = Object.fromEntries(
       Object.entries(weeklyMeals).map(([day, mealsByType]) => [
@@ -417,26 +567,26 @@ router.get("/week/shared/:token", async (req: Request, res: Response) => {
       visibility: "public",
       plannedMeals: publicWeeklyMeals,
       readiness: {
-        status: plannedSlots > 0 ? (plannedCoveragePct >= 70 ? "week-ready" : "in-progress") : "not-started",
-        plannedSlots,
-        totalSlots,
-        plannedCoveragePct,
+        status: summary.readinessStatus,
+        plannedSlots: summary.plannedSlots,
+        totalSlots: summary.totalSlots,
+        plannedCoveragePct: summary.plannedCoveragePct,
       },
       grocery: {
-        totalItems: groceryTotalItems,
-        purchasedItems: groceryPurchasedItems,
-        completionPct: groceryCompletionPct,
+        totalItems: summary.groceryTotalItems,
+        purchasedItems: summary.groceryPurchasedItems,
+        completionPct: summary.groceryCompletionPct,
       },
       prep: {
         status: "not-shared",
         note: "Prep details are not included in public shares yet.",
       },
       nutritionHighlights: {
-        plannedMealsCount: plannedSlots,
-        totalCalories,
-        totalProtein,
-        avgCaloriesPerPlannedDay: activePlannedDays > 0 ? Math.round(totalCalories / activePlannedDays) : 0,
-        avgProteinPerPlannedDay: activePlannedDays > 0 ? Math.round(totalProtein / activePlannedDays) : 0,
+        plannedMealsCount: summary.plannedMealsCount,
+        totalCalories: summary.totalCalories,
+        totalProtein: summary.totalProtein,
+        avgCaloriesPerPlannedDay: summary.avgCaloriesPerPlannedDay,
+        avgProteinPerPlannedDay: summary.avgProteinPerPlannedDay,
       },
     });
   } catch (error) {


### PR DESCRIPTION
### Motivation
- Public shared weeks were viewable only via a direct token link, making discovery and inspiration hard to access for users.
- Provide a safe, minimal discovery surface for meal-planning and nutrition ideas without adding social features or changing existing planner behavior.
- Keep changes additive and compatibility-safe by reusing the existing share metadata/token foundation and exposing only non-sensitive summary fields.

### Description
- Add a backend listing endpoint `GET /api/meal-planner/week/shared` that returns a bounded recent list of public shares with only safe summary fields (token link, week range, readiness snapshot, grocery snapshot, nutrition highlights, optional sharer display name/username) and an enforced limit via `PUBLIC_SHARED_WEEKS_LIMIT_DEFAULT`/`_MAX` in `server/routes/meal-planner-week.ts`.
- Introduce `buildPublicWeekSummary` in `server/routes/meal-planner-week.ts` to aggregate lightweight weekly summaries (planned slots, coverage pct, grocery snapshot, nutrition totals) and reuse it from the token-based endpoint to avoid duplication.
- Add a new client page `client/src/pages/nutrition/MealPlannerSharedBrowsePage.tsx` mounted at `/meal-planner/shared` that lists recent public shared weeks as simple inspiration cards linking to the existing token page at `/meal-planner/shared/:token`.
- Wire the new page into routing via lazy import in `client/src/App.tsx` and add small UX integrations: a "Browse Public Week Ideas" button in the planner `Share This Week` card (`client/src/components/NutritionMealPlanner.tsx`) and a "Browse more public weeks" CTA on the token-based shared-week page (`client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx`).
- All additions are intentionally minimal and additive: the existing token-based page and share metadata flow remain unchanged and are reused for compatibility.

### Testing
- Ran `npm run build` and the full product build completed successfully (no build errors).
- Ran `npm run build:client` and the client build completed successfully (Vite build succeeded).
- Ran `npm run build:server` and the server bundle completed successfully (esbuild succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5a2f4cfe08325bbe547258707d52b)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
