### PR TITLE
Add lightweight template-application bridge after shared-week import

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -164,6 +164,12 @@ type BlockerItemSuggestion = {
 
 type MealPlanVisibility = 'private' | 'friends' | 'public';
 type ShareMetadataSaveState = 'idle' | 'saving' | 'saved' | 'error';
+type TemplateBridgePayload = {
+  templateName: string;
+  targetWeekStart?: string;
+  source?: string;
+  requestedAt?: string;
+};
 
 const NutritionMealPlanner = () => {
   const { user, updateUser } = useUser();
@@ -205,6 +211,7 @@ const NutritionMealPlanner = () => {
   const [sharePublicToken, setSharePublicToken] = useState<string | null>(null);
   const [shareMetadataLoaded, setShareMetadataLoaded] = useState(false);
   const [shareMetadataSaveState, setShareMetadataSaveState] = useState<ShareMetadataSaveState>('idle');
+  const [templateBridgeRequest, setTemplateBridgeRequest] = useState<TemplateBridgePayload | null>(null);
 
   // Add Meal modal — controlled fields
   const [mealForm, setMealForm] = useState(INITIAL_MEAL_FORM);
@@ -237,6 +244,27 @@ const NutritionMealPlanner = () => {
       fetchWater();
     }
   }, [selectedDate, isPremium, user]);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem('meal-planner-template-bridge-v1');
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed.templateName !== 'string' || !parsed.templateName.trim()) {
+        localStorage.removeItem('meal-planner-template-bridge-v1');
+        return;
+      }
+      setTemplateBridgeRequest({
+        templateName: parsed.templateName.trim(),
+        targetWeekStart: typeof parsed.targetWeekStart === 'string' ? parsed.targetWeekStart : undefined,
+        source: typeof parsed.source === 'string' ? parsed.source : undefined,
+        requestedAt: typeof parsed.requestedAt === 'string' ? parsed.requestedAt : undefined,
+      });
+    } catch (error) {
+      console.error('Error loading template bridge request:', error);
+      localStorage.removeItem('meal-planner-template-bridge-v1');
+    }
+  }, []);
 
   useEffect(() => {
     if (isPremium) {
@@ -1049,6 +1077,44 @@ const NutritionMealPlanner = () => {
       setShowLoadTemplateModal(false);
     }
   };
+
+  useEffect(() => {
+    if (!templateBridgeRequest || loading || !isPremium) return;
+
+    const targetWeek = templateBridgeRequest.targetWeekStart?.trim();
+    if (targetWeek && targetWeek !== selectedDate) {
+      setSelectedDate(targetWeek);
+      return;
+    }
+
+    const saved = localStorage.getItem(`meal-template-${templateBridgeRequest.templateName}`);
+    if (!saved) {
+      toast({
+        variant: 'destructive',
+        description: `Template "${templateBridgeRequest.templateName}" was not found. Save it again and retry.`,
+      });
+      localStorage.removeItem('meal-planner-template-bridge-v1');
+      setTemplateBridgeRequest(null);
+      return;
+    }
+
+    try {
+      setWeeklyMeals(JSON.parse(saved));
+      toast({
+        title: 'Template applied',
+        description: `Loaded "${templateBridgeRequest.templateName}" into week ${targetWeek || selectedDate}.`,
+      });
+    } catch (error) {
+      console.error('Error applying bridged template:', error);
+      toast({
+        variant: 'destructive',
+        description: `Unable to apply "${templateBridgeRequest.templateName}".`,
+      });
+    } finally {
+      localStorage.removeItem('meal-planner-template-bridge-v1');
+      setTemplateBridgeRequest(null);
+    }
+  }, [templateBridgeRequest, loading, isPremium, selectedDate]);
 
   const handleAIRecipe = () => {
     setShowAIRecipeModal(true);

--- a/client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx
+++ b/client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx
@@ -102,6 +102,13 @@ function getWeekStartIso(date: Date) {
   return d.toISOString().split('T')[0];
 }
 
+function getNextWeekStartIso(weekStartIso: string) {
+  const parsed = new Date(`${weekStartIso}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) return getWeekStartIso(new Date(Date.now() + 7 * 24 * 60 * 60 * 1000));
+  parsed.setDate(parsed.getDate() + 7);
+  return getWeekStartIso(parsed);
+}
+
 function modePreview(mode: CopyMergeMode) {
   if (mode === 'append') return 'Append mode keeps your current meals and adds all copied meals into this week.';
   if (mode === 'skip-duplicates') return 'Merge safely mode keeps your current meals and skips copied meals that look like duplicates in the same day + meal slot.';
@@ -126,6 +133,7 @@ export default function MealPlannerSharedWeekPage() {
   const [copyAppliedSummary, setCopyAppliedSummary] = useState<CopyAppliedSummary | null>(null);
   const [templateNameDraft, setTemplateNameDraft] = useState('');
   const [templateSavedName, setTemplateSavedName] = useState<string | null>(null);
+  const [templateBridgeTargetWeekStart, setTemplateBridgeTargetWeekStart] = useState(() => getWeekStartIso(new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)));
 
   const fetchCopyImpactSummary = async (opts?: { silent?: boolean; targetWeek?: string; mode?: CopyMergeMode }) => {
     if (!token || !user) return null;
@@ -254,6 +262,7 @@ export default function MealPlannerSharedWeekPage() {
       const defaultTemplateName = `Imported week ${payload?.targetWeekStart ?? targetWeekStart}`;
       setTemplateNameDraft(defaultTemplateName);
       setTemplateSavedName(null);
+      setTemplateBridgeTargetWeekStart(getNextWeekStartIso(payload?.targetWeekStart ?? targetWeekStart));
       toast({ title: 'Week copied to your planner', description: summary });
     } catch (copyError: any) {
       toast({
@@ -292,6 +301,34 @@ export default function MealPlannerSharedWeekPage() {
         variant: 'destructive',
         title: 'Unable to save template',
         description: 'Please try again.',
+      });
+    }
+  };
+
+  const handleUseSavedTemplateOnAnotherWeek = () => {
+    if (!templateSavedName) return;
+
+    const normalizedTargetWeek = templateBridgeTargetWeekStart || getWeekStartIso(new Date(Date.now() + 7 * 24 * 60 * 60 * 1000));
+    const bridgePayload = {
+      templateName: templateSavedName,
+      targetWeekStart: normalizedTargetWeek,
+      requestedAt: new Date().toISOString(),
+      source: 'shared-week-import-success',
+    };
+
+    try {
+      localStorage.setItem('meal-planner-template-bridge-v1', JSON.stringify(bridgePayload));
+      toast({
+        title: 'Template ready to apply',
+        description: `Opening your planner to apply "${templateSavedName}" to week ${normalizedTargetWeek}.`,
+      });
+      window.location.href = '/nutrition';
+    } catch (error) {
+      console.error('Error preparing template bridge handoff:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Unable to open template bridge',
+        description: 'Please open your planner and load the template manually.',
       });
     }
   };
@@ -470,8 +507,25 @@ export default function MealPlannerSharedWeekPage() {
                 </Button>
               </div>
               {templateSavedName && (
-                <div className="mt-2 text-xs text-emerald-600">
-                  Saved as "{templateSavedName}".
+                <div className="mt-3 rounded-md border bg-emerald-50/60 p-3">
+                  <div className="text-xs font-medium text-emerald-700">Saved as "{templateSavedName}".</div>
+                  <div className="mt-1 text-xs text-emerald-700/90">
+                    Use it right away on another week without browsing away first.
+                  </div>
+                  <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-end">
+                    <label className="space-y-1 text-xs">
+                      <div className="font-medium text-foreground">Apply template to week (Monday)</div>
+                      <input
+                        type="date"
+                        value={templateBridgeTargetWeekStart}
+                        onChange={(event) => setTemplateBridgeTargetWeekStart(event.target.value || getWeekStartIso(new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)))}
+                        className="w-full rounded-md border bg-background px-3 py-2 text-sm sm:w-56"
+                      />
+                    </label>
+                    <Button size="sm" onClick={handleUseSavedTemplateOnAnotherWeek}>
+                      Use This Template on Another Week
+                    </Button>
+                  </div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
### Motivation
- Close the continuity gap after importing a shared week so users can save the import as a template and immediately apply it to another week without manual navigation.  
- Keep the change additive, low-risk, and focused on meal-planning UX by reusing existing local template storage rather than introducing a new template system.  

### Description
- Add a small post-save UI on `MealPlannerSharedWeekPage` with a target-week date picker and a CTA `Use This Template on Another Week` that appears after saving an imported week as a template.  
- Implement a one-time handoff payload saved to `localStorage` under the key `meal-planner-template-bridge-v1` containing `{ templateName, targetWeekStart, source, requestedAt }`.  
- Add `getNextWeekStartIso` helper and state `templateBridgeTargetWeekStart` to default the bridge target to the next Monday after the copied week.  
- Update `NutritionMealPlanner` to detect and validate the bridge payload on mount, optionally navigate to the requested week via `setSelectedDate`, load the existing `meal-template-${templateName}` into `weeklyMeals`, show a toast, and clear the bridge key.  
- Preserve existing behavior and storage format: templates still use `localStorage` keys `meal-template-${name}` and the existing `loadTemplate`/`setWeeklyMeals` logic is reused.  
- Files changed: `client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx`, `client/src/components/NutritionMealPlanner.tsx`.  

### Testing
- Built the project with `npm run build` and the command completed successfully (non-blocking Vite/size warnings observed).  
- Verified client build via `npm run build:client` completed successfully.  
- Verified server build via `npm run build:server` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb8030e3988325a972261abac6ed1f)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
