### PR TITLE
Add lightweight per-template merge defaults for meal planner templates

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -183,9 +183,11 @@ type RecentPinnedTemplateUsage = {
   lastUsedAt: string;
   mergeMode: TemplateMergeMode;
 };
+type TemplateMergePreferenceMap = Record<string, TemplateMergeMode>;
 
 const TEMPLATE_PINNED_STORAGE_KEY = 'meal-template-pinned-v1';
 const RECENT_PINNED_TEMPLATE_STORAGE_KEY = 'meal-template-recent-pinned-v1';
+const TEMPLATE_MERGE_PREFERENCES_STORAGE_KEY = 'meal-template-merge-preferences-v1';
 const RECENT_PINNED_TEMPLATE_LIMIT = 3;
 
 const NutritionMealPlanner = () => {
@@ -282,6 +284,42 @@ const NutritionMealPlanner = () => {
     }
   };
 
+  const loadTemplateMergePreferences = (): TemplateMergePreferenceMap => {
+    try {
+      const raw = localStorage.getItem(TEMPLATE_MERGE_PREFERENCES_STORAGE_KEY);
+      if (!raw) return {};
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+      const normalizedEntries = Object.entries(parsed).flatMap(([templateName, mergeMode]) => {
+        const normalizedName = typeof templateName === 'string' ? templateName.trim() : '';
+        if (!normalizedName) return [];
+        return [[normalizedName, mergeMode === 'append' ? 'append' : 'replace'] as const];
+      });
+      return Object.fromEntries(normalizedEntries);
+    } catch {
+      return {};
+    }
+  };
+
+  const setTemplateMergePreference = (templateName: string, mergeMode: TemplateMergeMode) => {
+    const normalizedName = templateName.trim();
+    if (!normalizedName) return;
+    try {
+      const existing = loadTemplateMergePreferences();
+      const next = { ...existing, [normalizedName]: mergeMode };
+      localStorage.setItem(TEMPLATE_MERGE_PREFERENCES_STORAGE_KEY, JSON.stringify(next));
+    } catch (error) {
+      console.error('Error storing template merge preference:', error);
+    }
+  };
+
+  const getTemplateMergePreference = (templateName: string): TemplateMergeMode => {
+    const normalizedName = templateName.trim();
+    if (!normalizedName) return 'replace';
+    const preferences = loadTemplateMergePreferences();
+    return preferences[normalizedName] === 'append' ? 'append' : 'replace';
+  };
+
   const sanitizeRecentPinnedTemplates = (items: RecentPinnedTemplateUsage[]) => {
     const pinned = new Set(loadPinnedTemplateNames());
     return items
@@ -296,13 +334,18 @@ const NutritionMealPlanner = () => {
         setRecentPinnedTemplates([]);
         return;
       }
+      const mergePreferences = loadTemplateMergePreferences();
       const parsed = JSON.parse(raw);
       const normalized = Array.isArray(parsed)
         ? parsed
             .map((item) => ({
               templateName: typeof item?.templateName === 'string' ? item.templateName.trim() : '',
               lastUsedAt: typeof item?.lastUsedAt === 'string' ? item.lastUsedAt : '',
-              mergeMode: item?.mergeMode === 'append' ? 'append' : 'replace',
+              mergeMode: mergePreferences[typeof item?.templateName === 'string' ? item.templateName.trim() : ''] === 'append'
+                ? 'append'
+                : item?.mergeMode === 'append'
+                  ? 'append'
+                  : 'replace',
             }))
             .filter((item) => Boolean(item.templateName))
         : [];
@@ -1234,6 +1277,7 @@ const NutritionMealPlanner = () => {
       const parsedTemplateMeals = JSON.parse(saved);
       const nextWeeklyMeals = applyTemplateMeals(weeklyMeals, parsedTemplateMeals, mergeMode);
       setWeeklyMeals(nextWeeklyMeals);
+      setTemplateMergePreference(templateName, mergeMode);
       recordRecentPinnedTemplateUse(templateName, mergeMode);
       toast({
         description: mergeMode === 'append'
@@ -1320,6 +1364,7 @@ const NutritionMealPlanner = () => {
       pendingTemplateBridgePreview.mergeMode,
     );
     setWeeklyMeals(nextWeeklyMeals);
+    setTemplateMergePreference(pendingTemplateBridgePreview.templateName, pendingTemplateBridgePreview.mergeMode);
     recordRecentPinnedTemplateUse(pendingTemplateBridgePreview.templateName, pendingTemplateBridgePreview.mergeMode);
     toast({
       title: 'Template applied',
@@ -1358,10 +1403,19 @@ const NutritionMealPlanner = () => {
       targetWeekStart: getCurrentWeekAnchor(),
       source: 'planner-recent-pinned-strip',
       requestedAt: new Date().toISOString(),
-      mergeMode: 'replace',
+      mergeMode: getTemplateMergePreference(templateName),
     };
     localStorage.setItem('meal-planner-template-bridge-v1', JSON.stringify(request));
     setTemplateBridgeRequest(request);
+  };
+
+  const handleChangeRecentPinnedTemplateMergePreference = (templateName: string, mergeMode: TemplateMergeMode) => {
+    setTemplateMergePreference(templateName, mergeMode);
+    setRecentPinnedTemplates((prev) => {
+      const nextItems = prev.map((item) => (item.templateName === templateName ? { ...item, mergeMode } : item));
+      localStorage.setItem(RECENT_PINNED_TEMPLATE_STORAGE_KEY, JSON.stringify(nextItems));
+      return nextItems;
+    });
   };
 
   const formatRecentTemplateDate = (value: string) => {
@@ -2686,8 +2740,24 @@ const NutritionMealPlanner = () => {
                         <div>
                           <p className="text-sm font-medium text-gray-900">{template.templateName}</p>
                           <p className="text-xs text-gray-500">
-                            Last used {formatRecentTemplateDate(template.lastUsedAt)} • {template.mergeMode === 'append' ? 'Append' : 'Replace'} mode
+                            Last used {formatRecentTemplateDate(template.lastUsedAt)} • Default {template.mergeMode === 'append' ? 'Append' : 'Replace'} mode
                           </p>
+                          <div className="mt-2 inline-flex rounded-md border border-indigo-200 bg-indigo-50 p-1">
+                            <button
+                              type="button"
+                              className={`px-2 py-1 text-[11px] font-medium rounded ${template.mergeMode === 'replace' ? 'bg-white text-indigo-800 shadow-sm' : 'text-indigo-700/80'}`}
+                              onClick={() => handleChangeRecentPinnedTemplateMergePreference(template.templateName, 'replace')}
+                            >
+                              Replace
+                            </button>
+                            <button
+                              type="button"
+                              className={`px-2 py-1 text-[11px] font-medium rounded ${template.mergeMode === 'append' ? 'bg-white text-indigo-800 shadow-sm' : 'text-indigo-700/80'}`}
+                              onClick={() => handleChangeRecentPinnedTemplateMergePreference(template.templateName, 'append')}
+                            >
+                              Append
+                            </button>
+                          </div>
                         </div>
                         <Button size="sm" variant="outline" onClick={() => handleUseRecentPinnedTemplate(template.templateName)}>
                           Use

--- a/client/src/components/meal-planner/modals/LoadTemplateModal.tsx
+++ b/client/src/components/meal-planner/modals/LoadTemplateModal.tsx
@@ -22,6 +22,7 @@ type TemplateImpactSummary = {
 const MEAL_TYPES = ['breakfast', 'lunch', 'dinner', 'snack'];
 const WEEK_DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
 const TEMPLATE_PINNED_STORAGE_KEY = 'meal-template-pinned-v1';
+const TEMPLATE_MERGE_PREFERENCES_STORAGE_KEY = 'meal-template-merge-preferences-v1';
 
 const toItems = (value: any): any[] => {
   if (!value) return [];
@@ -44,6 +45,40 @@ const loadPinnedTemplateNames = (): string[] => {
 
 const savePinnedTemplateNames = (templateNames: string[]) => {
   localStorage.setItem(TEMPLATE_PINNED_STORAGE_KEY, JSON.stringify(templateNames));
+};
+
+const loadTemplateMergePreferences = (): Record<string, 'replace' | 'append'> => {
+  try {
+    const raw = localStorage.getItem(TEMPLATE_MERGE_PREFERENCES_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const normalizedEntries = Object.entries(parsed).flatMap(([templateName, mergeMode]) => {
+      const normalizedName = typeof templateName === 'string' ? templateName.trim() : '';
+      if (!normalizedName) return [];
+      return [[normalizedName, mergeMode === 'append' ? 'append' : 'replace'] as const];
+    });
+    return Object.fromEntries(normalizedEntries);
+  } catch {
+    return {};
+  }
+};
+
+const getTemplateMergePreference = (templateName: string): 'replace' | 'append' => {
+  const normalizedName = templateName.trim();
+  if (!normalizedName) return 'replace';
+  const preferences = loadTemplateMergePreferences();
+  return preferences[normalizedName] === 'append' ? 'append' : 'replace';
+};
+
+const setTemplateMergePreference = (templateName: string, mergeMode: 'replace' | 'append') => {
+  const normalizedName = templateName.trim();
+  if (!normalizedName) return;
+  const existing = loadTemplateMergePreferences();
+  localStorage.setItem(
+    TEMPLATE_MERGE_PREFERENCES_STORAGE_KEY,
+    JSON.stringify({ ...existing, [normalizedName]: mergeMode }),
+  );
 };
 
 const buildImpactSummary = (currentWeek: Record<string, any>, templateWeek: Record<string, any>): TemplateImpactSummary => {
@@ -163,6 +198,14 @@ const LoadTemplateModal = ({ open, onClose, onLoadTemplate, currentWeeklyMeals }
     }
   }, [open, rawTemplates, templates]);
 
+  React.useEffect(() => {
+    if (!selectedTemplate) {
+      setMergeMode('replace');
+      return;
+    }
+    setMergeMode(getTemplateMergePreference(selectedTemplate));
+  }, [selectedTemplate]);
+
   const togglePinnedTemplate = (templateName: string) => {
     setPinnedTemplates((prev) => {
       const nextPinnedTemplates = prev.includes(templateName)
@@ -231,7 +274,8 @@ const LoadTemplateModal = ({ open, onClose, onLoadTemplate, currentWeeklyMeals }
                       </Button>
                       <Button size="sm" variant={isSelected ? 'default' : 'outline'} onClick={(event) => {
                         event.stopPropagation();
-                        onLoadTemplate(templateName, mergeMode);
+                        const effectiveMergeMode = isSelected ? mergeMode : getTemplateMergePreference(templateName);
+                        onLoadTemplate(templateName, effectiveMergeMode);
                       }}>
                         Apply
                       </Button>
@@ -249,14 +293,20 @@ const LoadTemplateModal = ({ open, onClose, onLoadTemplate, currentWeeklyMeals }
                       <button
                         type="button"
                         className={`px-3 py-1 text-xs font-medium rounded ${mergeMode === 'replace' ? 'bg-blue-100 text-blue-800' : 'text-gray-600'}`}
-                        onClick={() => setMergeMode('replace')}
+                        onClick={() => {
+                          setMergeMode('replace');
+                          setTemplateMergePreference(selectedTemplate, 'replace');
+                        }}
                       >
                         Replace
                       </button>
                       <button
                         type="button"
                         className={`px-3 py-1 text-xs font-medium rounded ${mergeMode === 'append' ? 'bg-blue-100 text-blue-800' : 'text-gray-600'}`}
-                        onClick={() => setMergeMode('append')}
+                        onClick={() => {
+                          setMergeMode('append');
+                          setTemplateMergePreference(selectedTemplate, 'append');
+                        }}
                       >
                         Append
                       </button>


### PR DESCRIPTION
### Motivation
- Users repeatedly reselect the same merge mode for the same templates; a tiny per-template default speeds reuse without changing apply safety. 
- The change must be additive, client-only, and preserve the existing preview/diff and apply flow.

### Description
- Added localStorage-backed preferences under key `meal-template-merge-preferences-v1` with shape `{ [templateName]: "replace" | "append" }` and safe sanitization that falls back to `replace` when missing or invalid. 
- Persist preference when a template is applied (both modal apply and bridge/quick-use), and read the preference when initiating quick-use from the recent pinned strip so the bridge preview starts with the stored mode. 
- Exposed lightweight controls to set/change the default mode from the UI: inline Replace/Append toggle on the recent pinned template cards and the Replace/Append toggle in `LoadTemplateModal` now persist the preference. 
- Files changed: `client/src/components/NutritionMealPlanner.tsx` and `client/src/components/meal-planner/modals/LoadTemplateModal.tsx`.

### Testing
- Built the project successfully with `npm run build` (includes client and server builds). 
- Built client bundle successfully with `npm run build:client`. 
- Built server bundle successfully with `npm run build:server`. 
All three commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd96b7d488325abf9a9d1abdc0530)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
