### PR TITLE
Add “Pin this template” quick action after saving imported/shared week

### DIFF
--- a/client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx
+++ b/client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx
@@ -47,6 +47,30 @@ type SharedWeekPayload = {
 };
 
 const DAY_ORDER = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+
+const TEMPLATE_PINNED_STORAGE_KEY = 'meal-template-pinned-v1';
+
+const loadPinnedTemplateNames = (): string[] => {
+  try {
+    const raw = localStorage.getItem(TEMPLATE_PINNED_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed
+      .map((name) => (typeof name === 'string' ? name.trim() : ''))
+      .filter((name): name is string => Boolean(name));
+  } catch {
+    return [];
+  }
+};
+
+const savePinnedTemplateNames = (templateNames: string[]) => {
+  const deduped = Array.from(new Set(templateNames.map((name) => name.trim()).filter(Boolean)));
+  localStorage.setItem(TEMPLATE_PINNED_STORAGE_KEY, JSON.stringify(deduped));
+  return deduped;
+};
+
 type CopyMergeMode = 'replace' | 'append' | 'skip-duplicates';
 type CopyImpactSummary = {
   mergeMode: CopyMergeMode;
@@ -134,6 +158,7 @@ export default function MealPlannerSharedWeekPage() {
   const [templateNameDraft, setTemplateNameDraft] = useState('');
   const [templateSavedName, setTemplateSavedName] = useState<string | null>(null);
   const [templateBridgeTargetWeekStart, setTemplateBridgeTargetWeekStart] = useState(() => getWeekStartIso(new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)));
+  const [templateWasPinnedAtSave, setTemplateWasPinnedAtSave] = useState(false);
 
   const fetchCopyImpactSummary = async (opts?: { silent?: boolean; targetWeek?: string; mode?: CopyMergeMode }) => {
     if (!token || !user) return null;
@@ -291,6 +316,7 @@ export default function MealPlannerSharedWeekPage() {
       localStorage.setItem(storageKey, JSON.stringify(data.plannedMeals));
       setTemplateSavedName(normalizedName);
       setTemplateNameDraft(normalizedName);
+      setTemplateWasPinnedAtSave(loadPinnedTemplateNames().includes(normalizedName));
       toast({
         title: 'Template saved',
         description: `Saved "${normalizedName}". You can load it anytime from your planner templates.`,
@@ -301,6 +327,37 @@ export default function MealPlannerSharedWeekPage() {
         variant: 'destructive',
         title: 'Unable to save template',
         description: 'Please try again.',
+      });
+    }
+  };
+
+
+  const handlePinSavedTemplate = () => {
+    if (!templateSavedName) return;
+
+    try {
+      const existingPinnedTemplates = loadPinnedTemplateNames();
+      if (existingPinnedTemplates.includes(templateSavedName)) {
+        setTemplateWasPinnedAtSave(true);
+        toast({
+          title: 'Template already pinned',
+          description: `"${templateSavedName}" is already pinned in your Load Template list.`,
+        });
+        return;
+      }
+
+      savePinnedTemplateNames([...existingPinnedTemplates, templateSavedName]);
+      setTemplateWasPinnedAtSave(true);
+      toast({
+        title: 'Template pinned',
+        description: `Pinned "${templateSavedName}" for quicker reuse in Load Template.`,
+      });
+    } catch (error) {
+      console.error('Error pinning imported week template:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Unable to pin template',
+        description: 'Template was saved, but pinning failed. Please try again.',
       });
     }
   };
@@ -511,6 +568,18 @@ export default function MealPlannerSharedWeekPage() {
                   <div className="text-xs font-medium text-emerald-700">Saved as "{templateSavedName}".</div>
                   <div className="mt-1 text-xs text-emerald-700/90">
                     Use it right away on another week without browsing away first.
+                  </div>
+                  <div className="mt-2 rounded-md border border-emerald-200 bg-white/70 p-2">
+                    <div className="text-xs font-medium text-foreground">Pin this template for quick reuse</div>
+                    <div className="mt-1 text-xs text-muted-foreground">Pinned templates appear at the top of your Load Template modal.</div>
+                    <Button
+                      size="sm"
+                      variant={templateWasPinnedAtSave ? 'outline' : 'secondary'}
+                      className="mt-2"
+                      onClick={handlePinSavedTemplate}
+                    >
+                      {templateWasPinnedAtSave ? 'Pinned for quick reuse' : 'Pin This Template'}
+                    </Button>
                   </div>
                   <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-end">
                     <label className="space-y-1 text-xs">


### PR DESCRIPTION
### Motivation
- Users who save an imported/shared week as a template could not pin it immediately, reducing discoverability in the Load Template modal; a lightweight post-save pin action improves reuse without adding backend or heavy template management.  
- The implementation should be purely additive, reuse the existing `meal-template-pinned-v1` convention, avoid duplicates, and preserve all existing copy/save/bridge behaviors.  
- Next best follow-up: offer a one-click “Use pinned template now” that pre-selects merge mode + target week and launches the template apply flow from the same post-save panel.

### Description
- Added safe localStorage helpers in `MealPlannerSharedWeekPage` to reuse the pinned convention: `TEMPLATE_PINNED_STORAGE_KEY`, `loadPinnedTemplateNames()`, and `savePinnedTemplateNames()` which sanitize and de-duplicate template names before writing.  
- Extended the save flow (`handleSaveImportedWeekAsTemplate`) to record whether the newly saved template is already pinned (`templateWasPinnedAtSave`) so the UI can reflect pinned state immediately.  
- Implemented `handlePinSavedTemplate()` that reads the existing pinned list, avoids duplicates, writes the de-duplicated array back to `meal-template-pinned-v1`, and surfaces toast feedback for success / already-pinned / error cases.  
- Added a small post-save UI panel in the existing “Saved as …” area with a one-click `Pin This Template` button that toggles to `Pinned for quick reuse` when pinned; preserved all existing save/bridge/apply behaviors.  
- Files changed: `client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx` (new helpers, state, handler, and UI); `LoadTemplateModal.tsx` already uses `meal-template-pinned-v1` and required no changes.

### Testing
- Built the project to validate changes: `npm run build` — succeeded.  
- Built client bundle: `npm run build:client` — succeeded.  
- Built server bundle: `npm run build:server` — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb5e1e23883259952712f42710800)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
