### PR TITLE
Add slot-level pre-apply diff preview for meal planner templates

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -61,6 +61,7 @@ import {
   gradeClass,
   clientSideNutritionLookup,
   toGroceryExportItems,
+  buildTemplateSlotDiff,
 } from '@/components/meal-planner/nutritionMealPlannerUtils';
 
 const INITIAL_MEAL_FORM = {
@@ -1214,6 +1215,14 @@ const NutritionMealPlanner = () => {
     () => estimateAppendAddedMeals(weeklyMeals, pendingTemplateBridgePreview?.templateMeals || {}),
     [weeklyMeals, pendingTemplateBridgePreview],
   );
+  const pendingTemplateSlotDiffPreview = useMemo(() => {
+    if (!pendingTemplateBridgePreview) return [];
+    return buildTemplateSlotDiff(
+      weeklyMeals,
+      pendingTemplateBridgePreview.templateMeals || {},
+      pendingTemplateBridgePreview.mergeMode,
+    );
+  }, [weeklyMeals, pendingTemplateBridgePreview]);
 
   const handleApplyPendingTemplateBridge = () => {
     if (!pendingTemplateBridgePreview) return;
@@ -2499,6 +2508,42 @@ const NutritionMealPlanner = () => {
                         Applying <span className="font-medium">"{pendingTemplateBridgePreview.templateName}"</span> will replace meals currently planned for this week.
                       </p>
                     )}
+                    {pendingTemplateSlotDiffPreview.length > 0 ? (
+                      <div className="rounded-lg border border-orange-200 bg-white p-3">
+                        <p className="text-xs text-gray-500 uppercase tracking-wide mb-2">Slot-level pre-apply diff</p>
+                        <div className="space-y-1.5">
+                          {pendingTemplateSlotDiffPreview.slice(0, 10).map((slot) => (
+                            <div key={slot.key} className="flex items-center justify-between text-xs">
+                              <span className="text-gray-700">
+                                {slot.day} • {slot.mealType}
+                              </span>
+                              <span
+                                className={`font-medium ${
+                                  slot.status === 'replace'
+                                    ? 'text-amber-700'
+                                    : slot.status === 'add'
+                                      ? 'text-emerald-700'
+                                      : slot.status === 'skip-existing'
+                                        ? 'text-sky-700'
+                                        : 'text-gray-500'
+                                }`}
+                              >
+                                {slot.status === 'replace'
+                                  ? `Replace ${slot.currentCount} → ${slot.templateCount}`
+                                  : slot.status === 'add'
+                                    ? `Add ${slot.templateCount}`
+                                    : slot.status === 'skip-existing'
+                                      ? `Keep current (${slot.currentCount})`
+                                      : 'No change'}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                        {pendingTemplateSlotDiffPreview.length > 10 ? (
+                          <p className="mt-2 text-[11px] text-gray-500">Showing 10 of {pendingTemplateSlotDiffPreview.length} template-filled slots.</p>
+                        ) : null}
+                      </div>
+                    ) : null}
                     <div className="flex flex-wrap gap-2">
                       <Button onClick={handleApplyPendingTemplateBridge} className="bg-orange-600 hover:bg-orange-700">
                         Apply Template

--- a/client/src/components/meal-planner/modals/LoadTemplateModal.tsx
+++ b/client/src/components/meal-planner/modals/LoadTemplateModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Save } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { buildTemplateSlotDiff } from '@/components/meal-planner/nutritionMealPlannerUtils';
 
 type LoadTemplateModalProps = {
   open: boolean;
@@ -91,6 +92,18 @@ const LoadTemplateModal = ({ open, onClose, onLoadTemplate, currentWeeklyMeals }
       return null;
     }
   }, [selectedTemplate, open, currentWeeklyMeals]);
+
+  const slotDiffPreview = React.useMemo(() => {
+    if (!selectedTemplate) return [];
+    try {
+      const templateRaw = localStorage.getItem(`meal-template-${selectedTemplate}`);
+      if (!templateRaw) return [];
+      const templateWeek = JSON.parse(templateRaw);
+      return buildTemplateSlotDiff(currentWeeklyMeals, templateWeek, mergeMode);
+    } catch {
+      return [];
+    }
+  }, [selectedTemplate, open, currentWeeklyMeals, mergeMode]);
 
   React.useEffect(() => {
     if (!open) {
@@ -189,6 +202,42 @@ const LoadTemplateModal = ({ open, onClose, onLoadTemplate, currentWeeklyMeals }
                   ) : (
                     <p className="text-xs text-emerald-700">Append mode keeps existing meals and only fills empty slots.</p>
                   )}
+                  {slotDiffPreview.length > 0 ? (
+                    <div className="rounded-md border border-gray-200 bg-white p-2">
+                      <p className="text-xs font-semibold text-gray-700 mb-2">Slot-level pre-apply diff</p>
+                      <div className="space-y-1">
+                        {slotDiffPreview.slice(0, 8).map((slot) => (
+                          <div key={slot.key} className="flex items-center justify-between text-xs">
+                            <span className="text-gray-700">
+                              {slot.day} • {slot.mealType}
+                            </span>
+                            <span
+                              className={`font-medium ${
+                                slot.status === 'replace'
+                                  ? 'text-amber-700'
+                                  : slot.status === 'add'
+                                    ? 'text-emerald-700'
+                                    : slot.status === 'skip-existing'
+                                      ? 'text-sky-700'
+                                      : 'text-gray-500'
+                              }`}
+                            >
+                              {slot.status === 'replace'
+                                ? `Replace ${slot.currentCount} → ${slot.templateCount}`
+                                : slot.status === 'add'
+                                  ? `Add ${slot.templateCount}`
+                                  : slot.status === 'skip-existing'
+                                    ? `Keep current (${slot.currentCount})`
+                                    : 'No change'}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                      {slotDiffPreview.length > 8 ? (
+                        <p className="text-[11px] text-gray-500 mt-2">Showing 8 of {slotDiffPreview.length} impacted slots.</p>
+                      ) : null}
+                    </div>
+                  ) : null}
                 </div>
               )}
             </>

--- a/client/src/components/meal-planner/nutritionMealPlannerUtils.ts
+++ b/client/src/components/meal-planner/nutritionMealPlannerUtils.ts
@@ -198,3 +198,61 @@ export const toGroceryExportItems = (groceryList: any[]) => groceryList.map((ite
   category: item.category || 'Other',
   checked: item.checked || false,
 }));
+
+export type TemplateMergeMode = 'replace' | 'append';
+export type TemplateSlotDiffStatus = 'add' | 'replace' | 'unchanged' | 'skip-existing';
+export type TemplateSlotDiffRow = {
+  key: string;
+  day: string;
+  mealType: string;
+  currentCount: number;
+  templateCount: number;
+  status: TemplateSlotDiffStatus;
+};
+
+const toMealItems = (value: any): any[] => {
+  if (!value) return [];
+  return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);
+};
+
+export const buildTemplateSlotDiff = (
+  currentWeek: Record<string, any>,
+  templateWeek: Record<string, any>,
+  mergeMode: TemplateMergeMode,
+): TemplateSlotDiffRow[] => {
+  const rows: TemplateSlotDiffRow[] = [];
+
+  for (const day of WEEK_DAYS) {
+    for (const mealType of MEAL_TYPES) {
+      const currentItems = toMealItems(currentWeek?.[day]?.[mealType]);
+      const templateItems = toMealItems(templateWeek?.[day]?.[mealType]);
+      if (templateItems.length === 0) continue;
+
+      const currentSerialized = JSON.stringify(currentItems);
+      const templateSerialized = JSON.stringify(templateItems);
+      const sameItems = currentSerialized === templateSerialized;
+
+      let status: TemplateSlotDiffStatus;
+      if (currentItems.length === 0) {
+        status = 'add';
+      } else if (sameItems) {
+        status = 'unchanged';
+      } else if (mergeMode === 'append') {
+        status = 'skip-existing';
+      } else {
+        status = 'replace';
+      }
+
+      rows.push({
+        key: `${day}-${mealType}`,
+        day,
+        mealType,
+        currentCount: currentItems.length,
+        templateCount: templateItems.length,
+        status,
+      });
+    }
+  }
+
+  return rows;
+};


### PR DESCRIPTION
### Motivation
- Improve user confidence when applying meal-plan templates by showing a lightweight, per-slot preview of what will be added, replaced, or left unchanged before applying a template.
- Keep the enhancement additive and focused on meal-planning/nutrition without changing existing merge/apply semantics.

### Description
- Added `buildTemplateSlotDiff` helper and related types (`TemplateMergeMode`, `TemplateSlotDiffRow`, `TemplateSlotDiffStatus`) to `client/src/components/meal-planner/nutritionMealPlannerUtils.ts` to compute slot-level diffs for `replace` and `append` modes.
- Integrated the slot-diff preview into the Load Template modal by importing `buildTemplateSlotDiff` and rendering a capped list of impacted slots with statuses (`add`, `replace`, `skip-existing`, `unchanged`) in `client/src/components/meal-planner/modals/LoadTemplateModal.tsx`.
- Added the same slot-level pre-apply diff to the bridged-template confirmation card in `client/src/components/NutritionMealPlanner.tsx` so users reviewing a bridged template see identical slot-level guidance before applying.
- UI changes are lightweight (capped rows, colorized status labels) and preserve all existing counts and merge-mode controls; no existing apply logic was altered.

### Testing
- Ran `npm run check` to validate TypeScript; the command executed but reported many pre-existing TypeScript errors across the repo unrelated to these changes, and no new targeted errors were introduced by this pass.
- Verified the new functions and UI integrations by static inspection of modified files: `nutritionMealPlannerUtils.ts`, `LoadTemplateModal.tsx`, and `NutritionMealPlanner.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebdba953c88325acecdfd6989e961c)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
