### PR TITLE
Add lightweight post-copy reconciliation banner for shared-week imports

### DIFF
--- a/client/src/pages/nutrition/MealPlannerSharedBrowsePage.tsx
+++ b/client/src/pages/nutrition/MealPlannerSharedBrowsePage.tsx
@@ -253,7 +253,7 @@ export default function MealPlannerSharedBrowsePage() {
 
       toast({
         title: 'Plan copied to your planner',
-        description: `Copied ${payload?.copiedEntriesCount ?? 0} meals to your week of ${payload?.targetWeekStart ?? targetWeekStart}${Number(payload?.skippedDuplicatesCount || 0) > 0 ? ` (${payload?.skippedDuplicatesCount} duplicates skipped)` : ''}.`,
+        description: String(payload?.appliedSummary || `Copied ${payload?.copiedEntriesCount ?? 0} meals to your week of ${payload?.targetWeekStart ?? targetWeekStart}${Number(payload?.skippedDuplicatesCount || 0) > 0 ? ` (${payload?.skippedDuplicatesCount} duplicates skipped)` : ''}.`),
       });
     } catch (copyError: any) {
       toast({

--- a/client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx
+++ b/client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx
@@ -70,6 +70,28 @@ type CopyImpactSummary = {
   }>;
   affectedSlotsPreviewCount?: number;
 };
+type CopyAppliedSummary = {
+  mergeMode?: CopyMergeMode;
+  targetWeekStart: string;
+  sourceEntriesCount?: number;
+  copiedEntriesCount: number;
+  skippedDuplicatesCount: number;
+  targetWeekMealsBeforeCount?: number;
+  targetWeekMealsAfterCount?: number;
+  appliedSummary?: string;
+  appliedAffectedSlots?: Array<{
+    day: string;
+    mealType: string;
+    label: string;
+    addCount: number;
+    skipDuplicateCount: number;
+    replaceCount: number;
+    existingCount: number;
+    incomingCount: number;
+    summary: string;
+  }>;
+  appliedAffectedSlotsPreviewCount?: number;
+};
 
 function getWeekStartIso(date: Date) {
   const d = new Date(date);
@@ -101,6 +123,7 @@ export default function MealPlannerSharedWeekPage() {
   const [mergeMode, setMergeMode] = useState<CopyMergeMode>('replace');
   const [impactSummary, setImpactSummary] = useState<CopyImpactSummary | null>(null);
   const [impactLoading, setImpactLoading] = useState(false);
+  const [copyAppliedSummary, setCopyAppliedSummary] = useState<CopyAppliedSummary | null>(null);
 
   const fetchCopyImpactSummary = async (opts?: { silent?: boolean; targetWeek?: string; mode?: CopyMergeMode }) => {
     if (!token || !user) return null;
@@ -213,6 +236,18 @@ export default function MealPlannerSharedWeekPage() {
 
       const skipped = Number(payload?.skippedDuplicatesCount || 0);
       const summary = `Copied ${payload?.copiedEntriesCount ?? 0} meals to your week of ${payload?.targetWeekStart ?? targetWeekStart}${skipped > 0 ? ` (${skipped} duplicates skipped)` : ''}.`;
+      setCopyAppliedSummary({
+        mergeMode: payload?.mergeMode || mergeMode,
+        targetWeekStart: payload?.targetWeekStart ?? targetWeekStart,
+        sourceEntriesCount: Number(payload?.sourceEntriesCount || 0),
+        copiedEntriesCount: Number(payload?.copiedEntriesCount || 0),
+        skippedDuplicatesCount: skipped,
+        targetWeekMealsBeforeCount: Number(payload?.targetWeekMealsBeforeCount || 0),
+        targetWeekMealsAfterCount: Number(payload?.targetWeekMealsAfterCount || 0),
+        appliedSummary: String(payload?.appliedSummary || ''),
+        appliedAffectedSlots: Array.isArray(payload?.appliedAffectedSlots) ? payload.appliedAffectedSlots : [],
+        appliedAffectedSlotsPreviewCount: Number(payload?.appliedAffectedSlotsPreviewCount || 12),
+      });
       setCopySummary(summary);
       toast({ title: 'Week copied to your planner', description: summary });
     } catch (copyError: any) {
@@ -352,6 +387,36 @@ export default function MealPlannerSharedWeekPage() {
           <CardContent className="p-4 text-sm">
             <div className="font-medium">Saved to your planner</div>
             <div className="text-muted-foreground">{copySummary}</div>
+            {copyAppliedSummary && (
+              <div className="mt-3 rounded-md border bg-muted/40 p-3">
+                <div className="font-medium">Post-copy reconciliation</div>
+                <div className="mt-1 text-muted-foreground">
+                  {copyAppliedSummary.appliedSummary || `Applied ${copyAppliedSummary.copiedEntriesCount} imported meals.`}
+                </div>
+                <div className="mt-2 text-xs text-muted-foreground">
+                  Week {copyAppliedSummary.targetWeekStart}
+                  {typeof copyAppliedSummary.targetWeekMealsBeforeCount === 'number' ? ` • Before: ${copyAppliedSummary.targetWeekMealsBeforeCount}` : ''}
+                  {typeof copyAppliedSummary.targetWeekMealsAfterCount === 'number' ? ` • After: ${copyAppliedSummary.targetWeekMealsAfterCount}` : ''}
+                  {copyAppliedSummary.sourceEntriesCount ? ` • Incoming: ${copyAppliedSummary.sourceEntriesCount}` : ''}
+                  {' • Added: '} {copyAppliedSummary.copiedEntriesCount}
+                  {copyAppliedSummary.skippedDuplicatesCount > 0 ? ` • Duplicates skipped: ${copyAppliedSummary.skippedDuplicatesCount}` : ''}
+                </div>
+                {Array.isArray(copyAppliedSummary.appliedAffectedSlots) && copyAppliedSummary.appliedAffectedSlots.length > 0 && (
+                  <div className="mt-2">
+                    <div className="text-xs font-medium text-foreground">Applied slot deltas</div>
+                    <ul className="mt-1 space-y-1 text-xs text-muted-foreground">
+                      {copyAppliedSummary.appliedAffectedSlots
+                        .slice(0, copyAppliedSummary.appliedAffectedSlotsPreviewCount || 12)
+                        .map((slot) => (
+                          <li key={`${slot.label}-${slot.summary}`}>
+                            {slot.label}: {slot.summary}
+                          </li>
+                        ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            )}
             <Button asChild size="sm" className="mt-3">
               <a href="/nutrition">Open My Planner</a>
             </Button>

--- a/server/routes/meal-planner-week.ts
+++ b/server/routes/meal-planner-week.ts
@@ -119,6 +119,49 @@ type CopyImpactAffectedSlot = {
   summary: string;
 };
 
+function createImpactSlotTracker() {
+  const slotMap = new Map<string, Omit<CopyImpactAffectedSlot, "summary">>();
+  const getOrCreateSlot = (entry: { date: Date | string; mealType: string }) => {
+    const dateIso = fmtISODate(startOfDay(new Date(entry.date)));
+    const mealType = String(entry.mealType || "").trim().toLowerCase();
+    const key = `${dateIso}|${mealType}`;
+    const existing = slotMap.get(key);
+    if (existing) return existing;
+    const labelParts = formatImpactSlotLabel(entry.date, entry.mealType);
+    const next: Omit<CopyImpactAffectedSlot, "summary"> = {
+      day: labelParts.day,
+      mealType: labelParts.mealType,
+      label: labelParts.label,
+      addCount: 0,
+      skipDuplicateCount: 0,
+      replaceCount: 0,
+      existingCount: 0,
+      incomingCount: 0,
+    };
+    slotMap.set(key, next);
+    return next;
+  };
+
+  return {
+    slotMap,
+    getOrCreateSlot,
+  };
+}
+
+function finalizeAffectedSlots(slotMap: Map<string, Omit<CopyImpactAffectedSlot, "summary">>) {
+  return Array.from(slotMap.values())
+    .filter((slot) => slot.addCount > 0 || slot.skipDuplicateCount > 0 || slot.replaceCount > 0)
+    .sort((a, b) => {
+      if (b.replaceCount !== a.replaceCount) return b.replaceCount - a.replaceCount;
+      if (b.skipDuplicateCount !== a.skipDuplicateCount) return b.skipDuplicateCount - a.skipDuplicateCount;
+      return b.addCount - a.addCount;
+    })
+    .map((slot) => ({
+      ...slot,
+      summary: buildSlotImpactSummary(slot),
+    }));
+}
+
 function formatImpactSlotLabel(date: Date | string, mealTypeRaw: string) {
   const dateValue = startOfDay(new Date(date));
   const day = dateValue.toLocaleDateString("en-US", { weekday: "short", timeZone: "UTC" });
@@ -865,11 +908,27 @@ router.post("/week/shared/:token/copy", requireAuth, async (req: Request, res: R
           eq(mealPlans.isTemplate, false)
         )
       );
+    const existingTargetPlanIds = existingTargetPlans.map((plan) => plan.id);
+    const existingTargetEntriesForWeek = existingTargetPlanIds.length
+      ? await db
+          .select({
+            date: mealPlanEntries.date,
+            mealType: mealPlanEntries.mealType,
+            recipeId: mealPlanEntries.recipeId,
+            customName: mealPlanEntries.customName,
+            customCalories: mealPlanEntries.customCalories,
+            customProtein: mealPlanEntries.customProtein,
+            customCarbs: mealPlanEntries.customCarbs,
+            customFat: mealPlanEntries.customFat,
+          })
+          .from(mealPlanEntries)
+          .where(inArray(mealPlanEntries.mealPlanId, existingTargetPlanIds))
+      : [];
+    const targetWeekMealsBeforeCount = existingTargetEntriesForWeek.length;
 
     if (replaceExisting && existingTargetPlans.length) {
-      const existingIds = existingTargetPlans.map((plan) => plan.id);
-      await db.delete(mealPlanEntries).where(inArray(mealPlanEntries.mealPlanId, existingIds));
-      await db.delete(mealPlans).where(inArray(mealPlans.id, existingIds));
+      await db.delete(mealPlanEntries).where(inArray(mealPlanEntries.mealPlanId, existingTargetPlanIds));
+      await db.delete(mealPlans).where(inArray(mealPlans.id, existingTargetPlanIds));
     }
 
     let targetPlanId: string | null = null;
@@ -912,15 +971,46 @@ router.post("/week/shared/:token/copy", requireAuth, async (req: Request, res: R
           .from(mealPlanEntries)
           .where(eq(mealPlanEntries.mealPlanId, targetPlanId));
 
+    const slotTracker = createImpactSlotTracker();
+    const slotBaselineEntries = replaceExisting ? existingTargetEntriesForWeek : existingTargetEntries;
+    for (const entry of slotBaselineEntries) {
+      const slot = slotTracker.getOrCreateSlot(entry);
+      slot.existingCount += 1;
+    }
+    for (const entry of mappedEntries) {
+      const slot = slotTracker.getOrCreateSlot(entry);
+      slot.incomingCount += 1;
+    }
+
     const existingSignatures = new Set(existingTargetEntries.map((entry) => buildCopyEntrySignature(entry)));
     const entriesToInsert = copyMode === "skip-duplicates"
       ? mappedEntries.filter((entry) => {
           const signature = buildCopyEntrySignature(entry);
-          if (existingSignatures.has(signature)) return false;
+          const slot = slotTracker.getOrCreateSlot(entry);
+          if (existingSignatures.has(signature)) {
+            slot.skipDuplicateCount += 1;
+            return false;
+          }
           existingSignatures.add(signature);
+          slot.addCount += 1;
           return true;
         })
       : mappedEntries;
+    if (copyMode === "append") {
+      for (const entry of mappedEntries) {
+        const slot = slotTracker.getOrCreateSlot(entry);
+        slot.addCount += 1;
+      }
+    } else if (copyMode === "replace") {
+      for (const entry of mappedEntries) {
+        const slot = slotTracker.getOrCreateSlot(entry);
+        if (slot.existingCount > 0) {
+          slot.replaceCount += 1;
+        } else {
+          slot.addCount += 1;
+        }
+      }
+    }
 
     if (entriesToInsert.length > 0) {
       await db.insert(mealPlanEntries).values(entriesToInsert);
@@ -946,15 +1036,28 @@ router.post("/week/shared/:token/copy", requireAuth, async (req: Request, res: R
       .leftJoin(recipes, eq(mealPlanEntries.recipeId, recipes.id))
       .where(eq(mealPlanEntries.mealPlanId, targetPlanId))
       .orderBy(mealPlanEntries.date);
+    const targetWeekMealsAfterCount = copiedEntries.length;
+    const skippedDuplicatesCount = Math.max(0, mappedEntries.length - entriesToInsert.length);
+    const appliedAffectedSlots = finalizeAffectedSlots(slotTracker.slotMap);
+    const appliedSummary = copyMode === "replace"
+      ? `Replaced ${targetWeekMealsBeforeCount} existing meals with ${entriesToInsert.length} imported meals.`
+      : copyMode === "append"
+        ? `Added ${entriesToInsert.length} meals to ${targetWeekMealsBeforeCount} existing meals.`
+        : `Added ${entriesToInsert.length} meals and skipped ${skippedDuplicatesCount} duplicates.`;
 
     res.json({
       ok: true,
       copiedEntriesCount: entriesToInsert.length,
       sourceEntriesCount: sourceEntries.length,
-      skippedDuplicatesCount: Math.max(0, mappedEntries.length - entriesToInsert.length),
+      skippedDuplicatesCount,
       mergeMode: copyMode,
       targetWeekStart: fmtISODate(targetWeekStart),
       targetWeekEnd: fmtISODate(targetWeekEnd),
+      targetWeekMealsBeforeCount,
+      targetWeekMealsAfterCount,
+      appliedSummary,
+      appliedAffectedSlots,
+      appliedAffectedSlotsPreviewCount: Math.min(12, appliedAffectedSlots.length),
       weeklyMeals: mapEntriesToWeeklyMeals(copiedEntries),
     });
   } catch (error) {
@@ -1077,34 +1180,14 @@ router.get("/week/shared/:token/copy-impact", requireAuth, async (req: Request, 
     const targetWeekMealsCount = existingTargetEntries.length;
     const willReplaceExisting = copyMode === "replace";
 
-    const slotMap = new Map<string, Omit<CopyImpactAffectedSlot, "summary">>();
-    const getOrCreateSlot = (entry: { date: Date | string; mealType: string }) => {
-      const dateIso = fmtISODate(startOfDay(new Date(entry.date)));
-      const mealType = String(entry.mealType || "").trim().toLowerCase();
-      const key = `${dateIso}|${mealType}`;
-      const existing = slotMap.get(key);
-      if (existing) return existing;
-      const labelParts = formatImpactSlotLabel(entry.date, entry.mealType);
-      const next: Omit<CopyImpactAffectedSlot, "summary"> = {
-        day: labelParts.day,
-        mealType: labelParts.mealType,
-        label: labelParts.label,
-        addCount: 0,
-        skipDuplicateCount: 0,
-        replaceCount: 0,
-        existingCount: 0,
-        incomingCount: 0,
-      };
-      slotMap.set(key, next);
-      return next;
-    };
+    const slotTracker = createImpactSlotTracker();
 
     for (const entry of existingTargetEntries) {
-      const slot = getOrCreateSlot(entry);
+      const slot = slotTracker.getOrCreateSlot(entry);
       slot.existingCount += 1;
     }
     for (const entry of mappedEntries) {
-      const slot = getOrCreateSlot(entry);
+      const slot = slotTracker.getOrCreateSlot(entry);
       slot.incomingCount += 1;
     }
 
@@ -1114,7 +1197,7 @@ router.get("/week/shared/:token/copy-impact", requireAuth, async (req: Request, 
       const existingSignatures = new Set(existingTargetEntries.map((entry) => buildCopyEntrySignature(entry)));
       let additions = 0;
       for (const entry of mappedEntries) {
-        const slot = getOrCreateSlot(entry);
+        const slot = slotTracker.getOrCreateSlot(entry);
         const signature = buildCopyEntrySignature(entry);
         if (existingSignatures.has(signature)) {
           slot.skipDuplicateCount += 1;
@@ -1128,12 +1211,12 @@ router.get("/week/shared/:token/copy-impact", requireAuth, async (req: Request, 
       estimatedSkippedDuplicatesCount = Math.max(0, sourceEntriesCount - additions);
     } else if (copyMode === "append") {
       for (const entry of mappedEntries) {
-        const slot = getOrCreateSlot(entry);
+        const slot = slotTracker.getOrCreateSlot(entry);
         slot.addCount += 1;
       }
     } else {
       for (const entry of mappedEntries) {
-        const slot = getOrCreateSlot(entry);
+        const slot = slotTracker.getOrCreateSlot(entry);
         if (slot.existingCount > 0) {
           slot.replaceCount += 1;
         } else {
@@ -1142,17 +1225,7 @@ router.get("/week/shared/:token/copy-impact", requireAuth, async (req: Request, 
       }
     }
 
-    const affectedSlots = Array.from(slotMap.values())
-      .filter((slot) => slot.addCount > 0 || slot.skipDuplicateCount > 0 || slot.replaceCount > 0)
-      .sort((a, b) => {
-        if (b.replaceCount !== a.replaceCount) return b.replaceCount - a.replaceCount;
-        if (b.skipDuplicateCount !== a.skipDuplicateCount) return b.skipDuplicateCount - a.skipDuplicateCount;
-        return b.addCount - a.addCount;
-      })
-      .map((slot) => ({
-        ...slot,
-        summary: buildSlotImpactSummary(slot),
-      }));
+    const affectedSlots = finalizeAffectedSlots(slotTracker.slotMap);
 
     const impactSummary = copyMode === "replace"
       ? `Target week has ${targetWeekMealsCount} meals. Copy will replace that week with ${sourceEntriesCount} meals from this shared plan.`


### PR DESCRIPTION
### Motivation
- Users could preview an import but lacked clear confirmation of what was actually applied after copying a shared week, which reduced trust for `append`/`skip-duplicates` modes.  
- Deliver a lightweight, additive improvement that surfaces actual applied results without changing storage/import architecture or creating a heavy wizard.  
- Reuse existing impact/slot-diff logic so pre-copy intent and post-copy applied deltas stay aligned.

### Description
- Server: added `createImpactSlotTracker` and `finalizeAffectedSlots` helpers and extended `POST /api/meal-planner/week/shared/:token/copy` to compute and return applied-result signals: `targetWeekMealsBeforeCount`, `targetWeekMealsAfterCount`, `appliedSummary`, `appliedAffectedSlots`, and `appliedAffectedSlotsPreviewCount`, while preserving existing fields like `copiedEntriesCount` and `skippedDuplicatesCount` (file: `server/routes/meal-planner-week.ts`).
- Server: reused the same slot-impact pattern in the pre-copy endpoint so the pre-copy `copy-impact` and post-copy applied slot deltas remain consistent (file: `server/routes/meal-planner-week.ts`).
- Client: `MealPlannerSharedWeekPage` now stores a `CopyAppliedSummary` and renders a lightweight post-copy reconciliation banner/card after a successful import showing the `appliedSummary`, before/after counts, incoming/added/skipped counts, and a compact list of applied slot deltas with graceful fallback for older response shapes (file: `client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx`).
- Client: `MealPlannerSharedBrowsePage` success toast prefers server-provided `appliedSummary` when available while maintaining backwards-compatible fallback text (file: `client/src/pages/nutrition/MealPlannerSharedBrowsePage.tsx`).

### Testing
- Ran `npm run build` which completed successfully.  
- Ran `npm run build:client` which completed successfully (Vite produced informational chunk-size warnings).  
- Ran `npm run build:server` which completed successfully.  
All automated builds succeeded; no new automated unit/integration tests were added for this lightweight UI/response enhancement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9501c81148325aa30f9fe8034e684)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
