### PR TITLE
Add lightweight “Fix It” quick actions to Weekly Nutrition Insights

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -2315,11 +2315,15 @@ const NutritionMealPlanner = () => {
 
   const hasWeeklyNutritionData = weeklyNutritionData.some((day) => day.mealsLogged > 0 || day.calories > 0);
   const weeklyNutritionInsights = useMemo(() => {
-    const missingMealDays = weeklyNutritionData.filter((day) => day.mealsLogged === 0).length;
+    const missingMealDaysList = weeklyNutritionData.filter((day) => day.mealsLogged === 0);
+    const missingMealDays = missingMealDaysList.length;
     const plannedDays = weeklyNutritionData.filter((day) => day.mealsLogged > 0);
     const proteinTrackedDays = plannedDays.filter((day) => day.protein > 0);
     const calorieTrackedDays = plannedDays.filter((day) => day.calories > 0);
-    const lowProteinDays = proteinTrackedDays.filter((day) => day.protein < 60).length;
+    const lowProteinDaysList = proteinTrackedDays.filter((day) => day.protein < 60);
+    const lowProteinDays = lowProteinDaysList.length;
+    const missingProteinDataDaysList = plannedDays.filter((day) => day.protein <= 0);
+    const missingCalorieDataDaysList = plannedDays.filter((day) => day.calories <= 0);
 
     const caloriesVaryWidely = calorieTrackedDays.length >= 3
       ? (() => {
@@ -2368,8 +2372,91 @@ const NutritionMealPlanner = () => {
     return {
       insights,
       looksBalanced,
+      missingMealDaysList,
+      lowProteinDaysList,
+      missingProteinDataDaysList,
+      missingCalorieDataDaysList,
+      caloriesVaryWidely,
+      canCompareCalories: calorieTrackedDays.length >= 3,
     };
   }, [weeklyNutritionData]);
+
+  const focusPlannerDay = (day: string) => {
+    setActiveTab('planner');
+    setSelectedDate(getDateForWeekday(day));
+  };
+
+  const handleFixMissingDay = () => {
+    const targetDay = weeklyNutritionInsights.missingMealDaysList[0]?.day;
+    if (!targetDay) {
+      setActiveTab('planner');
+      return;
+    }
+    focusPlannerDay(targetDay);
+    handleAddMeal(targetDay, 'Dinner');
+  };
+
+  const handleFixLowProteinDay = () => {
+    const targetDay = weeklyNutritionInsights.lowProteinDaysList[0]?.day;
+    if (!targetDay) {
+      setActiveTab('planner');
+      return;
+    }
+    focusPlannerDay(targetDay);
+  };
+
+  const handleFixMealDetails = () => {
+    const targetDay = weeklyNutritionInsights.missingProteinDataDaysList[0]?.day
+      || weeklyNutritionInsights.missingCalorieDataDaysList[0]?.day;
+    if (!targetDay) {
+      setActiveTab('planner');
+      return;
+    }
+    focusPlannerDay(targetDay);
+  };
+
+  const weeklyNutritionFixActions = useMemo(() => {
+    const actions: Array<{ key: string; label: string; onClick: () => void }> = [];
+    if (weeklyNutritionInsights.missingMealDaysList.length > 0) {
+      actions.push({
+        key: 'fill-unplanned-day',
+        label: 'Fill unplanned day',
+        onClick: handleFixMissingDay,
+      });
+    }
+    if (weeklyNutritionInsights.lowProteinDaysList.length > 0) {
+      actions.push({
+        key: 'review-low-protein-day',
+        label: 'Review low-protein day',
+        onClick: handleFixLowProteinDay,
+      });
+    }
+    if (weeklyNutritionInsights.missingProteinDataDaysList.length > 0 || weeklyNutritionInsights.missingCalorieDataDaysList.length > 0) {
+      actions.push({
+        key: 'review-meal-details',
+        label: 'Add meal details',
+        onClick: handleFixMealDetails,
+      });
+    }
+    if (weeklyNutritionInsights.canCompareCalories && weeklyNutritionInsights.caloriesVaryWidely) {
+      actions.push({
+        key: 'review-calorie-balance',
+        label: 'Review calorie balance',
+        onClick: () => setActiveTab('analytics'),
+      });
+    }
+    if (actions.length > 0) {
+      actions.push({
+        key: 'open-ai-suggestions',
+        label: 'Open AI suggestions',
+        onClick: () => {
+          setActiveTab('planner');
+          handleAIRecipe();
+        },
+      });
+    }
+    return actions;
+  }, [weeklyNutritionInsights]);
 
   const weeklyMacroTotals = weeklyNutritionData.reduce((acc, day) => ({
     protein: acc.protein + day.protein,
@@ -2942,6 +3029,25 @@ const NutritionMealPlanner = () => {
                   {weeklyNutritionInsights.looksBalanced ? (
                     <div className="rounded-md border border-emerald-200 bg-white px-3 py-2 text-sm font-medium text-emerald-700">
                       Balanced week 👍
+                    </div>
+                  ) : null}
+                  {weeklyNutritionFixActions.length > 0 ? (
+                    <div className="rounded-md border border-emerald-200/70 bg-white px-3 py-2">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-emerald-800">Fix It</p>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {weeklyNutritionFixActions.map((action) => (
+                          <Button
+                            key={action.key}
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            className="border-emerald-300 text-emerald-800 hover:bg-emerald-50"
+                            onClick={action.onClick}
+                          >
+                            {action.label}
+                          </Button>
+                        ))}
+                      </div>
                     </div>
                   ) : null}
                 </CardContent>


### PR DESCRIPTION
### Motivation
- The Weekly Nutrition Insights panel diagnosed issues but did not provide immediate next steps, increasing friction from insight → action. 
- The goal was to add a minimal guided action layer focused on meal planning that is additive, client-only, and reuses existing planner flows.

### Description
- Added actionable lists and handlers to `NutritionMealPlanner` and surfaced a compact “Fix It” section inside the existing Weekly Nutrition Insights card (no redesign). 
- Implemented quick actions: `Fill unplanned day`, `Review low-protein day`, `Add meal details`, `Review calorie balance`, and `Open AI suggestions`, which appear only when relevant. 
- Each action reuses existing orchestration handlers (`setActiveTab`, `setSelectedDate`, `handleAddMeal`, `handleAIRecipe`) to navigate/focus the planner or open the AI modal without backend changes. 
- Files changed: `client/src/components/NutritionMealPlanner.tsx` (added insight lists, focus/navigation helpers, `weeklyNutritionFixActions`, and the UI block rendering the Fix It buttons).

### Testing
- Built the project end-to-end with `npm run build` which runs `generate:*`, `npm run build:client`, and `npm run build:server`, and the build completed successfully in this environment. 
- Ran `npm run build:client` and `npm run build:server` individually and both finished successfully (Vite emitted non-blocking chunking warnings only). 
- No automated unit tests were added or modified as the change is UI/UX-focused and fully additive.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed439e71f48325b9b03a84bff8307f)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
