### PR TITLE
Add affected-slots mini diff to shared week copy-impact preview

### DIFF
--- a/client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx
+++ b/client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx
@@ -57,6 +57,18 @@ type CopyImpactSummary = {
   estimatedSkippedDuplicatesCount: number;
   willReplaceExisting: boolean;
   impactSummary: string;
+  affectedSlots?: Array<{
+    day: string;
+    mealType: string;
+    label: string;
+    addCount: number;
+    skipDuplicateCount: number;
+    replaceCount: number;
+    existingCount: number;
+    incomingCount: number;
+    summary: string;
+  }>;
+  affectedSlotsPreviewCount?: number;
 };
 
 function getWeekStartIso(date: Date) {
@@ -304,10 +316,31 @@ export default function MealPlannerSharedWeekPage() {
                   : impactSummary?.impactSummary || 'Impact preview unavailable right now. Copy still works with your selected mode.'}
               </div>
               {!impactLoading && impactSummary && (
-                <div className="mt-2 text-xs text-muted-foreground">
-                  Target week meals: {impactSummary.targetWeekMealsCount} • Shared meals: {impactSummary.sourceEntriesCount} • Estimated add: {impactSummary.estimatedAddedCount}
-                  {impactSummary.estimatedSkippedDuplicatesCount > 0 ? ` • Estimated skip: ${impactSummary.estimatedSkippedDuplicatesCount}` : ''}
-                </div>
+                <>
+                  <div className="mt-2 text-xs text-muted-foreground">
+                    Target week meals: {impactSummary.targetWeekMealsCount} • Shared meals: {impactSummary.sourceEntriesCount} • Estimated add: {impactSummary.estimatedAddedCount}
+                    {impactSummary.estimatedSkippedDuplicatesCount > 0 ? ` • Estimated skip: ${impactSummary.estimatedSkippedDuplicatesCount}` : ''}
+                  </div>
+                  {Array.isArray(impactSummary.affectedSlots) && impactSummary.affectedSlots.length > 0 && (
+                    <div className="mt-3">
+                      <div className="text-xs font-medium text-foreground">Affected slots (mini diff)</div>
+                      <ul className="mt-1 space-y-1 text-xs text-muted-foreground">
+                        {impactSummary.affectedSlots
+                          .slice(0, impactSummary.affectedSlotsPreviewCount || 12)
+                          .map((slot) => (
+                            <li key={`${slot.label}-${slot.summary}`}>
+                              {slot.label}: {slot.summary}
+                            </li>
+                          ))}
+                      </ul>
+                      {(impactSummary.affectedSlotsPreviewCount || 12) < impactSummary.affectedSlots.length && (
+                        <div className="mt-1 text-[11px] text-muted-foreground">
+                          +{impactSummary.affectedSlots.length - (impactSummary.affectedSlotsPreviewCount || 12)} more affected slots
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </>
               )}
             </div>
           </CardContent>

--- a/server/routes/meal-planner-week.ts
+++ b/server/routes/meal-planner-week.ts
@@ -107,6 +107,38 @@ type SharedWeekSourceEntry = {
   source: string | null;
 };
 
+type CopyImpactAffectedSlot = {
+  day: string;
+  mealType: string;
+  label: string;
+  addCount: number;
+  skipDuplicateCount: number;
+  replaceCount: number;
+  existingCount: number;
+  incomingCount: number;
+  summary: string;
+};
+
+function formatImpactSlotLabel(date: Date | string, mealTypeRaw: string) {
+  const dateValue = startOfDay(new Date(date));
+  const day = dateValue.toLocaleDateString("en-US", { weekday: "short", timeZone: "UTC" });
+  const mealType = String(mealTypeRaw || "meal").trim().toLowerCase();
+  const prettyMealType = mealType ? `${mealType.charAt(0).toUpperCase()}${mealType.slice(1)}` : "Meal";
+  return {
+    day,
+    mealType,
+    label: `${day} ${prettyMealType}`,
+  };
+}
+
+function buildSlotImpactSummary(slot: Omit<CopyImpactAffectedSlot, "summary">): string {
+  if (slot.replaceCount > 0) return `replace ${slot.replaceCount}`;
+  const parts: string[] = [];
+  if (slot.addCount > 0) parts.push(`add ${slot.addCount}`);
+  if (slot.skipDuplicateCount > 0) parts.push(`skip ${slot.skipDuplicateCount} duplicate${slot.skipDuplicateCount === 1 ? "" : "s"}`);
+  return parts.length ? parts.join(", ") : "no change";
+}
+
 function mapSharedEntriesToTargetWeek(args: {
   sourceEntries: SharedWeekSourceEntry[];
   sourceWeekStart: Date;
@@ -1045,20 +1077,82 @@ router.get("/week/shared/:token/copy-impact", requireAuth, async (req: Request, 
     const targetWeekMealsCount = existingTargetEntries.length;
     const willReplaceExisting = copyMode === "replace";
 
+    const slotMap = new Map<string, Omit<CopyImpactAffectedSlot, "summary">>();
+    const getOrCreateSlot = (entry: { date: Date | string; mealType: string }) => {
+      const dateIso = fmtISODate(startOfDay(new Date(entry.date)));
+      const mealType = String(entry.mealType || "").trim().toLowerCase();
+      const key = `${dateIso}|${mealType}`;
+      const existing = slotMap.get(key);
+      if (existing) return existing;
+      const labelParts = formatImpactSlotLabel(entry.date, entry.mealType);
+      const next: Omit<CopyImpactAffectedSlot, "summary"> = {
+        day: labelParts.day,
+        mealType: labelParts.mealType,
+        label: labelParts.label,
+        addCount: 0,
+        skipDuplicateCount: 0,
+        replaceCount: 0,
+        existingCount: 0,
+        incomingCount: 0,
+      };
+      slotMap.set(key, next);
+      return next;
+    };
+
+    for (const entry of existingTargetEntries) {
+      const slot = getOrCreateSlot(entry);
+      slot.existingCount += 1;
+    }
+    for (const entry of mappedEntries) {
+      const slot = getOrCreateSlot(entry);
+      slot.incomingCount += 1;
+    }
+
     let estimatedAddedCount = sourceEntriesCount;
     let estimatedSkippedDuplicatesCount = 0;
     if (copyMode === "skip-duplicates") {
       const existingSignatures = new Set(existingTargetEntries.map((entry) => buildCopyEntrySignature(entry)));
       let additions = 0;
       for (const entry of mappedEntries) {
+        const slot = getOrCreateSlot(entry);
         const signature = buildCopyEntrySignature(entry);
-        if (existingSignatures.has(signature)) continue;
+        if (existingSignatures.has(signature)) {
+          slot.skipDuplicateCount += 1;
+          continue;
+        }
         existingSignatures.add(signature);
+        slot.addCount += 1;
         additions += 1;
       }
       estimatedAddedCount = additions;
       estimatedSkippedDuplicatesCount = Math.max(0, sourceEntriesCount - additions);
+    } else if (copyMode === "append") {
+      for (const entry of mappedEntries) {
+        const slot = getOrCreateSlot(entry);
+        slot.addCount += 1;
+      }
+    } else {
+      for (const entry of mappedEntries) {
+        const slot = getOrCreateSlot(entry);
+        if (slot.existingCount > 0) {
+          slot.replaceCount += 1;
+        } else {
+          slot.addCount += 1;
+        }
+      }
     }
+
+    const affectedSlots = Array.from(slotMap.values())
+      .filter((slot) => slot.addCount > 0 || slot.skipDuplicateCount > 0 || slot.replaceCount > 0)
+      .sort((a, b) => {
+        if (b.replaceCount !== a.replaceCount) return b.replaceCount - a.replaceCount;
+        if (b.skipDuplicateCount !== a.skipDuplicateCount) return b.skipDuplicateCount - a.skipDuplicateCount;
+        return b.addCount - a.addCount;
+      })
+      .map((slot) => ({
+        ...slot,
+        summary: buildSlotImpactSummary(slot),
+      }));
 
     const impactSummary = copyMode === "replace"
       ? `Target week has ${targetWeekMealsCount} meals. Copy will replace that week with ${sourceEntriesCount} meals from this shared plan.`
@@ -1077,6 +1171,8 @@ router.get("/week/shared/:token/copy-impact", requireAuth, async (req: Request, 
       estimatedSkippedDuplicatesCount,
       willReplaceExisting,
       impactSummary,
+      affectedSlots,
+      affectedSlotsPreviewCount: Math.min(12, affectedSlots.length),
     });
   } catch (error) {
     console.error("Error building shared week copy impact:", error);


### PR DESCRIPTION
### Motivation
- Users can see high-level copy totals (add/skip/replace) but not where those changes land in the week, reducing confidence before copying shared plans. 
- Provide a lightweight, additive preview that shows day+meal-slot level signals without introducing a full import wizard or changing storage/import architecture. 
- Preserve existing copy behavior and merge modes while reusing the current mapping/signature logic to remain safe and backward-compatible.

### Description
- Extended the copy-impact API `GET /api/meal-planner/week/shared/:token/copy-impact` to compute and return a compact `affectedSlots` array and `affectedSlotsPreviewCount`, using existing mapped entries and `buildCopyEntrySignature` to detect duplicates. 
- Added `CopyImpactAffectedSlot` model and helpers `formatImpactSlotLabel` and `buildSlotImpactSummary` to produce short labels and summaries like `Tue Dinner: add 1`, `Thu Lunch: skip 1 duplicate`, or `Sat Breakfast: replace 1`. 
- Updated the UI in `MealPlannerSharedWeekPage` to render the mini diff inside the existing Pre-copy impact card, showing up to the preview cap and gracefully doing nothing if `affectedSlots` is not present. 
- All changes are additive and preserve prior fields and behavior (existing `impactSummary`, estimated counts, and copy flow remain unchanged).

### Testing
- Built the project to validate integrations by running `npm run build`, which executed `generate` tasks and sub-builds and completed successfully. 
- Built the client bundle via `npm run build:client` and the server bundle via `npm run build:server`, both completing without errors. 
- Automated build logs show the new UI bundle includes `MealPlannerSharedWeekPage` updates and server compiled `server/routes/meal-planner-week.ts` with the new payload fields.

Files changed: `server/routes/meal-planner-week.ts`, `client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx`.

Slot-level signals now shown: `add N`, `skip N duplicate(s)`, and `replace N` (per day + meal slot), with short labels like `Wed Dinner: add 1`.

Why this was highest-value: it closes the trust gap between totals and where changes land with minimal risk and no UX heavy-lift, improving conversion from inspiration → action.

Suggested next improvement: add a lightweight post-copy reconciliation banner that compares the previewed `affectedSlots` to actual applied results so users can verify what changed after a copy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e94988c1488325a9768fd18ccfeb18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
