### PR TITLE
Add lightweight replace/append merge modes for meal templates

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -164,14 +164,18 @@ type BlockerItemSuggestion = {
 
 type MealPlanVisibility = 'private' | 'friends' | 'public';
 type ShareMetadataSaveState = 'idle' | 'saving' | 'saved' | 'error';
+type TemplateMergeMode = 'replace' | 'append';
+
 type TemplateBridgePayload = {
   templateName: string;
   targetWeekStart?: string;
   source?: string;
   requestedAt?: string;
+  mergeMode?: TemplateMergeMode;
 };
 type PendingTemplateBridgePreview = TemplateBridgePayload & {
   templateMeals: Record<string, any>;
+  mergeMode: TemplateMergeMode;
 };
 
 const NutritionMealPlanner = () => {
@@ -248,6 +252,58 @@ const NutritionMealPlanner = () => {
     }, 0);
   };
 
+  const toMealItems = (value: any): any[] => {
+    if (!value) return [];
+    return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);
+  };
+
+  const applyTemplateMeals = (
+    currentWeek: Record<string, any>,
+    templateWeek: Record<string, any>,
+    mergeMode: TemplateMergeMode,
+  ) => {
+    if (mergeMode === 'replace') {
+      return templateWeek && typeof templateWeek === 'object' ? templateWeek : currentWeek;
+    }
+
+    const mergedWeek: Record<string, any> = { ...currentWeek };
+    for (const day of WEEK_DAYS) {
+      const currentDayMeals = currentWeek?.[day] && typeof currentWeek[day] === 'object' ? currentWeek[day] : {};
+      const nextDayMeals: Record<string, any> = { ...currentDayMeals };
+
+      for (const mealType of MEAL_TYPES) {
+        const currentItems = toMealItems(currentDayMeals?.[mealType]);
+        if (currentItems.length > 0) continue;
+
+        const templateItems = toMealItems(templateWeek?.[day]?.[mealType]);
+        if (templateItems.length === 0) continue;
+
+        nextDayMeals[mealType] = Array.isArray(templateWeek?.[day]?.[mealType])
+          ? templateItems
+          : templateItems[0];
+      }
+
+      if (Object.keys(nextDayMeals).length > 0) {
+        mergedWeek[day] = nextDayMeals;
+      }
+    }
+
+    return mergedWeek;
+  };
+
+  const estimateAppendAddedMeals = (currentWeek: Record<string, any>, templateWeek: Record<string, any>) => {
+    let addedMeals = 0;
+    for (const day of WEEK_DAYS) {
+      for (const mealType of MEAL_TYPES) {
+        const currentItems = toMealItems(currentWeek?.[day]?.[mealType]);
+        if (currentItems.length > 0) continue;
+
+        addedMeals += toMealItems(templateWeek?.[day]?.[mealType]).length;
+      }
+    }
+    return addedMeals;
+  };
+
   useEffect(() => {
     fetchUserData();
     if (isPremium) {
@@ -275,6 +331,7 @@ const NutritionMealPlanner = () => {
         targetWeekStart: typeof parsed.targetWeekStart === 'string' ? parsed.targetWeekStart : undefined,
         source: typeof parsed.source === 'string' ? parsed.source : undefined,
         requestedAt: typeof parsed.requestedAt === 'string' ? parsed.requestedAt : undefined,
+        mergeMode: parsed.mergeMode === 'append' ? 'append' : 'replace',
       });
     } catch (error) {
       console.error('Error loading template bridge request:', error);
@@ -1083,12 +1140,16 @@ const NutritionMealPlanner = () => {
     }
   };
 
-  const loadTemplate = (templateName: string) => {
+  const loadTemplate = (templateName: string, mergeMode: TemplateMergeMode = 'replace') => {
     const saved = localStorage.getItem(`meal-template-${templateName}`);
     if (saved) {
-      setWeeklyMeals(JSON.parse(saved));
+      const parsedTemplateMeals = JSON.parse(saved);
+      const nextWeeklyMeals = applyTemplateMeals(weeklyMeals, parsedTemplateMeals, mergeMode);
+      setWeeklyMeals(nextWeeklyMeals);
       toast({
-        description: `✅ Template "${templateName}" loaded successfully!`,
+        description: mergeMode === 'append'
+          ? `✅ Template "${templateName}" appended into open planner slots!`
+          : `✅ Template "${templateName}" loaded successfully!`,
       });
       setShowLoadTemplateModal(false);
     }
@@ -1126,6 +1187,7 @@ const NutritionMealPlanner = () => {
       setPendingTemplateBridgePreview({
         ...templateBridgeRequest,
         targetWeekStart: targetWeek || selectedDate,
+        mergeMode: templateBridgeRequest.mergeMode === 'append' ? 'append' : 'replace',
         templateMeals: parsedTemplateMeals,
       });
     } catch (error) {
@@ -1148,13 +1210,24 @@ const NutritionMealPlanner = () => {
     () => countMealEntries(pendingTemplateBridgePreview?.templateMeals),
     [pendingTemplateBridgePreview],
   );
+  const pendingTemplateAppendAddedMeals = useMemo(
+    () => estimateAppendAddedMeals(weeklyMeals, pendingTemplateBridgePreview?.templateMeals || {}),
+    [weeklyMeals, pendingTemplateBridgePreview],
+  );
 
   const handleApplyPendingTemplateBridge = () => {
     if (!pendingTemplateBridgePreview) return;
-    setWeeklyMeals(pendingTemplateBridgePreview.templateMeals);
+    const nextWeeklyMeals = applyTemplateMeals(
+      weeklyMeals,
+      pendingTemplateBridgePreview.templateMeals,
+      pendingTemplateBridgePreview.mergeMode,
+    );
+    setWeeklyMeals(nextWeeklyMeals);
     toast({
       title: 'Template applied',
-      description: `Loaded "${pendingTemplateBridgePreview.templateName}" into week ${pendingTemplateBridgePreview.targetWeekStart || selectedDate}.`,
+      description: pendingTemplateBridgePreview.mergeMode === 'append'
+        ? `Appended "${pendingTemplateBridgePreview.templateName}" into open slots for week ${pendingTemplateBridgePreview.targetWeekStart || selectedDate}.`
+        : `Loaded "${pendingTemplateBridgePreview.templateName}" into week ${pendingTemplateBridgePreview.targetWeekStart || selectedDate}.`,
     });
     localStorage.removeItem('meal-planner-template-bridge-v1');
     setTemplateBridgeRequest(null);
@@ -2398,9 +2471,34 @@ const NutritionMealPlanner = () => {
                         <p className="text-sm font-semibold text-gray-900 mt-1">{pendingTemplateMealsCount} meals in template</p>
                       </div>
                     </div>
-                    <p className="text-sm text-gray-700">
-                      Applying <span className="font-medium">"{pendingTemplateBridgePreview.templateName}"</span> will replace meals currently planned for this week.
-                    </p>
+                    <div className="rounded-lg border border-orange-200 bg-white p-3">
+                      <p className="text-xs text-gray-500 uppercase tracking-wide">Merge mode</p>
+                      <div className="mt-2 inline-flex rounded-md border border-orange-200 bg-orange-100/50 p-1">
+                        <button
+                          type="button"
+                          className={`px-3 py-1 text-xs font-medium rounded ${pendingTemplateBridgePreview.mergeMode === 'replace' ? 'bg-white text-orange-800 shadow-sm' : 'text-orange-700/80'}`}
+                          onClick={() => setPendingTemplateBridgePreview((prev) => (prev ? { ...prev, mergeMode: 'replace' } : prev))}
+                        >
+                          Replace
+                        </button>
+                        <button
+                          type="button"
+                          className={`px-3 py-1 text-xs font-medium rounded ${pendingTemplateBridgePreview.mergeMode === 'append' ? 'bg-white text-orange-800 shadow-sm' : 'text-orange-700/80'}`}
+                          onClick={() => setPendingTemplateBridgePreview((prev) => (prev ? { ...prev, mergeMode: 'append' } : prev))}
+                        >
+                          Append
+                        </button>
+                      </div>
+                    </div>
+                    {pendingTemplateBridgePreview.mergeMode === 'append' ? (
+                      <p className="text-sm text-gray-700">
+                        Append mode keeps existing meals and only fills empty slots. Estimated meals added: <span className="font-semibold text-emerald-700">{pendingTemplateAppendAddedMeals}</span>.
+                      </p>
+                    ) : (
+                      <p className="text-sm text-gray-700">
+                        Applying <span className="font-medium">"{pendingTemplateBridgePreview.templateName}"</span> will replace meals currently planned for this week.
+                      </p>
+                    )}
                     <div className="flex flex-wrap gap-2">
                       <Button onClick={handleApplyPendingTemplateBridge} className="bg-orange-600 hover:bg-orange-700">
                         Apply Template

--- a/client/src/components/meal-planner/modals/LoadTemplateModal.tsx
+++ b/client/src/components/meal-planner/modals/LoadTemplateModal.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 type LoadTemplateModalProps = {
   open: boolean;
   onClose: () => void;
-  onLoadTemplate: (templateName: string) => void;
+  onLoadTemplate: (templateName: string, mergeMode: 'replace' | 'append') => void;
   currentWeeklyMeals: Record<string, any>;
 };
 
@@ -14,6 +14,8 @@ type TemplateImpactSummary = {
   overwriteSlots: number;
   noChangeSlots: number;
   templateMealItems: number;
+  currentMealItems: number;
+  appendAddedMealItems: number;
 };
 
 const MEAL_TYPES = ['breakfast', 'lunch', 'dinner', 'snack'];
@@ -29,16 +31,23 @@ const buildImpactSummary = (currentWeek: Record<string, any>, templateWeek: Reco
   let overwriteSlots = 0;
   let noChangeSlots = 0;
   let templateMealItems = 0;
+  let currentMealItems = 0;
+  let appendAddedMealItems = 0;
 
   for (const day of WEEK_DAYS) {
     for (const mealType of MEAL_TYPES) {
       const currentItems = toItems(currentWeek?.[day]?.[mealType]);
       const templateItems = toItems(templateWeek?.[day]?.[mealType]);
+      if (currentItems.length > 0) {
+        currentMealItems += currentItems.length;
+      }
+
       if (templateItems.length === 0) continue;
 
       templateMealItems += templateItems.length;
       filledSlots += 1;
       if (currentItems.length === 0) {
+        appendAddedMealItems += templateItems.length;
         continue;
       }
 
@@ -52,11 +61,12 @@ const buildImpactSummary = (currentWeek: Record<string, any>, templateWeek: Reco
     }
   }
 
-  return { filledSlots, overwriteSlots, noChangeSlots, templateMealItems };
+  return { filledSlots, overwriteSlots, noChangeSlots, templateMealItems, currentMealItems, appendAddedMealItems };
 };
 
 const LoadTemplateModal = ({ open, onClose, onLoadTemplate, currentWeeklyMeals }: LoadTemplateModalProps) => {
   const [selectedTemplate, setSelectedTemplate] = React.useState<string | null>(null);
+  const [mergeMode, setMergeMode] = React.useState<'replace' | 'append'>('replace');
 
   const templates = React.useMemo(() => {
     const savedTemplates: string[] = [];
@@ -85,6 +95,7 @@ const LoadTemplateModal = ({ open, onClose, onLoadTemplate, currentWeeklyMeals }
   React.useEffect(() => {
     if (!open) {
       setSelectedTemplate(null);
+      setMergeMode('replace');
       return;
     }
     if (templates.length > 0) {
@@ -132,7 +143,7 @@ const LoadTemplateModal = ({ open, onClose, onLoadTemplate, currentWeeklyMeals }
                     </div>
                     <Button size="sm" variant={isSelected ? 'default' : 'outline'} onClick={(event) => {
                       event.stopPropagation();
-                      onLoadTemplate(templateName);
+                      onLoadTemplate(templateName, mergeMode);
                     }}>
                       Apply
                     </Button>
@@ -141,14 +152,43 @@ const LoadTemplateModal = ({ open, onClose, onLoadTemplate, currentWeeklyMeals }
               })}
 
               {selectedTemplate && impactPreview && (
-                <div className="rounded-lg border bg-gray-50 p-3">
+                <div className="rounded-lg border bg-gray-50 p-3 space-y-3">
                   <p className="text-sm font-medium text-gray-900">Impact preview for "{selectedTemplate}"</p>
+                  <div>
+                    <p className="text-xs text-gray-500 uppercase tracking-wide">Merge mode</p>
+                    <div className="mt-2 inline-flex rounded-md border border-gray-200 bg-white p-1">
+                      <button
+                        type="button"
+                        className={`px-3 py-1 text-xs font-medium rounded ${mergeMode === 'replace' ? 'bg-blue-100 text-blue-800' : 'text-gray-600'}`}
+                        onClick={() => setMergeMode('replace')}
+                      >
+                        Replace
+                      </button>
+                      <button
+                        type="button"
+                        className={`px-3 py-1 text-xs font-medium rounded ${mergeMode === 'append' ? 'bg-blue-100 text-blue-800' : 'text-gray-600'}`}
+                        onClick={() => setMergeMode('append')}
+                      >
+                        Append
+                      </button>
+                    </div>
+                  </div>
                   <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-gray-600">
+                    <div>Target week meals: <span className="font-semibold text-gray-900">{impactPreview.currentMealItems}</span></div>
+                    <div>Template meals: <span className="font-semibold text-gray-900">{impactPreview.templateMealItems}</span></div>
                     <div>Filled slots: <span className="font-semibold text-gray-900">{impactPreview.filledSlots}</span></div>
-                    <div>Total meals: <span className="font-semibold text-gray-900">{impactPreview.templateMealItems}</span></div>
-                    <div>Will overwrite: <span className="font-semibold text-amber-700">{impactPreview.overwriteSlots}</span></div>
+                    {mergeMode === 'append' ? (
+                      <div>Estimated added: <span className="font-semibold text-emerald-700">{impactPreview.appendAddedMealItems}</span></div>
+                    ) : (
+                      <div>Will overwrite: <span className="font-semibold text-amber-700">{impactPreview.overwriteSlots}</span></div>
+                    )}
                     <div>Unchanged slots: <span className="font-semibold text-emerald-700">{impactPreview.noChangeSlots}</span></div>
                   </div>
+                  {mergeMode === 'replace' ? (
+                    <p className="text-xs text-amber-700">Replace mode overwrites existing meals in slots populated by the template.</p>
+                  ) : (
+                    <p className="text-xs text-emerald-700">Append mode keeps existing meals and only fills empty slots.</p>
+                  )}
                 </div>
               )}
             </>


### PR DESCRIPTION
### Motivation

- Users currently lose their week when applying a saved template because template application always replaced the week, so we need a safer option to append template meals into empty slots only.
- Keep changes additive and low-risk by reusing existing preview/UI patterns and keeping `NutritionMealPlanner` as the orchestrator.

### Description

- Introduced a lightweight `TemplateMergeMode = 'replace' | 'append'` and centralized template application logic with `applyTemplateMeals` and `estimateAppendAddedMeals` in `NutritionMealPlanner` so template application supports both modes without changing storage format.
- Manual template load (`LoadTemplateModal`) now exposes a small Merge mode selector (Replace / Append), shows extended impact metrics (target week meal count, template meal count, estimated added meals for append, overwrite count for replace), and passes the selected mode to the planner on apply.
- Bridge-based pre-apply preview flow now carries a `mergeMode` from the bridge request (defaulting to `replace`), shows a merge-mode toggle inside the preview card, updates preview messaging/counts based on mode, and applies the selected mode when confirming the bridged template.
- Preserved existing behavior by default: `replace` keeps the original overwrite semantics; `append` only fills empty slots and never overwrites existing meals (no duplicate-detection was added to keep it simple).
- Files changed: `client/src/components/NutritionMealPlanner.tsx`, `client/src/components/meal-planner/modals/LoadTemplateModal.tsx`.

### Testing

- Ran `npm run build` successfully in this environment (includes client + server build steps).  
- Ran `npm run build:client` which completed successfully (Vite emitted chunk-size warnings but build succeeded).  
- Ran `npm run build:server` which completed successfully.  
- No automated test failures were produced by these build commands; UI and runtime validation should be performed in a browser environment as a next step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebba42ee6c8325a9d85ee07d76802c)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
