### PR TITLE
Add target-week picker and merge-mode for copying public shared weeks

### DIFF
--- a/client/src/pages/nutrition/MealPlannerSharedBrowsePage.tsx
+++ b/client/src/pages/nutrition/MealPlannerSharedBrowsePage.tsx
@@ -11,6 +11,7 @@ type BrowseReadinessFilter = 'all' | 'not-started' | 'in-progress' | 'week-ready
 type BrowseCoverageFilter = 'all' | 'low' | 'medium' | 'high';
 type BrowseSort = 'newest' | 'readiness' | 'coverage';
 type BrowsePreset = 'ready-high-coverage' | 'newest-ideas' | 'in-progress' | 'balanced-browse';
+type CopyMergeMode = 'replace' | 'append' | 'skip-duplicates';
 
 type SharedBrowseItem = {
   token: string;
@@ -48,6 +49,21 @@ type SharedBrowseStats = {
   highCoveragePlans: number;
   avgPlannedMealsPerPlan: number;
 };
+
+function getWeekStartIso(date: Date) {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  d.setHours(0, 0, 0, 0);
+  return d.toISOString().split('T')[0];
+}
+
+function modePreview(mode: CopyMergeMode) {
+  if (mode === 'append') return 'Append keeps existing meals and adds every copied meal.';
+  if (mode === 'skip-duplicates') return 'Merge safely keeps existing meals and skips likely duplicate day + meal slots.';
+  return 'Replace clears existing meals in that week before copying.';
+}
 
 export default function MealPlannerSharedBrowsePage() {
   const { user } = useUser();
@@ -105,6 +121,8 @@ export default function MealPlannerSharedBrowsePage() {
   const [items, setItems] = useState<SharedBrowseItem[]>([]);
   const [stats, setStats] = useState<SharedBrowseStats | null>(null);
   const [copyingToken, setCopyingToken] = useState<string | null>(null);
+  const [targetWeekStart, setTargetWeekStart] = useState(() => getWeekStartIso(new Date()));
+  const [mergeMode, setMergeMode] = useState<CopyMergeMode>('replace');
 
   useEffect(() => {
     let cancelled = false;
@@ -185,7 +203,7 @@ export default function MealPlannerSharedBrowsePage() {
   const handleCopyToPlanner = async (token: string) => {
     if (!user || copyingToken) return;
 
-    const confirmed = window.confirm('Copy this shared plan into your planner for your current week? This will replace your existing meals for that week.');
+    const confirmed = window.confirm(`Copy this shared plan into your planner for the week of ${targetWeekStart}? ${modePreview(mergeMode)}`);
     if (!confirmed) return;
 
     try {
@@ -194,7 +212,7 @@ export default function MealPlannerSharedBrowsePage() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ replaceExisting: true }),
+        body: JSON.stringify({ targetWeekStart, mergeMode, replaceExisting: mergeMode === 'replace' }),
       });
       const payload = await response.json().catch(() => null);
       if (!response.ok) {
@@ -203,7 +221,7 @@ export default function MealPlannerSharedBrowsePage() {
 
       toast({
         title: 'Plan copied to your planner',
-        description: `Copied ${payload?.copiedEntriesCount ?? 0} meals to your week of ${payload?.targetWeekStart ?? 'this week'}.`,
+        description: `Copied ${payload?.copiedEntriesCount ?? 0} meals to your week of ${payload?.targetWeekStart ?? targetWeekStart}${Number(payload?.skippedDuplicatesCount || 0) > 0 ? ` (${payload?.skippedDuplicatesCount} duplicates skipped)` : ''}.`,
       });
     } catch (copyError: any) {
       toast({
@@ -223,6 +241,32 @@ export default function MealPlannerSharedBrowsePage() {
   return (
     <div className="mx-auto max-w-5xl space-y-6 p-6">
       <Card>
+        {user && (
+          <CardContent className="grid gap-3 border-b pb-4 md:grid-cols-2">
+            <label className="space-y-1 text-sm">
+              <div className="font-medium">Target week (Monday)</div>
+              <input
+                type="date"
+                value={targetWeekStart}
+                onChange={(event) => setTargetWeekStart(event.target.value || getWeekStartIso(new Date()))}
+                className="w-full rounded-md border bg-background px-3 py-2"
+              />
+            </label>
+            <label className="space-y-1 text-sm">
+              <div className="font-medium">Copy mode</div>
+              <select
+                value={mergeMode}
+                onChange={(event) => setMergeMode(event.target.value as CopyMergeMode)}
+                className="w-full rounded-md border bg-background px-3 py-2"
+              >
+                <option value="replace">Replace existing week meals</option>
+                <option value="append">Append copied meals</option>
+                <option value="skip-duplicates">Merge safely (skip duplicates)</option>
+              </select>
+            </label>
+            <div className="text-sm text-muted-foreground md:col-span-2">{modePreview(mergeMode)}</div>
+          </CardContent>
+        )}
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-xl">
             <Globe className="h-5 w-5" />

--- a/client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx
+++ b/client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx
@@ -47,6 +47,22 @@ type SharedWeekPayload = {
 };
 
 const DAY_ORDER = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+type CopyMergeMode = 'replace' | 'append' | 'skip-duplicates';
+
+function getWeekStartIso(date: Date) {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  d.setHours(0, 0, 0, 0);
+  return d.toISOString().split('T')[0];
+}
+
+function modePreview(mode: CopyMergeMode) {
+  if (mode === 'append') return 'Append mode keeps your current meals and adds all copied meals into this week.';
+  if (mode === 'skip-duplicates') return 'Merge safely mode keeps your current meals and skips copied meals that look like duplicates in the same day + meal slot.';
+  return 'Replace mode clears existing meals in the target week, then copies this shared week.';
+}
 
 export default function MealPlannerSharedWeekPage() {
   const { user } = useUser();
@@ -59,6 +75,8 @@ export default function MealPlannerSharedWeekPage() {
   const [data, setData] = useState<SharedWeekPayload | null>(null);
   const [isCopying, setIsCopying] = useState(false);
   const [copySummary, setCopySummary] = useState<string | null>(null);
+  const [targetWeekStart, setTargetWeekStart] = useState(() => getWeekStartIso(new Date()));
+  const [mergeMode, setMergeMode] = useState<CopyMergeMode>('replace');
 
   useEffect(() => {
     if (!token) {
@@ -113,7 +131,7 @@ export default function MealPlannerSharedWeekPage() {
   const handleCopyWeek = async () => {
     if (!token || !user || isCopying) return;
 
-    const confirmed = window.confirm('Copy this shared week into your planner for your current week? This will replace your existing meals for that week.');
+    const confirmed = window.confirm(`Copy this shared week into your planner for the week of ${targetWeekStart}? ${modePreview(mergeMode)}`);
     if (!confirmed) return;
 
     try {
@@ -122,14 +140,15 @@ export default function MealPlannerSharedWeekPage() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ replaceExisting: true }),
+        body: JSON.stringify({ targetWeekStart, mergeMode, replaceExisting: mergeMode === 'replace' }),
       });
       const payload = await response.json().catch(() => null);
       if (!response.ok) {
         throw new Error(payload?.message || `Failed to copy shared week (HTTP ${response.status}).`);
       }
 
-      const summary = `Copied ${payload?.copiedEntriesCount ?? 0} meals to your week of ${payload?.targetWeekStart ?? 'this week'}.`;
+      const skipped = Number(payload?.skippedDuplicatesCount || 0);
+      const summary = `Copied ${payload?.copiedEntriesCount ?? 0} meals to your week of ${payload?.targetWeekStart ?? targetWeekStart}${skipped > 0 ? ` (${skipped} duplicates skipped)` : ''}.`;
       setCopySummary(summary);
       toast({ title: 'Week copied to your planner', description: summary });
     } catch (copyError: any) {
@@ -193,6 +212,41 @@ export default function MealPlannerSharedWeekPage() {
           </Button>
         </CardContent>
       </Card>
+
+      {user && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Copy options</CardTitle>
+            <CardDescription>Pick a target week and merge behavior before importing this shared plan.</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-3 md:grid-cols-2">
+            <label className="space-y-1 text-sm">
+              <div className="font-medium">Target week (Monday)</div>
+              <input
+                type="date"
+                value={targetWeekStart}
+                onChange={(event) => setTargetWeekStart(event.target.value || getWeekStartIso(new Date()))}
+                className="w-full rounded-md border bg-background px-3 py-2"
+              />
+            </label>
+            <label className="space-y-1 text-sm">
+              <div className="font-medium">Merge mode</div>
+              <select
+                value={mergeMode}
+                onChange={(event) => setMergeMode(event.target.value as CopyMergeMode)}
+                className="w-full rounded-md border bg-background px-3 py-2"
+              >
+                <option value="replace">Replace existing week meals</option>
+                <option value="append">Append copied meals</option>
+                <option value="skip-duplicates">Merge safely (skip duplicates)</option>
+              </select>
+            </label>
+            <div className="text-sm text-muted-foreground md:col-span-2">
+              {modePreview(mergeMode)}
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {copySummary && (
         <Card>

--- a/server/routes/meal-planner-week.ts
+++ b/server/routes/meal-planner-week.ts
@@ -34,6 +34,7 @@ const PUBLIC_SHARED_WEEKS_LIMIT_MAX = 50;
 type PublicSharedReadinessFilter = PublicWeekSummary["readinessStatus"] | "all";
 type PublicSharedCoverageFilter = "all" | "low" | "medium" | "high";
 type PublicSharedSort = "newest" | "readiness" | "coverage";
+type SharedWeekCopyMode = "replace" | "append" | "skip-duplicates";
 
 function parsePublicSharedReadinessFilter(raw: unknown): PublicSharedReadinessFilter {
   const value = String(raw || "all").trim();
@@ -66,6 +67,31 @@ function readinessSortScore(status: PublicWeekSummary["readinessStatus"]): numbe
   if (status === "week-ready") return 3;
   if (status === "in-progress") return 2;
   return 1;
+}
+
+function parseSharedWeekCopyMode(raw: unknown): SharedWeekCopyMode {
+  const value = String(raw || "").trim();
+  if (value === "append" || value === "skip-duplicates") return value;
+  return "replace";
+}
+
+function buildCopyEntrySignature(entry: {
+  date: Date | string;
+  mealType: string;
+  recipeId?: string | null;
+  customName?: string | null;
+  customCalories?: number | null;
+  customProtein?: number | null;
+  customCarbs?: number | null;
+  customFat?: number | null;
+}) {
+  const dateIso = fmtISODate(startOfDay(new Date(entry.date)));
+  const recipeSig = entry.recipeId ? `recipe:${entry.recipeId}` : "recipe:none";
+  const customName = String(entry.customName || "").trim().toLowerCase();
+  const customSig = customName
+    ? `custom:${customName}:${Number(entry.customCalories || 0)}:${Number(entry.customProtein || 0)}:${Number(entry.customCarbs || 0)}:${Number(entry.customFat || 0)}`
+    : "custom:none";
+  return `${dateIso}|${entry.mealType}|${recipeSig}|${customSig}`;
 }
 
 router.use(async (_req: Request, res: Response, next: NextFunction) => {
@@ -686,8 +712,11 @@ router.post("/week/shared/:token/copy", requireAuth, async (req: Request, res: R
       return res.status(400).json({ message: "Invalid share token" });
     }
 
-    const targetDateRaw = String(req.body?.targetDate || "").trim();
-    const replaceExisting = req.body?.replaceExisting !== false;
+    const targetDateRaw = String(req.body?.targetDate || req.body?.targetWeekStart || "").trim();
+    const copyMode = parseSharedWeekCopyMode(req.body?.mergeMode);
+    const replaceExisting = copyMode === "replace"
+      ? req.body?.replaceExisting !== false
+      : false;
     const parsedTargetDate = targetDateRaw ? new Date(targetDateRaw) : new Date();
     if (isNaN(parsedTargetDate.getTime())) {
       return res.status(400).json({ message: "Invalid target date" });
@@ -786,7 +815,7 @@ router.post("/week/shared/:token/copy", requireAuth, async (req: Request, res: R
       targetPlanId = createdPlan.id;
     }
 
-    const entriesToInsert = sourceEntries.map((entry) => {
+    const mappedEntries = sourceEntries.map((entry) => {
       const sourceDate = startOfDay(new Date(entry.date));
       const dayOffset = Math.max(
         0,
@@ -807,7 +836,35 @@ router.post("/week/shared/:token/copy", requireAuth, async (req: Request, res: R
       };
     });
 
-    await db.insert(mealPlanEntries).values(entriesToInsert);
+    const existingTargetEntries = replaceExisting || !targetPlanId
+      ? []
+      : await db
+          .select({
+            date: mealPlanEntries.date,
+            mealType: mealPlanEntries.mealType,
+            recipeId: mealPlanEntries.recipeId,
+            customName: mealPlanEntries.customName,
+            customCalories: mealPlanEntries.customCalories,
+            customProtein: mealPlanEntries.customProtein,
+            customCarbs: mealPlanEntries.customCarbs,
+            customFat: mealPlanEntries.customFat,
+          })
+          .from(mealPlanEntries)
+          .where(eq(mealPlanEntries.mealPlanId, targetPlanId));
+
+    const existingSignatures = new Set(existingTargetEntries.map((entry) => buildCopyEntrySignature(entry)));
+    const entriesToInsert = copyMode === "skip-duplicates"
+      ? mappedEntries.filter((entry) => {
+          const signature = buildCopyEntrySignature(entry);
+          if (existingSignatures.has(signature)) return false;
+          existingSignatures.add(signature);
+          return true;
+        })
+      : mappedEntries;
+
+    if (entriesToInsert.length > 0) {
+      await db.insert(mealPlanEntries).values(entriesToInsert);
+    }
 
     const copiedEntries = await db
       .select({
@@ -833,6 +890,9 @@ router.post("/week/shared/:token/copy", requireAuth, async (req: Request, res: R
     res.json({
       ok: true,
       copiedEntriesCount: entriesToInsert.length,
+      sourceEntriesCount: sourceEntries.length,
+      skippedDuplicatesCount: Math.max(0, mappedEntries.length - entriesToInsert.length),
+      mergeMode: copyMode,
       targetWeekStart: fmtISODate(targetWeekStart),
       targetWeekEnd: fmtISODate(targetWeekEnd),
       weeklyMeals: mapEntriesToWeeklyMeals(copiedEntries),


### PR DESCRIPTION
### Motivation
- Users need to choose which week to copy a public shared plan into (future or other weeks) rather than always using the current week.  
- Reduce accidental overwrites by offering safer, lightweight merge behaviors without redesigning planner storage.  
- Keep the change additive and preserve existing default/behavior while improving confidence before import.

### Description
- Backend: extended copy endpoint to accept a target week date and a `mergeMode` (`replace` | `append` | `skip-duplicates`), added `parseSharedWeekCopyMode` and minimal duplicate-signature logic (`buildCopyEntrySignature`) so `skip-duplicates` only inserts non-duplicate day+slot entries; preserved default `replace` behavior and backward compatibility with `replaceExisting`. (file: `server/routes/meal-planner-week.ts`)
- Backend: normalize `targetWeekStart` to the Monday week span and return extra copy stats (`sourceEntriesCount`, `skippedDuplicatesCount`, `mergeMode`, `targetWeekStart`) for improved UX messaging. (file: `server/routes/meal-planner-week.ts`)
- Frontend: added a target-week date picker, merge-mode selector, and small explanatory preview text to both the shared-week detail page and the shared browse page, and updated confirmation prompt and success summary to surface skipped duplicates. (files: `client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx`, `client/src/pages/nutrition/MealPlannerSharedBrowsePage.tsx`)
- Files changed: `server/routes/meal-planner-week.ts`, `client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx`, `client/src/pages/nutrition/MealPlannerSharedBrowsePage.tsx`.

### Testing
- Ran `npm run build` and the full build completed successfully.  
- Ran `npm run build:client` and the client build completed successfully.  
- Ran `npm run build:server` and the server build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ef8b48008325bbdd2051f16e9973)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
