### PR TITLE
Add unresolved Fix It hint row under meal planner progress

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -2597,6 +2597,46 @@ const NutritionMealPlanner = () => {
     };
   }, [activeFixItSlotSignals, activeFixItTarget, calorieGoal, macroGoals.protein, mealTypes, weeklyMeals]);
 
+  const activeFixItUnresolvedHint = useMemo<string | null>(() => {
+    if (!activeFixItTarget || !activeFixItTarget.targetDay || !activeFixItProgressMiniState) return null;
+    if (activeFixItProgressMiniState.unresolvedCount <= 0) return null;
+
+    if (activeFixItTarget.issueType === 'missing-meals') {
+      const emptySlots = activeFixItSlotSignals.filter((slot) => !slot.hasMeals);
+      if (emptySlots.length === 0) return 'Some meal slots are still empty.';
+      const labels = emptySlots.map((slot) => slot.mealTypeLabel);
+      if (labels.length === 1) return `${labels[0]} is still empty.`;
+      if (labels.length === 2) return `${labels[0]} and ${labels[1]} are still empty.`;
+      return `${labels[0]}, ${labels[1]}, and ${labels.length - 2} other slots are still empty.`;
+    }
+
+    if (activeFixItTarget.issueType === 'low-protein') {
+      const dayProtein = activeFixItSlotSignals.reduce((sum, slot) => sum + slot.protein, 0);
+      const proteinGap = Math.max(0, Math.ceil(macroGoals.protein - dayProtein));
+      if (proteinGap <= 0) return null;
+      if (macroGoals.protein <= 0) return 'Protein is still below target.';
+      return `Protein is still ${proteinGap}g below target.`;
+    }
+
+    if (activeFixItTarget.issueType === 'missing-details') {
+      const firstMissingDetailsSlot = activeFixItSlotSignals.find((slot) => slot.missingDetails);
+      if (!firstMissingDetailsSlot) return 'Some meals are still missing calories or protein.';
+      return `${firstMissingDetailsSlot.mealTypeLabel} is missing calories or protein.`;
+    }
+
+    if (activeFixItTarget.issueType === 'calorie-balance') {
+      if (calorieGoal <= 0) return 'This day is still outside your calorie range.';
+      const dayTotals = calculateTodayNutritionTotals(weeklyMeals, activeFixItTarget.targetDay);
+      const lowerBound = calorieGoal * 0.9;
+      const upperBound = calorieGoal * 1.1;
+      if (dayTotals.calories < lowerBound || dayTotals.calories > upperBound) {
+        return 'This day is still outside the target calorie range.';
+      }
+    }
+
+    return null;
+  }, [activeFixItProgressMiniState, activeFixItSlotSignals, activeFixItTarget, calorieGoal, macroGoals.protein, weeklyMeals]);
+
   const activeFixItSlotRecommendations = useMemo<FixItSlotRecommendation[]>(() => {
     if (!activeFixItTarget?.targetDay) return [];
 
@@ -3341,6 +3381,11 @@ const NutritionMealPlanner = () => {
                         }`}>
                           <p className="text-xs font-semibold uppercase tracking-wide">Progress</p>
                           <p className="mt-1 font-medium">{activeFixItProgressMiniState.message}</p>
+                        </div>
+                      ) : null}
+                      {activeFixItUnresolvedHint ? (
+                        <div className="rounded-md border border-orange-200/80 bg-white/90 px-3 py-2 text-sm text-gray-700">
+                          <p className="truncate">{activeFixItUnresolvedHint}</p>
                         </div>
                       ) : null}
                       {activeFixItSlotRecommendations.length > 0 ? (


### PR DESCRIPTION
### Motivation
- Surface a concise, issue-specific explanation for why a Fix It target remains unresolved so users know the single highest-value reason to act. 
- Keep the change additive, client-only, and lightweight to avoid any behavior regression in the existing Fix It guidance and recommendations. 
- Use only existing in-memory signals to avoid backend work or persistence changes. 

### Description
- Added a new client-side memo `activeFixItUnresolvedHint` in `client/src/components/NutritionMealPlanner.tsx` that returns a single one-line unresolved hint or `null` when resolved. 
- Integrated the hint as a compact row directly under the existing Fix It Progress mini-state in the Fix It Guidance card, shown only when `unresolvedCount > 0` and otherwise hidden. 
- Hints shown by issue type are: `missing-meals` — lists open meal slot labels concisely (single, two, or first-two+count); `low-protein` — reports remaining protein gap in grams when available; `missing-details` — points to the first slot missing calories or protein; `calorie-balance` — notes the day is outside the target calorie range. 
- Missing/uncertain data handling uses conservative fallbacks and avoids false precision (e.g., generic wording when goals are invalid/zero), and the logic relies only on `activeFixItTarget`, `activeFixItSlotSignals`, `activeFixItProgressMiniState`, `macroGoals`, `calorieGoal`, and `weeklyMeals`. 

### Testing
- Ran `npm run build` and the build completed successfully. 
- Ran `npm run build:client` and the client build completed successfully. 
- Ran `npm run build:server` and the server build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee311e57dc8325879feef690ca2d3d)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
