### PR TITLE
Add Fix It data-completeness confidence chip to meal planner guidance

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -185,6 +185,11 @@ type FixItProgressMiniState = {
   message: string;
   tone: 'warning' | 'success' | 'neutral';
 };
+type FixItDataCompletenessChipState = {
+  label: string;
+  detail: string;
+  tone: 'success' | 'warning' | 'neutral';
+};
 
 type TemplateBridgePayload = {
   templateName: string;
@@ -2556,6 +2561,59 @@ const NutritionMealPlanner = () => {
     });
   }, [activeFixItTarget?.targetDay, mealTypes, weeklyMeals]);
 
+  const activeFixItDataCompleteness = useMemo<FixItDataCompletenessChipState | null>(() => {
+    if (!activeFixItTarget?.targetDay) return null;
+
+    let plannedMealCount = 0;
+    let mealsWithNutritionCount = 0;
+    let missingNutritionCount = 0;
+
+    mealTypes.forEach((mealType) => {
+      const items = getMealSlotItems(weeklyMeals, activeFixItTarget.targetDay as string, mealType);
+      items.forEach((item) => {
+        plannedMealCount += 1;
+        const hasCalories = Number(item?.calories) > 0;
+        const hasProtein = Number(item?.protein) > 0;
+        const hasCoreNutrition = hasCalories && hasProtein;
+        if (hasCoreNutrition) {
+          mealsWithNutritionCount += 1;
+          return;
+        }
+        missingNutritionCount += 1;
+      });
+    });
+
+    if (plannedMealCount <= 0) {
+      return {
+        label: 'Needs more meal details',
+        detail: 'No meals planned yet for this day.',
+        tone: 'neutral',
+      };
+    }
+
+    if (missingNutritionCount <= 0) {
+      return {
+        label: 'Complete data',
+        detail: 'Guidance is based on complete calories and protein data.',
+        tone: 'success',
+      };
+    }
+
+    if (mealsWithNutritionCount <= 0) {
+      return {
+        label: 'Needs more meal details',
+        detail: `${missingNutritionCount} planned meal${missingNutritionCount === 1 ? '' : 's'} missing calories or protein.`,
+        tone: 'warning',
+      };
+    }
+
+    return {
+      label: 'Partial nutrition data',
+      detail: `${missingNutritionCount} meal${missingNutritionCount === 1 ? '' : 's'} missing calories or protein.`,
+      tone: 'warning',
+    };
+  }, [activeFixItTarget?.targetDay, mealTypes, weeklyMeals]);
+
   const activeFixItProgressMiniState = useMemo<FixItProgressMiniState | null>(() => {
     if (!activeFixItTarget || !activeFixItTarget.targetDay) return null;
 
@@ -3362,7 +3420,22 @@ const NutritionMealPlanner = () => {
                   {activeFixItTarget ? (
                     <div className="rounded-md border border-orange-200 bg-orange-50/70 px-3 py-3 space-y-3">
                       <div>
-                        <p className="text-xs font-semibold uppercase tracking-wide text-orange-800">Fix It Guidance</p>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="text-xs font-semibold uppercase tracking-wide text-orange-800">Fix It Guidance</p>
+                          {activeFixItDataCompleteness ? (
+                            <Badge
+                              className={
+                                activeFixItDataCompleteness.tone === 'success'
+                                  ? 'border border-emerald-300 bg-emerald-100 text-emerald-800'
+                                  : activeFixItDataCompleteness.tone === 'warning'
+                                    ? 'border border-orange-300 bg-orange-100 text-orange-900'
+                                    : 'border border-slate-300 bg-slate-100 text-slate-700'
+                              }
+                            >
+                              {activeFixItDataCompleteness.label}
+                            </Badge>
+                          ) : null}
+                        </div>
                         <p className="mt-1 text-sm font-medium text-orange-900">
                           {activeFixItTarget.targetDay
                             ? `${activeFixItTarget.targetDay} (${activeFixItTarget.targetDate})`
@@ -3370,6 +3443,9 @@ const NutritionMealPlanner = () => {
                         </p>
                         <p className="mt-1 text-sm text-gray-700">{activeFixItTarget.reason}</p>
                         <p className="mt-1 text-sm text-gray-700">{activeFixItTarget.suggestedNextStep}</p>
+                        {activeFixItDataCompleteness ? (
+                          <p className="mt-1 text-xs text-gray-600">{activeFixItDataCompleteness.detail}</p>
+                        ) : null}
                       </div>
                       {activeFixItProgressMiniState ? (
                         <div className={`rounded-md border px-3 py-2 text-sm ${


### PR DESCRIPTION
### Motivation
- Users could not tell how complete or reliable the nutrition data is for the active Fix It guidance day, which reduces trust in suggested fixes. 
- The improvement must be lightweight, client-side only, additive, and avoid pretending precision when data is incomplete. 
- A small, contextual completeness/confidence chip beside the existing Fix It Guidance heading is the highest-value, low-risk UX increment. 

### Description
- Added a new type `FixItDataCompletenessChipState` and a computed state `activeFixItDataCompleteness` in `NutritionMealPlanner` to summarize day-level data completeness. 
- The completeness computation iterates meal slots for the `activeFixItTarget.targetDay` and counts `plannedMealCount`, `mealsWithNutritionCount`, and `missingNutritionCount`. 
- A meal is considered core-nutrition-complete only when both `calories > 0` and `protein > 0`, and the chip label/detail/tone are derived from those counts to avoid overstating precision. 
- Integrated a compact `Badge` next to the `Fix It Guidance` heading and added a short detail line under the guidance copy; all changes are limited to `client/src/components/NutritionMealPlanner.tsx`. 

### Testing
- Built the project with `npm run build` and the build completed successfully with only unrelated, non-blocking warnings from the bundler. 
- Built the client bundle with `npm run build:client` and the build completed successfully (vite warnings about chunking only). 
- Built the server bundle with `npm run build:server` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee3b1088e4832592666bb0b1d03147)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
