### PR TITLE
Add lightweight template impact preview to meal planner Load Template modal

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -3130,6 +3130,7 @@ const NutritionMealPlanner = () => {
           open={showLoadTemplateModal}
           onClose={() => setShowLoadTemplateModal(false)}
           onLoadTemplate={loadTemplate}
+          currentWeeklyMeals={weeklyMeals}
         />
 
         <AddGroceryItemModal

--- a/client/src/components/meal-planner/modals/LoadTemplateModal.tsx
+++ b/client/src/components/meal-planner/modals/LoadTemplateModal.tsx
@@ -6,9 +6,94 @@ type LoadTemplateModalProps = {
   open: boolean;
   onClose: () => void;
   onLoadTemplate: (templateName: string) => void;
+  currentWeeklyMeals: Record<string, any>;
 };
 
-const LoadTemplateModal = ({ open, onClose, onLoadTemplate }: LoadTemplateModalProps) => {
+type TemplateImpactSummary = {
+  filledSlots: number;
+  overwriteSlots: number;
+  noChangeSlots: number;
+  templateMealItems: number;
+};
+
+const MEAL_TYPES = ['breakfast', 'lunch', 'dinner', 'snack'];
+const WEEK_DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+
+const toItems = (value: any): any[] => {
+  if (!value) return [];
+  return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);
+};
+
+const buildImpactSummary = (currentWeek: Record<string, any>, templateWeek: Record<string, any>): TemplateImpactSummary => {
+  let filledSlots = 0;
+  let overwriteSlots = 0;
+  let noChangeSlots = 0;
+  let templateMealItems = 0;
+
+  for (const day of WEEK_DAYS) {
+    for (const mealType of MEAL_TYPES) {
+      const currentItems = toItems(currentWeek?.[day]?.[mealType]);
+      const templateItems = toItems(templateWeek?.[day]?.[mealType]);
+      if (templateItems.length === 0) continue;
+
+      templateMealItems += templateItems.length;
+      filledSlots += 1;
+      if (currentItems.length === 0) {
+        continue;
+      }
+
+      const currentSerialized = JSON.stringify(currentItems);
+      const templateSerialized = JSON.stringify(templateItems);
+      if (currentSerialized === templateSerialized) {
+        noChangeSlots += 1;
+      } else {
+        overwriteSlots += 1;
+      }
+    }
+  }
+
+  return { filledSlots, overwriteSlots, noChangeSlots, templateMealItems };
+};
+
+const LoadTemplateModal = ({ open, onClose, onLoadTemplate, currentWeeklyMeals }: LoadTemplateModalProps) => {
+  const [selectedTemplate, setSelectedTemplate] = React.useState<string | null>(null);
+
+  const templates = React.useMemo(() => {
+    const savedTemplates: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key?.startsWith('meal-template-')) {
+        savedTemplates.push(key.replace('meal-template-', ''));
+      }
+    }
+    return savedTemplates.sort((a, b) => a.localeCompare(b));
+  }, [open]);
+
+  const impactPreview = React.useMemo(() => {
+    if (!selectedTemplate) return null;
+    try {
+      const templateRaw = localStorage.getItem(`meal-template-${selectedTemplate}`);
+      if (!templateRaw) return null;
+
+      const templateWeek = JSON.parse(templateRaw);
+      return buildImpactSummary(currentWeeklyMeals, templateWeek);
+    } catch {
+      return null;
+    }
+  }, [selectedTemplate, open, currentWeeklyMeals]);
+
+  React.useEffect(() => {
+    if (!open) {
+      setSelectedTemplate(null);
+      return;
+    }
+    if (templates.length > 0) {
+      setSelectedTemplate((prev) => (prev && templates.includes(prev) ? prev : templates[0]));
+    } else {
+      setSelectedTemplate(null);
+    }
+  }, [open, templates]);
+
   if (!open) return null;
 
   return (
@@ -25,39 +110,49 @@ const LoadTemplateModal = ({ open, onClose, onLoadTemplate }: LoadTemplateModalP
         <p className="text-gray-600 mb-6">Select a saved meal plan template to load:</p>
 
         <div className="space-y-3">
-          {(() => {
-            const templates = [];
-            for (let i = 0; i < localStorage.length; i++) {
-              const key = localStorage.key(i);
-              if (key?.startsWith('meal-template-')) {
-                templates.push(key.replace('meal-template-', ''));
-              }
-            }
+          {templates.length === 0 ? (
+            <div className="text-center py-8 text-gray-500">
+              <Save className="w-12 h-12 mx-auto mb-3 opacity-50" />
+              <p>No saved templates yet</p>
+              <p className="text-sm mt-1">Create a meal plan and click "Save Template" to save it</p>
+            </div>
+          ) : (
+            <>
+              {templates.map((templateName) => {
+                const isSelected = selectedTemplate === templateName;
+                return (
+                  <div
+                    key={templateName}
+                    className={`p-4 border rounded-lg cursor-pointer flex items-center justify-between ${isSelected ? 'border-blue-400 bg-blue-50' : 'hover:bg-gray-50'}`}
+                    onClick={() => setSelectedTemplate(templateName)}
+                  >
+                    <div>
+                      <h4 className="font-medium">{templateName}</h4>
+                      <p className="text-xs text-gray-500">{isSelected ? 'Selected for preview' : 'Click to preview impact'}</p>
+                    </div>
+                    <Button size="sm" variant={isSelected ? 'default' : 'outline'} onClick={(event) => {
+                      event.stopPropagation();
+                      onLoadTemplate(templateName);
+                    }}>
+                      Apply
+                    </Button>
+                  </div>
+                );
+              })}
 
-            if (templates.length === 0) {
-              return (
-                <div className="text-center py-8 text-gray-500">
-                  <Save className="w-12 h-12 mx-auto mb-3 opacity-50" />
-                  <p>No saved templates yet</p>
-                  <p className="text-sm mt-1">Create a meal plan and click "Save Template" to save it</p>
+              {selectedTemplate && impactPreview && (
+                <div className="rounded-lg border bg-gray-50 p-3">
+                  <p className="text-sm font-medium text-gray-900">Impact preview for "{selectedTemplate}"</p>
+                  <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-gray-600">
+                    <div>Filled slots: <span className="font-semibold text-gray-900">{impactPreview.filledSlots}</span></div>
+                    <div>Total meals: <span className="font-semibold text-gray-900">{impactPreview.templateMealItems}</span></div>
+                    <div>Will overwrite: <span className="font-semibold text-amber-700">{impactPreview.overwriteSlots}</span></div>
+                    <div>Unchanged slots: <span className="font-semibold text-emerald-700">{impactPreview.noChangeSlots}</span></div>
+                  </div>
                 </div>
-              );
-            }
-
-            return templates.map((templateName) => (
-              <div
-                key={templateName}
-                className="p-4 border rounded-lg hover:bg-gray-50 cursor-pointer flex items-center justify-between"
-                onClick={() => onLoadTemplate(templateName)}
-              >
-                <div>
-                  <h4 className="font-medium">{templateName}</h4>
-                  <p className="text-xs text-gray-500">Click to load</p>
-                </div>
-                <Button size="sm">Load</Button>
-              </div>
-            ));
-          })()}
+              )}
+            </>
+          )}
         </div>
 
         <Button variant="outline" className="w-full mt-6" onClick={onClose}>


### PR DESCRIPTION
### Motivation
- Provide users a quick, non-destructive preview of what will change before applying a saved meal-plan template to their planner week.
- Make the preview accurate by using the planner's current in-memory week state rather than stale localStorage values.

### Description
- Added a lightweight impact calculator (`buildImpactSummary`, `toItems`, constants for days/meal types) that computes filled slots, overwrite slots, unchanged slots, and total template meals. Changes live in `client/src/components/meal-planner/modals/LoadTemplateModal.tsx`.
- Updated the `LoadTemplateModal` UI to support selecting a template for preview, highlight the selected template, and keep `Apply` as an explicit per-template action.
- Wired the planner's current `weeklyMeals` into the modal via a new `currentWeeklyMeals` prop so the preview reflects the live planner state; this prop is passed from `client/src/components/NutritionMealPlanner.tsx`.
- All changes are additive and preserve the existing apply behavior (no automatic overwrites or implicit applies).

### Testing
- Ran the type check with `npm run check`; the command executed but the repository currently shows many pre-existing TypeScript errors unrelated to this change, so the check is not green and failures are from unrelated files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb85d120ac8325a3294c48a395bdf2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
