### PR TITLE
Add Weekly Nutrition Insights panel to meal planner

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -2314,6 +2314,62 @@ const NutritionMealPlanner = () => {
   });
 
   const hasWeeklyNutritionData = weeklyNutritionData.some((day) => day.mealsLogged > 0 || day.calories > 0);
+  const weeklyNutritionInsights = useMemo(() => {
+    const missingMealDays = weeklyNutritionData.filter((day) => day.mealsLogged === 0).length;
+    const plannedDays = weeklyNutritionData.filter((day) => day.mealsLogged > 0);
+    const proteinTrackedDays = plannedDays.filter((day) => day.protein > 0);
+    const calorieTrackedDays = plannedDays.filter((day) => day.calories > 0);
+    const lowProteinDays = proteinTrackedDays.filter((day) => day.protein < 60).length;
+
+    const caloriesVaryWidely = calorieTrackedDays.length >= 3
+      ? (() => {
+          const calorieValues = calorieTrackedDays.map((day) => day.calories);
+          const minCalories = Math.min(...calorieValues);
+          const maxCalories = Math.max(...calorieValues);
+          const spread = maxCalories - minCalories;
+          const ratio = maxCalories / Math.max(1, minCalories);
+          return ratio >= 1.6 || spread >= 800;
+        })()
+      : false;
+
+    const insights: string[] = [];
+    if (missingMealDays > 0) {
+      insights.push(`${missingMealDays} day${missingMealDays === 1 ? '' : 's'} have no meals planned.`);
+    } else {
+      insights.push('Week fully planned.');
+    }
+
+    if (proteinTrackedDays.length > 0) {
+      if (lowProteinDays > 0) {
+        insights.push(`Low protein on ${lowProteinDays} day${lowProteinDays === 1 ? '' : 's'} (<60g).`);
+      } else {
+        insights.push('Protein coverage looks steady across planned days.');
+      }
+    } else {
+      insights.push('Protein insights unlock as meal protein data is added.');
+    }
+
+    if (calorieTrackedDays.length >= 3) {
+      if (caloriesVaryWidely) {
+        insights.push('Calories vary widely across the week.');
+      } else {
+        insights.push('Calorie range is fairly consistent this week.');
+      }
+    } else {
+      insights.push('Add calorie details to at least 3 days to compare weekly consistency.');
+    }
+
+    const looksBalanced = missingMealDays === 0
+      && proteinTrackedDays.length > 0
+      && lowProteinDays === 0
+      && calorieTrackedDays.length >= 3
+      && !caloriesVaryWidely;
+
+    return {
+      insights,
+      looksBalanced,
+    };
+  }, [weeklyNutritionData]);
 
   const weeklyMacroTotals = weeklyNutritionData.reduce((acc, day) => ({
     protein: acc.protein + day.protein,
@@ -2864,6 +2920,32 @@ const NutritionMealPlanner = () => {
                   </CardContent>
                 </Card>
               ) : null}
+              <Card className="border-emerald-200 bg-emerald-50/40">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-emerald-900">
+                    <Sparkles className="w-5 h-5 text-emerald-600" />
+                    Weekly Nutrition Insights
+                  </CardTitle>
+                  <CardDescription className="text-emerald-900/80">
+                    Lightweight quality signals based on this week&apos;s planned meals.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                  <ul className="space-y-1.5">
+                    {weeklyNutritionInsights.insights.map((insight) => (
+                      <li key={insight} className="flex items-start gap-2 text-sm text-gray-700">
+                        <span className="mt-0.5">•</span>
+                        <span>{insight}</span>
+                      </li>
+                    ))}
+                  </ul>
+                  {weeklyNutritionInsights.looksBalanced ? (
+                    <div className="rounded-md border border-emerald-200 bg-white px-3 py-2 text-sm font-medium text-emerald-700">
+                      Balanced week 👍
+                    </div>
+                  ) : null}
+                </CardContent>
+              </Card>
               <WeeklyReadinessChecklist
                 unplannedMealSlots={unplannedMealSlots}
                 unplannedDaysCount={unplannedDays.length}


### PR DESCRIPTION
### Motivation
- Provide lightweight, actionable nutrition feedback in the meal planner to close the gap between organization and nutritional quality without changing flows or adding backend work. 
- Keep the change fully additive and low-risk so planners retain all existing behaviors and layouts.

### Description
- Added a new "Weekly Nutrition Insights" card to the planner tab (near the readiness area) that renders short bullet-style insights and an optional positive badge when the week looks balanced. 
- Implemented client-only heuristics (in `client/src/components/NutritionMealPlanner.tsx`) that compute: missing coverage, low-protein days, and wide calorie variance from the existing `weeklyNutritionData` rollups. 
- Heuristics and thresholds: low protein = day protein < `60g`; calorie variance checks require at least 3 calorie-tracked days and flag when `max/min >= 1.6` or `(max - min) >= 800 kcal`; shows `Balanced week 👍` when coverage is full, protein is adequate, and calories are consistent. 
- All logic is local and additive with safe fallbacks: informational hints are shown when protein or calorie data are insufficient, and no backend/API code or planner redesign was introduced. 

### Testing
- Built the project successfully with `npm run build` in this environment and confirmed the full pipeline completed. 
- Built the client bundle with `npm run build:client` successfully. 
- Built the server bundle with `npm run build:server` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed32cf3ca88325b4542ca327fb0874)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
