### PR TITLE
Add lightweight filters and sorting for public shared meal-plan browse

### DIFF
--- a/client/src/pages/nutrition/MealPlannerSharedBrowsePage.tsx
+++ b/client/src/pages/nutrition/MealPlannerSharedBrowsePage.tsx
@@ -5,6 +5,10 @@ import { Progress } from '@/components/ui/progress';
 import { Button } from '@/components/ui/button';
 import { CalendarDays, ShoppingCart, ShieldCheck, Activity, Globe, ArrowRight } from 'lucide-react';
 
+type BrowseReadinessFilter = 'all' | 'not-started' | 'in-progress' | 'week-ready';
+type BrowseCoverageFilter = 'all' | 'low' | 'medium' | 'high';
+type BrowseSort = 'newest' | 'readiness' | 'coverage';
+
 type SharedBrowseItem = {
   token: string;
   weekAnchor: string;
@@ -36,6 +40,24 @@ type SharedBrowseItem = {
 };
 
 export default function MealPlannerSharedBrowsePage() {
+  const [readinessFilter, setReadinessFilter] = useState<BrowseReadinessFilter>(() => {
+    const params = new URLSearchParams(window.location.search);
+    const value = params.get('readiness');
+    if (value === 'not-started' || value === 'in-progress' || value === 'week-ready') return value;
+    return 'all';
+  });
+  const [coverageFilter, setCoverageFilter] = useState<BrowseCoverageFilter>(() => {
+    const params = new URLSearchParams(window.location.search);
+    const value = params.get('coverage');
+    if (value === 'low' || value === 'medium' || value === 'high') return value;
+    return 'all';
+  });
+  const [sortBy, setSortBy] = useState<BrowseSort>(() => {
+    const params = new URLSearchParams(window.location.search);
+    const value = params.get('sort');
+    if (value === 'readiness' || value === 'coverage') return value;
+    return 'newest';
+  });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [items, setItems] = useState<SharedBrowseItem[]>([]);
@@ -47,7 +69,16 @@ export default function MealPlannerSharedBrowsePage() {
       setLoading(true);
       setError(null);
       try {
-        const response = await fetch('/api/meal-planner/week/shared');
+        const params = new URLSearchParams();
+        if (readinessFilter !== 'all') params.set('readiness', readinessFilter);
+        if (coverageFilter !== 'all') params.set('coverage', coverageFilter);
+        if (sortBy !== 'newest') params.set('sort', sortBy);
+
+        const query = params.toString();
+        const nextUrl = query ? `${window.location.pathname}?${query}` : window.location.pathname;
+        window.history.replaceState({}, '', nextUrl);
+
+        const response = await fetch(`/api/meal-planner/week/shared${query ? `?${query}` : ''}`);
         if (!response.ok) {
           throw new Error(`Failed to load public shared weeks (HTTP ${response.status}).`);
         }
@@ -73,7 +104,7 @@ export default function MealPlannerSharedBrowsePage() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [readinessFilter, coverageFilter, sortBy]);
 
   if (loading) {
     return <div className="p-6 text-sm text-muted-foreground">Loading public shared meal-planner weeks…</div>;
@@ -94,6 +125,55 @@ export default function MealPlannerSharedBrowsePage() {
         <CardContent className="flex flex-wrap gap-2">
           <Badge variant="secondary">Read-only public snapshots</Badge>
           <Badge variant="outline">Recent public shares</Badge>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Browse relevance controls</CardTitle>
+          <CardDescription>Filter by readiness + coverage and sort for inspiration quality.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3 md:grid-cols-3">
+          <label className="grid gap-1 text-sm">
+            <span className="font-medium">Readiness</span>
+            <select
+              value={readinessFilter}
+              onChange={(event) => setReadinessFilter(event.target.value as BrowseReadinessFilter)}
+              className="h-9 rounded-md border bg-background px-2"
+            >
+              <option value="all">All readiness</option>
+              <option value="week-ready">Week ready</option>
+              <option value="in-progress">In progress</option>
+              <option value="not-started">Not started</option>
+            </select>
+          </label>
+
+          <label className="grid gap-1 text-sm">
+            <span className="font-medium">Planned coverage</span>
+            <select
+              value={coverageFilter}
+              onChange={(event) => setCoverageFilter(event.target.value as BrowseCoverageFilter)}
+              className="h-9 rounded-md border bg-background px-2"
+            >
+              <option value="all">All coverage</option>
+              <option value="high">High (70%+ planned)</option>
+              <option value="medium">Medium (40-69%)</option>
+              <option value="low">Low (&lt;40%)</option>
+            </select>
+          </label>
+
+          <label className="grid gap-1 text-sm">
+            <span className="font-medium">Sort</span>
+            <select
+              value={sortBy}
+              onChange={(event) => setSortBy(event.target.value as BrowseSort)}
+              className="h-9 rounded-md border bg-background px-2"
+            >
+              <option value="newest">Newest shared</option>
+              <option value="readiness">Best readiness</option>
+              <option value="coverage">Most planned coverage</option>
+            </select>
+          </label>
         </CardContent>
       </Card>
 

--- a/server/routes/meal-planner-week.ts
+++ b/server/routes/meal-planner-week.ts
@@ -31,6 +31,42 @@ const MEAL_SHARE_VISIBILITY = ["private", "friends", "public"] as const;
 const SHARED_WEEK_TOKEN_PATTERN = /^[a-zA-Z0-9_-]{8,80}$/;
 const PUBLIC_SHARED_WEEKS_LIMIT_DEFAULT = 20;
 const PUBLIC_SHARED_WEEKS_LIMIT_MAX = 50;
+type PublicSharedReadinessFilter = PublicWeekSummary["readinessStatus"] | "all";
+type PublicSharedCoverageFilter = "all" | "low" | "medium" | "high";
+type PublicSharedSort = "newest" | "readiness" | "coverage";
+
+function parsePublicSharedReadinessFilter(raw: unknown): PublicSharedReadinessFilter {
+  const value = String(raw || "all").trim();
+  if (value === "not-started" || value === "in-progress" || value === "week-ready") {
+    return value;
+  }
+  return "all";
+}
+
+function parsePublicSharedCoverageFilter(raw: unknown): PublicSharedCoverageFilter {
+  const value = String(raw || "all").trim();
+  if (value === "low" || value === "medium" || value === "high") return value;
+  return "all";
+}
+
+function parsePublicSharedSort(raw: unknown): PublicSharedSort {
+  const value = String(raw || "newest").trim();
+  if (value === "readiness" || value === "coverage") return value;
+  return "newest";
+}
+
+function isCoverageMatch(coveragePct: number, filter: PublicSharedCoverageFilter): boolean {
+  if (filter === "all") return true;
+  if (filter === "low") return coveragePct < 40;
+  if (filter === "medium") return coveragePct >= 40 && coveragePct < 70;
+  return coveragePct >= 70;
+}
+
+function readinessSortScore(status: PublicWeekSummary["readinessStatus"]): number {
+  if (status === "week-ready") return 3;
+  if (status === "in-progress") return 2;
+  return 1;
+}
 
 router.use(async (_req: Request, res: Response, next: NextFunction) => {
   try {
@@ -414,6 +450,9 @@ router.get("/week/shared", async (req: Request, res: Response) => {
   try {
     const parsedLimit = Number(req.query.limit ?? PUBLIC_SHARED_WEEKS_LIMIT_DEFAULT);
     const limit = Math.max(1, Math.min(PUBLIC_SHARED_WEEKS_LIMIT_MAX, Number.isFinite(parsedLimit) ? parsedLimit : PUBLIC_SHARED_WEEKS_LIMIT_DEFAULT));
+    const readinessFilter = parsePublicSharedReadinessFilter(req.query.readiness);
+    const coverageFilter = parsePublicSharedCoverageFilter(req.query.coverage);
+    const sort = parsePublicSharedSort(req.query.sort);
 
     const shareResult = await db.execute(sql`
       SELECT s.user_id, s.week_anchor, s.public_share_token, s.updated_at, u.display_name, u.username
@@ -421,7 +460,7 @@ router.get("/week/shared", async (req: Request, res: Response) => {
       LEFT JOIN users u ON u.id = s.user_id
       WHERE s.visibility = 'public' AND s.public_share_token IS NOT NULL
       ORDER BY s.updated_at DESC
-      LIMIT ${limit}
+      LIMIT ${Math.min(PUBLIC_SHARED_WEEKS_LIMIT_MAX, Math.max(limit * 3, limit))}
     `);
     const shareRows = ((shareResult as any).rows || []) as Array<{
       user_id: string;
@@ -432,7 +471,7 @@ router.get("/week/shared", async (req: Request, res: Response) => {
       username: string | null;
     }>;
 
-    const items = await Promise.all(
+    let items = await Promise.all(
       shareRows.map(async (row) => {
         const summary = await buildPublicWeekSummary(row.user_id, row.week_anchor);
         return {
@@ -467,7 +506,38 @@ router.get("/week/shared", async (req: Request, res: Response) => {
       })
     );
 
-    res.json({ items });
+    items = items.filter((item) => {
+      const readinessMatches = readinessFilter === "all" || item.readiness.status === readinessFilter;
+      const coverageMatches = isCoverageMatch(item.readiness.plannedCoveragePct, coverageFilter);
+      return readinessMatches && coverageMatches;
+    });
+
+    if (sort === "coverage") {
+      items.sort((a, b) => {
+        const coverageDiff = b.readiness.plannedCoveragePct - a.readiness.plannedCoveragePct;
+        if (coverageDiff !== 0) return coverageDiff;
+        return new Date(b.sharedAt || 0).getTime() - new Date(a.sharedAt || 0).getTime();
+      });
+    } else if (sort === "readiness") {
+      items.sort((a, b) => {
+        const readinessDiff = readinessSortScore(b.readiness.status as PublicWeekSummary["readinessStatus"]) - readinessSortScore(a.readiness.status as PublicWeekSummary["readinessStatus"]);
+        if (readinessDiff !== 0) return readinessDiff;
+        const coverageDiff = b.readiness.plannedCoveragePct - a.readiness.plannedCoveragePct;
+        if (coverageDiff !== 0) return coverageDiff;
+        return new Date(b.sharedAt || 0).getTime() - new Date(a.sharedAt || 0).getTime();
+      });
+    }
+
+    items = items.slice(0, limit);
+
+    res.json({
+      items,
+      filters: {
+        readiness: readinessFilter,
+        coverage: coverageFilter,
+        sort,
+      },
+    });
   } catch (error) {
     console.error("Error fetching public shared weeks list:", error);
     res.status(500).json({ message: "Failed to load public shared weeks" });


### PR DESCRIPTION
### Motivation
- The public shared-week browse surface returned recent shares but offered limited relevance controls, making discovery of ready/high-coverage plans harder. 
- Use existing public share summary fields (readiness status, plannedCoveragePct, plannedSlots) to provide a safe, additive discovery surface without changing planner behavior.

### Description
- Added frontend browse controls (compact card with three selects) for Readiness (`all`, `week-ready`, `in-progress`, `not-started`), Planned coverage (`all`, `high`, `medium`, `low`), and Sort (`newest`, `readiness`, `coverage`) and persisted control state to the URL query string. (file: `client/src/pages/nutrition/MealPlannerSharedBrowsePage.tsx`)
- Wired fetch to include query params when present and kept existing defaults when omitted so behavior is backward-compatible. (file: `client/src/pages/nutrition/MealPlannerSharedBrowsePage.tsx`)
- Extended `GET /api/meal-planner/week/shared` to accept `readiness`, `coverage`, and `sort` query params with safe parsers/enums, apply lightweight filtering/sorting in-memory after summary hydration, and return the active `filters` in the response for observability. (file: `server/routes/meal-planner-week.ts`)
- Kept changes additive and scoped to public shared weeks only, with no changes to private planner workflows; backend expands the DB pull (looser LIMIT) to prefetch candidates then filters/sorts and slices to the requested `limit` for safe compatibility.

### Testing
- Ran `npm run build` and the overall build completed successfully in this environment. (passed)
- Ran `npm run build:client` to verify client compilation and bundling; the build completed successfully with normal bundle warnings. (passed)
- Ran `npm run build:server` to verify server bundling; the build completed successfully. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67475e58c8325a40249a390265674)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
