### PR TITLE
Add lightweight pre-copy impact summary for shared-week imports

### DIFF
--- a/client/src/pages/nutrition/MealPlannerSharedBrowsePage.tsx
+++ b/client/src/pages/nutrition/MealPlannerSharedBrowsePage.tsx
@@ -12,6 +12,16 @@ type BrowseCoverageFilter = 'all' | 'low' | 'medium' | 'high';
 type BrowseSort = 'newest' | 'readiness' | 'coverage';
 type BrowsePreset = 'ready-high-coverage' | 'newest-ideas' | 'in-progress' | 'balanced-browse';
 type CopyMergeMode = 'replace' | 'append' | 'skip-duplicates';
+type CopyImpactSummary = {
+  mergeMode: CopyMergeMode;
+  targetWeekStart: string;
+  targetWeekMealsCount: number;
+  sourceEntriesCount: number;
+  estimatedAddedCount: number;
+  estimatedSkippedDuplicatesCount: number;
+  willReplaceExisting: boolean;
+  impactSummary: string;
+};
 
 type SharedBrowseItem = {
   token: string;
@@ -200,10 +210,32 @@ export default function MealPlannerSharedBrowsePage() {
     setActivePreset(null);
   };
 
+  const fetchCopyImpactSummary = async (token: string) => {
+    if (!user) return null;
+    try {
+      const params = new URLSearchParams({
+        targetWeekStart,
+        mergeMode,
+      });
+      const response = await fetch(`/api/meal-planner/week/shared/${encodeURIComponent(token)}/copy-impact?${params.toString()}`, {
+        credentials: 'include',
+      });
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(payload?.message || `Failed to load copy impact (HTTP ${response.status}).`);
+      }
+      return payload as CopyImpactSummary;
+    } catch {
+      return null;
+    }
+  };
+
   const handleCopyToPlanner = async (token: string) => {
     if (!user || copyingToken) return;
 
-    const confirmed = window.confirm(`Copy this shared plan into your planner for the week of ${targetWeekStart}? ${modePreview(mergeMode)}`);
+    const preview = await fetchCopyImpactSummary(token);
+    const previewText = preview?.impactSummary || modePreview(mergeMode);
+    const confirmed = window.confirm(`Copy this shared plan into your planner for the week of ${targetWeekStart}? ${previewText}`);
     if (!confirmed) return;
 
     try {

--- a/client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx
+++ b/client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx
@@ -48,6 +48,16 @@ type SharedWeekPayload = {
 
 const DAY_ORDER = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
 type CopyMergeMode = 'replace' | 'append' | 'skip-duplicates';
+type CopyImpactSummary = {
+  mergeMode: CopyMergeMode;
+  targetWeekStart: string;
+  targetWeekMealsCount: number;
+  sourceEntriesCount: number;
+  estimatedAddedCount: number;
+  estimatedSkippedDuplicatesCount: number;
+  willReplaceExisting: boolean;
+  impactSummary: string;
+};
 
 function getWeekStartIso(date: Date) {
   const d = new Date(date);
@@ -77,6 +87,38 @@ export default function MealPlannerSharedWeekPage() {
   const [copySummary, setCopySummary] = useState<string | null>(null);
   const [targetWeekStart, setTargetWeekStart] = useState(() => getWeekStartIso(new Date()));
   const [mergeMode, setMergeMode] = useState<CopyMergeMode>('replace');
+  const [impactSummary, setImpactSummary] = useState<CopyImpactSummary | null>(null);
+  const [impactLoading, setImpactLoading] = useState(false);
+
+  const fetchCopyImpactSummary = async (opts?: { silent?: boolean; targetWeek?: string; mode?: CopyMergeMode }) => {
+    if (!token || !user) return null;
+    const nextTargetWeek = opts?.targetWeek ?? targetWeekStart;
+    const nextMode = opts?.mode ?? mergeMode;
+
+    try {
+      if (!opts?.silent) setImpactLoading(true);
+      const params = new URLSearchParams({
+        targetWeekStart: nextTargetWeek,
+        mergeMode: nextMode,
+      });
+      const response = await fetch(`/api/meal-planner/week/shared/${encodeURIComponent(token)}/copy-impact?${params.toString()}`, {
+        credentials: 'include',
+      });
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(payload?.message || `Failed to load copy impact (HTTP ${response.status}).`);
+      }
+      setImpactSummary(payload);
+      return payload as CopyImpactSummary;
+    } catch {
+      if (!opts?.silent) {
+        setImpactSummary(null);
+      }
+      return null;
+    } finally {
+      if (!opts?.silent) setImpactLoading(false);
+    }
+  };
 
   useEffect(() => {
     if (!token) {
@@ -121,6 +163,14 @@ export default function MealPlannerSharedWeekPage() {
     };
   }, [token]);
 
+  useEffect(() => {
+    if (!user || !token) {
+      setImpactSummary(null);
+      return;
+    }
+    fetchCopyImpactSummary();
+  }, [user, token, targetWeekStart, mergeMode]);
+
   const orderedDays = useMemo(() => {
     if (!data?.plannedMeals) return DAY_ORDER;
     const existingDays = new Set(Object.keys(data.plannedMeals));
@@ -131,7 +181,9 @@ export default function MealPlannerSharedWeekPage() {
   const handleCopyWeek = async () => {
     if (!token || !user || isCopying) return;
 
-    const confirmed = window.confirm(`Copy this shared week into your planner for the week of ${targetWeekStart}? ${modePreview(mergeMode)}`);
+    const preview = await fetchCopyImpactSummary({ silent: true });
+    const previewText = preview?.impactSummary || modePreview(mergeMode);
+    const confirmed = window.confirm(`Copy this shared week into your planner for the week of ${targetWeekStart}? ${previewText}`);
     if (!confirmed) return;
 
     try {
@@ -243,6 +295,20 @@ export default function MealPlannerSharedWeekPage() {
             </label>
             <div className="text-sm text-muted-foreground md:col-span-2">
               {modePreview(mergeMode)}
+            </div>
+            <div className="rounded-md border bg-muted/40 p-3 text-sm md:col-span-2">
+              <div className="font-medium">Pre-copy impact</div>
+              <div className="mt-1 text-muted-foreground">
+                {impactLoading
+                  ? 'Calculating impact preview…'
+                  : impactSummary?.impactSummary || 'Impact preview unavailable right now. Copy still works with your selected mode.'}
+              </div>
+              {!impactLoading && impactSummary && (
+                <div className="mt-2 text-xs text-muted-foreground">
+                  Target week meals: {impactSummary.targetWeekMealsCount} • Shared meals: {impactSummary.sourceEntriesCount} • Estimated add: {impactSummary.estimatedAddedCount}
+                  {impactSummary.estimatedSkippedDuplicatesCount > 0 ? ` • Estimated skip: ${impactSummary.estimatedSkippedDuplicatesCount}` : ''}
+                </div>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/server/routes/meal-planner-week.ts
+++ b/server/routes/meal-planner-week.ts
@@ -94,6 +94,48 @@ function buildCopyEntrySignature(entry: {
   return `${dateIso}|${entry.mealType}|${recipeSig}|${customSig}`;
 }
 
+type SharedWeekSourceEntry = {
+  date: Date | string;
+  mealType: string;
+  servings: number | null;
+  recipeId: string | null;
+  customName: string | null;
+  customCalories: number | null;
+  customProtein: number | null;
+  customCarbs: number | null;
+  customFat: number | null;
+  source: string | null;
+};
+
+function mapSharedEntriesToTargetWeek(args: {
+  sourceEntries: SharedWeekSourceEntry[];
+  sourceWeekStart: Date;
+  targetWeekStart: Date;
+  targetPlanId?: string | null;
+}) {
+  const { sourceEntries, sourceWeekStart, targetWeekStart, targetPlanId = null } = args;
+  return sourceEntries.map((entry) => {
+    const sourceDate = startOfDay(new Date(entry.date));
+    const dayOffset = Math.max(
+      0,
+      Math.min(6, Math.round((sourceDate.getTime() - startOfDay(sourceWeekStart).getTime()) / (1000 * 60 * 60 * 24)))
+    );
+    return {
+      mealPlanId: targetPlanId || "",
+      recipeId: entry.recipeId || null,
+      date: startOfDay(addDays(targetWeekStart, dayOffset)),
+      mealType: entry.mealType,
+      servings: Number(entry.servings || 1),
+      customName: entry.customName || null,
+      customCalories: entry.customCalories ?? null,
+      customProtein: entry.customProtein ?? null,
+      customCarbs: entry.customCarbs ?? null,
+      customFat: entry.customFat ?? null,
+      source: entry.source || "shared-copy",
+    };
+  });
+}
+
 router.use(async (_req: Request, res: Response, next: NextFunction) => {
   try {
     await ensureMealPlannerWeekSchema();
@@ -756,7 +798,7 @@ router.post("/week/shared/:token/copy", requireAuth, async (req: Request, res: R
       return res.status(404).json({ message: "Shared plan data is no longer available." });
     }
 
-    const sourceEntries = await db
+    const sourceEntries: SharedWeekSourceEntry[] = await db
       .select({
         date: mealPlanEntries.date,
         mealType: mealPlanEntries.mealType,
@@ -815,25 +857,11 @@ router.post("/week/shared/:token/copy", requireAuth, async (req: Request, res: R
       targetPlanId = createdPlan.id;
     }
 
-    const mappedEntries = sourceEntries.map((entry) => {
-      const sourceDate = startOfDay(new Date(entry.date));
-      const dayOffset = Math.max(
-        0,
-        Math.min(6, Math.round((sourceDate.getTime() - startOfDay(sourceWeekStart).getTime()) / (1000 * 60 * 60 * 24)))
-      );
-      return {
-        mealPlanId: targetPlanId!,
-        recipeId: entry.recipeId || null,
-        date: startOfDay(addDays(targetWeekStart, dayOffset)),
-        mealType: entry.mealType,
-        servings: Number(entry.servings || 1),
-        customName: entry.customName || null,
-        customCalories: entry.customCalories ?? null,
-        customProtein: entry.customProtein ?? null,
-        customCarbs: entry.customCarbs ?? null,
-        customFat: entry.customFat ?? null,
-        source: entry.source || "shared-copy",
-      };
+    const mappedEntries = mapSharedEntriesToTargetWeek({
+      sourceEntries,
+      sourceWeekStart,
+      targetWeekStart,
+      targetPlanId,
     });
 
     const existingTargetEntries = replaceExisting || !targetPlanId
@@ -900,6 +928,159 @@ router.post("/week/shared/:token/copy", requireAuth, async (req: Request, res: R
   } catch (error) {
     console.error("Error copying shared meal planner week:", error);
     res.status(500).json({ message: "Failed to copy shared week" });
+  }
+});
+
+// ============================================================
+// GET /api/meal-planner/week/shared/:token/copy-impact
+// Lightweight pre-copy summary for selected target week + merge mode.
+// ============================================================
+router.get("/week/shared/:token/copy-impact", requireAuth, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.id;
+    const token = String(req.params?.token || "").trim();
+    if (!SHARED_WEEK_TOKEN_PATTERN.test(token)) {
+      return res.status(400).json({ message: "Invalid share token" });
+    }
+
+    const targetDateRaw = String(req.query?.targetDate || req.query?.targetWeekStart || "").trim();
+    const copyMode = parseSharedWeekCopyMode(req.query?.mergeMode);
+    const parsedTargetDate = targetDateRaw ? new Date(targetDateRaw) : new Date();
+    if (isNaN(parsedTargetDate.getTime())) {
+      return res.status(400).json({ message: "Invalid target date" });
+    }
+
+    const shareResult = await db.execute(sql`
+      SELECT user_id, week_anchor, visibility
+      FROM meal_plan_week_shares
+      WHERE public_share_token = ${token}
+      LIMIT 1
+    `);
+    const shareRow = (shareResult as any).rows?.[0];
+    if (!shareRow || shareRow.visibility !== "public") {
+      return res.status(404).json({ message: "Shared week not found" });
+    }
+    if (shareRow.user_id === userId) {
+      return res.status(400).json({ message: "This is already your week plan." });
+    }
+
+    const sourceWeekStart = startOfWeekMonday(new Date(shareRow.week_anchor));
+    const sourceWeekEnd = endOfDay(addDays(sourceWeekStart, 6));
+    const [sourcePlan] = await db
+      .select()
+      .from(mealPlans)
+      .where(
+        and(
+          eq(mealPlans.userId, shareRow.user_id),
+          lte(mealPlans.startDate, sourceWeekEnd),
+          gte(mealPlans.endDate, sourceWeekStart),
+          eq(mealPlans.isTemplate, false)
+        )
+      )
+      .orderBy(desc(mealPlans.createdAt))
+      .limit(1);
+
+    if (!sourcePlan) {
+      return res.status(404).json({ message: "Shared plan data is no longer available." });
+    }
+
+    const sourceEntries: SharedWeekSourceEntry[] = await db
+      .select({
+        date: mealPlanEntries.date,
+        mealType: mealPlanEntries.mealType,
+        servings: mealPlanEntries.servings,
+        recipeId: mealPlanEntries.recipeId,
+        customName: mealPlanEntries.customName,
+        customCalories: mealPlanEntries.customCalories,
+        customProtein: mealPlanEntries.customProtein,
+        customCarbs: mealPlanEntries.customCarbs,
+        customFat: mealPlanEntries.customFat,
+        source: mealPlanEntries.source,
+      })
+      .from(mealPlanEntries)
+      .where(eq(mealPlanEntries.mealPlanId, sourcePlan.id))
+      .orderBy(mealPlanEntries.date);
+
+    if (!sourceEntries.length) {
+      return res.status(400).json({ message: "This shared week has no meals to copy yet." });
+    }
+
+    const targetWeekStart = startOfWeekMonday(parsedTargetDate);
+    const targetWeekEnd = endOfDay(addDays(targetWeekStart, 6));
+    const targetPlans = await db
+      .select({ id: mealPlans.id })
+      .from(mealPlans)
+      .where(
+        and(
+          eq(mealPlans.userId, userId),
+          lte(mealPlans.startDate, targetWeekEnd),
+          gte(mealPlans.endDate, targetWeekStart),
+          eq(mealPlans.isTemplate, false)
+        )
+      );
+    const targetPlanIds = targetPlans.map((plan) => plan.id);
+
+    const existingTargetEntries = targetPlanIds.length
+      ? await db
+          .select({
+            date: mealPlanEntries.date,
+            mealType: mealPlanEntries.mealType,
+            recipeId: mealPlanEntries.recipeId,
+            customName: mealPlanEntries.customName,
+            customCalories: mealPlanEntries.customCalories,
+            customProtein: mealPlanEntries.customProtein,
+            customCarbs: mealPlanEntries.customCarbs,
+            customFat: mealPlanEntries.customFat,
+          })
+          .from(mealPlanEntries)
+          .where(inArray(mealPlanEntries.mealPlanId, targetPlanIds))
+      : [];
+
+    const mappedEntries = mapSharedEntriesToTargetWeek({
+      sourceEntries,
+      sourceWeekStart,
+      targetWeekStart,
+    });
+    const sourceEntriesCount = mappedEntries.length;
+    const targetWeekMealsCount = existingTargetEntries.length;
+    const willReplaceExisting = copyMode === "replace";
+
+    let estimatedAddedCount = sourceEntriesCount;
+    let estimatedSkippedDuplicatesCount = 0;
+    if (copyMode === "skip-duplicates") {
+      const existingSignatures = new Set(existingTargetEntries.map((entry) => buildCopyEntrySignature(entry)));
+      let additions = 0;
+      for (const entry of mappedEntries) {
+        const signature = buildCopyEntrySignature(entry);
+        if (existingSignatures.has(signature)) continue;
+        existingSignatures.add(signature);
+        additions += 1;
+      }
+      estimatedAddedCount = additions;
+      estimatedSkippedDuplicatesCount = Math.max(0, sourceEntriesCount - additions);
+    }
+
+    const impactSummary = copyMode === "replace"
+      ? `Target week has ${targetWeekMealsCount} meals. Copy will replace that week with ${sourceEntriesCount} meals from this shared plan.`
+      : copyMode === "append"
+        ? `Target week has ${targetWeekMealsCount} meals. Copy will add ${sourceEntriesCount} meals.`
+        : `Target week has ${targetWeekMealsCount} meals. Copy will add about ${estimatedAddedCount} meals and skip about ${estimatedSkippedDuplicatesCount} duplicates.`;
+
+    res.json({
+      ok: true,
+      mergeMode: copyMode,
+      targetWeekStart: fmtISODate(targetWeekStart),
+      targetWeekEnd: fmtISODate(targetWeekEnd),
+      targetWeekMealsCount,
+      sourceEntriesCount,
+      estimatedAddedCount,
+      estimatedSkippedDuplicatesCount,
+      willReplaceExisting,
+      impactSummary,
+    });
+  } catch (error) {
+    console.error("Error building shared week copy impact:", error);
+    res.status(500).json({ message: "Failed to build copy impact summary" });
   }
 });
 


### PR DESCRIPTION
### Motivation
- Users can select a target week and merge mode when copying a public shared week but currently lack a concise pre-copy preview, which reduces confidence before making potentially destructive choices like `replace` or merge; this change adds a lightweight, just-in-time summary to improve trust and conversion from inspiration → import.

### Description
- Added a backend-safe preview endpoint `GET /api/meal-planner/week/shared/:token/copy-impact` that computes a lightweight impact summary for a selected `targetWeekStart` and `mergeMode` and returns `impactSummary`, `targetWeekMealsCount`, `sourceEntriesCount`, `estimatedAddedCount`, `estimatedSkippedDuplicatesCount`, and `willReplaceExisting` in JSON.
- Introduced `mapSharedEntriesToTargetWeek` and a small `SharedWeekSourceEntry` type to reuse the same mapping logic in both execution and preview so the preview estimates align with the copy behavior without changing storage or import architecture.
- Updated the shared-week detail page (`MealPlannerSharedWeekPage`) to fetch and show a compact pre-copy impact panel in the copy options and to use the preview text in the final confirm prompt, with graceful fallback to existing mode text when preview is unavailable.
- Updated the browse/listing flow (`MealPlannerSharedBrowsePage`) to fetch the preview just-in-time for the selected card and include it in the confirmation prompt prior to copy.
- Exact files changed: `server/routes/meal-planner-week.ts`, `client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx`, `client/src/pages/nutrition/MealPlannerSharedBrowsePage.tsx`.
- Impact signals now shown: `targetWeekMealsCount` (Target week currently has X meals), `sourceEntriesCount` (Shared week meals), `estimatedAddedCount` (This copy will add Y), `estimatedSkippedDuplicatesCount` (This copy will skip Z duplicates), and `willReplaceExisting` / replace-specific summary text for `replace` mode.
- Next best improvement: add a lightweight “affected slots” mini-diff (day + meal-type counts) in the same impact panel so users can quickly see where changes land without a heavy wizard.

### Testing
- Built and validated the app artifacts with `npm run build`, which invokes `npm run build:client` and `npm run build:server`, and the builds completed successfully.
- Ran `npm run build:client` and `npm run build:server` individually and both completed with no errors.
- The change is additive and preserves existing copy behavior with fallbacks when the preview endpoint is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92cfbfb588325ba56d260fe69e74c)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
