### PR TITLE
Add lightweight impact delta badge to template bridge pre-apply preview

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -1395,6 +1395,27 @@ const NutritionMealPlanner = () => {
       pendingTemplateBridgePreview.mergeMode,
     );
   }, [weeklyMeals, pendingTemplateBridgePreview]);
+  const pendingTemplateImpactBadge = useMemo(() => {
+    if (!pendingTemplateBridgePreview) {
+      return { label: '', className: '' };
+    }
+    if (pendingTemplateBridgePreview.mergeMode === 'replace') {
+      return {
+        label: `Will replace with ${pendingTemplateMealsCount} ${pendingTemplateMealsCount === 1 ? 'meal' : 'meals'}`,
+        className: 'bg-amber-100 text-amber-800 border-amber-200',
+      };
+    }
+    if (pendingTemplateAppendAddedMeals > 0) {
+      return {
+        label: `Will add ${pendingTemplateAppendAddedMeals} ${pendingTemplateAppendAddedMeals === 1 ? 'meal' : 'meals'}`,
+        className: 'bg-emerald-100 text-emerald-800 border-emerald-200',
+      };
+    }
+    return {
+      label: 'No empty slots to fill',
+      className: 'bg-slate-100 text-slate-700 border-slate-200',
+    };
+  }, [pendingTemplateBridgePreview, pendingTemplateMealsCount, pendingTemplateAppendAddedMeals]);
 
   const handleApplyPendingTemplateBridge = () => {
     if (!pendingTemplateBridgePreview) return;
@@ -2677,6 +2698,11 @@ const NutritionMealPlanner = () => {
                     <CardDescription className="text-orange-900/80">
                       Review the impact before applying this bridged template to your planner week.
                     </CardDescription>
+                    <div>
+                      <Badge variant="outline" className={`mt-2 ${pendingTemplateImpactBadge.className}`}>
+                        {pendingTemplateImpactBadge.label}
+                      </Badge>
+                    </div>
                   </CardHeader>
                   <CardContent className="space-y-4">
                     <div className="grid grid-cols-1 md:grid-cols-3 gap-3">


### PR DESCRIPTION
### Motivation
- Provide a one-glance summary of the expected template apply impact in the bridge pre-apply preview so users can decide faster while keeping the existing detailed slot diff intact. 
- Keep the change lightweight and purely client-side with no backend or behavioral changes to applying templates. 
- Preserve existing UI layout and merge/apply logic while improving confidence and consistency with recent last-applied metadata. 
- Next best improvement: add an optional small parity line under the badge for append mode like `Will add Y meals, keep Z existing meals` using existing slot-diff counts. 

### Description
- Introduced a memoized `pendingTemplateImpactBadge` in `NutritionMealPlanner` that reuses `pendingTemplateMealsCount`, `pendingTemplateAppendAddedMeals`, and `mergeMode` to compute a compact label and simple color classes. 
- Rendered the badge in the template bridge pre-apply preview card header below the existing description so it is visible without changing the detailed slot-level diff. 
- File changed: `client/src/components/NutritionMealPlanner.tsx`. 
- Badge text shown: replace mode: `Will replace with X meal(s)`; append mode with additions: `Will add Y meal(s)`; append mode with no additions: `No empty slots to fill`.
- The change is additive only and does not modify `applyTemplateMeals`, `recordRecentPinnedTemplateUse`, or any server/API behavior. 

### Testing
- Ran `npm run build` and it completed successfully. 
- Ran `npm run build:client` and it completed successfully. 
- Ran `npm run build:server` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf4ed48b88325aa8e650f3fe11a4f)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
