### PR TITLE
Add append impact parity line under template bridge pre-apply badge

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -1416,6 +1416,17 @@ const NutritionMealPlanner = () => {
       className: 'bg-slate-100 text-slate-700 border-slate-200',
     };
   }, [pendingTemplateBridgePreview, pendingTemplateMealsCount, pendingTemplateAppendAddedMeals]);
+  const pendingTemplateAppendParityLine = useMemo(() => {
+    if (!pendingTemplateBridgePreview) return '';
+    if (pendingTemplateMealsCount === 0) {
+      return 'Append parity: this template currently has no meals to add.';
+    }
+    if (pendingTemplateAppendAddedMeals === 0) {
+      return 'Append parity: append mode would add 0 meals because this week has no open template slots.';
+    }
+    const estimatedAppendSkippedMeals = Math.max(pendingTemplateMealsCount - pendingTemplateAppendAddedMeals, 0);
+    return `Append parity: append mode would add ${pendingTemplateAppendAddedMeals} ${pendingTemplateAppendAddedMeals === 1 ? 'meal' : 'meals'} and skip ${estimatedAppendSkippedMeals} already-filled ${estimatedAppendSkippedMeals === 1 ? 'slot' : 'slots'}.`;
+  }, [pendingTemplateBridgePreview, pendingTemplateMealsCount, pendingTemplateAppendAddedMeals]);
 
   const handleApplyPendingTemplateBridge = () => {
     if (!pendingTemplateBridgePreview) return;
@@ -2702,6 +2713,7 @@ const NutritionMealPlanner = () => {
                       <Badge variant="outline" className={`mt-2 ${pendingTemplateImpactBadge.className}`}>
                         {pendingTemplateImpactBadge.label}
                       </Badge>
+                      <p className="mt-1 text-xs text-orange-900/80">{pendingTemplateAppendParityLine}</p>
                     </div>
                   </CardHeader>
                   <CardContent className="space-y-4">


### PR DESCRIPTION
### Motivation
- Improve the template-bridge preview UX in the meal planner by adding a lightweight parity line that explains what append mode would actually do (including 0-add and empty-template cases) shown under the existing pre-apply badge.

### Description
- Add a memoized `pendingTemplateAppendParityLine` that computes a short human-readable parity string and render it beneath the pre-apply `Badge` in the template bridge confirmation card; change is additive and limited to `client/src/components/NutritionMealPlanner.tsx`.

### Testing
- Ran `npm run check` (TypeScript typecheck) which failed due to many pre-existing unrelated TypeScript errors in the repo; this small UI-only change was committed and is additive without changing apply/merge behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed04ab078c8325aecda7486d77efc2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
