### PR TITLE
Stabilize meal planner shared-import template bridge and localStorage handling

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -286,9 +286,9 @@ const NutritionMealPlanner = () => {
       if (!raw) return [];
       const parsed = JSON.parse(raw);
       if (!Array.isArray(parsed)) return [];
-      return parsed
+      return Array.from(new Set(parsed
         .map((name) => (typeof name === 'string' ? name.trim() : ''))
-        .filter((name) => Boolean(name));
+        .filter((name) => Boolean(name))));
     } catch {
       return [];
     }
@@ -1308,23 +1308,35 @@ const NutritionMealPlanner = () => {
   const loadTemplate = (templateName: string, mergeMode: TemplateMergeMode = 'replace') => {
     const saved = localStorage.getItem(`meal-template-${templateName}`);
     if (saved) {
-      const parsedTemplateMeals = JSON.parse(saved);
-      const appliedMealCount = countMealEntries(parsedTemplateMeals);
-      const addedMealCount = mergeMode === 'append' ? estimateAppendAddedMeals(weeklyMeals, parsedTemplateMeals) : undefined;
-      const nextWeeklyMeals = applyTemplateMeals(weeklyMeals, parsedTemplateMeals, mergeMode);
-      setWeeklyMeals(nextWeeklyMeals);
-      setTemplateMergePreference(templateName, mergeMode);
-      recordRecentPinnedTemplateUse(templateName, mergeMode, {
-        appliedMealCount,
-        addedMealCount,
-        targetWeekStart: getCurrentWeekAnchor(),
-      });
-      toast({
-        description: mergeMode === 'append'
-          ? `✅ Template "${templateName}" appended into open planner slots!`
-          : `✅ Template "${templateName}" loaded successfully!`,
-      });
-      setShowLoadTemplateModal(false);
+      try {
+        const parsedTemplateMeals = JSON.parse(saved);
+        if (!parsedTemplateMeals || typeof parsedTemplateMeals !== 'object') {
+          throw new Error('Invalid template payload');
+        }
+
+        const appliedMealCount = countMealEntries(parsedTemplateMeals);
+        const addedMealCount = mergeMode === 'append' ? estimateAppendAddedMeals(weeklyMeals, parsedTemplateMeals) : undefined;
+        const nextWeeklyMeals = applyTemplateMeals(weeklyMeals, parsedTemplateMeals, mergeMode);
+        setWeeklyMeals(nextWeeklyMeals);
+        setTemplateMergePreference(templateName, mergeMode);
+        recordRecentPinnedTemplateUse(templateName, mergeMode, {
+          appliedMealCount,
+          addedMealCount,
+          targetWeekStart: getCurrentWeekAnchor(),
+        });
+        toast({
+          description: mergeMode === 'append'
+            ? `✅ Template "${templateName}" appended into open planner slots!`
+            : `✅ Template "${templateName}" loaded successfully!`,
+        });
+        setShowLoadTemplateModal(false);
+      } catch (error) {
+        console.error('Error loading template from localStorage:', error);
+        toast({
+          variant: 'destructive',
+          description: `Template "${templateName}" is invalid or outdated. Re-save it and try again.`,
+        });
+      }
     }
   };
 

--- a/client/src/components/meal-planner/modals/LoadTemplateModal.tsx
+++ b/client/src/components/meal-planner/modals/LoadTemplateModal.tsx
@@ -35,16 +35,17 @@ const loadPinnedTemplateNames = (): string[] => {
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
-    return parsed
+    return Array.from(new Set(parsed
       .map((name) => (typeof name === 'string' ? name.trim() : ''))
-      .filter((name) => Boolean(name));
+      .filter((name) => Boolean(name))));
   } catch {
     return [];
   }
 };
 
 const savePinnedTemplateNames = (templateNames: string[]) => {
-  localStorage.setItem(TEMPLATE_PINNED_STORAGE_KEY, JSON.stringify(templateNames));
+  const deduped = Array.from(new Set(templateNames.map((name) => name.trim()).filter(Boolean)));
+  localStorage.setItem(TEMPLATE_PINNED_STORAGE_KEY, JSON.stringify(deduped));
 };
 
 const loadTemplateMergePreferences = (): Record<string, 'replace' | 'append'> => {

--- a/client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx
+++ b/client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx
@@ -72,6 +72,7 @@ const savePinnedTemplateNames = (templateNames: string[]) => {
 };
 
 type CopyMergeMode = 'replace' | 'append' | 'skip-duplicates';
+type TemplateMergeMode = 'replace' | 'append';
 type CopyImpactSummary = {
   mergeMode: CopyMergeMode;
   targetWeekStart: string;
@@ -158,6 +159,7 @@ export default function MealPlannerSharedWeekPage() {
   const [templateNameDraft, setTemplateNameDraft] = useState('');
   const [templateSavedName, setTemplateSavedName] = useState<string | null>(null);
   const [templateBridgeTargetWeekStart, setTemplateBridgeTargetWeekStart] = useState(() => getWeekStartIso(new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)));
+  const [templateBridgeMergeMode, setTemplateBridgeMergeMode] = useState<TemplateMergeMode>('replace');
   const [templateWasPinnedAtSave, setTemplateWasPinnedAtSave] = useState(false);
 
   const fetchCopyImpactSummary = async (opts?: { silent?: boolean; targetWeek?: string; mode?: CopyMergeMode }) => {
@@ -369,6 +371,7 @@ export default function MealPlannerSharedWeekPage() {
     const bridgePayload = {
       templateName: templateSavedName,
       targetWeekStart: normalizedTargetWeek,
+      mergeMode: templateBridgeMergeMode,
       requestedAt: new Date().toISOString(),
       source: 'shared-week-import-success',
     };
@@ -377,7 +380,7 @@ export default function MealPlannerSharedWeekPage() {
       localStorage.setItem('meal-planner-template-bridge-v1', JSON.stringify(bridgePayload));
       toast({
         title: 'Template ready to apply',
-        description: `Opening your planner to apply "${templateSavedName}" to week ${normalizedTargetWeek}.`,
+        description: `Opening your planner to preview "${templateSavedName}" for week ${normalizedTargetWeek} in ${templateBridgeMergeMode} mode.`,
       });
       window.location.href = '/nutrition';
     } catch (error) {
@@ -590,6 +593,17 @@ export default function MealPlannerSharedWeekPage() {
                         onChange={(event) => setTemplateBridgeTargetWeekStart(event.target.value || getWeekStartIso(new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)))}
                         className="w-full rounded-md border bg-background px-3 py-2 text-sm sm:w-56"
                       />
+                    </label>
+                    <label className="space-y-1 text-xs">
+                      <div className="font-medium text-foreground">Merge mode</div>
+                      <select
+                        value={templateBridgeMergeMode}
+                        onChange={(event) => setTemplateBridgeMergeMode(event.target.value === 'append' ? 'append' : 'replace')}
+                        className="w-full rounded-md border bg-background px-3 py-2 text-sm sm:w-48"
+                      >
+                        <option value="replace">Replace</option>
+                        <option value="append">Append</option>
+                      </select>
                     </label>
                     <Button size="sm" onClick={handleUseSavedTemplateOnAnotherWeek}>
                       Use This Template on Another Week


### PR DESCRIPTION
### Motivation
- Fix inconsistencies and crash risks in the share → import → template → reuse flow discovered during an end-to-end QA pass. 
- Ensure the template bridge handoff preserves the user-selected merge mode so preview/apply behavior matches user intent. 
- Make localStorage interactions for pinned templates and saved templates resilient to stale/malformed data to avoid duplicates and runtime errors.

### Description
- Added a Merge mode selector to the shared-week success panel and include the selected `mergeMode` in the `meal-planner-template-bridge-v1` bridge payload, and updated the handoff toast to reflect preview behavior and chosen mode.  
- Hardened pinned template storage handling by trimming and deduplicating pinned names on load/save to prevent duplicate pin entries and preserve pinned-first ordering.  
- Guarded template loading from `localStorage` with JSON/shape validation and surface a destructive toast (instead of throwing) when a saved template is invalid or stale.  
- Minor UI/data plumbing updates to use the validated values and keep behavior additive and backward-compatible.

Files changed: `client/src/pages/nutrition/MealPlannerSharedWeekPage.tsx`, `client/src/components/meal-planner/modals/LoadTemplateModal.tsx`, `client/src/components/NutritionMealPlanner.tsx`.

### Testing
- Ran `npm run build` and the full build pipeline which succeeded in this environment.  
- Ran `npm run build:client` which completed successfully.  
- Ran `npm run build:server` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed27273a50832589107e557ba9e5ad)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
