### PR TITLE
Add lightweight Fix It data-completeness confidence chip

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -2567,6 +2567,7 @@ const NutritionMealPlanner = () => {
     let plannedMealCount = 0;
     let mealsWithNutritionCount = 0;
     let missingNutritionCount = 0;
+    const emptySlotCount = activeFixItSlotSignals.filter((slot) => !slot.hasMeals).length;
 
     mealTypes.forEach((mealType) => {
       const items = getMealSlotItems(weeklyMeals, activeFixItTarget.targetDay as string, mealType);
@@ -2591,6 +2592,14 @@ const NutritionMealPlanner = () => {
       };
     }
 
+    if (activeFixItTarget.issueType === 'missing-meals' && emptySlotCount > 0) {
+      return {
+        label: 'Partial meal coverage',
+        detail: `${emptySlotCount} meal slot${emptySlotCount === 1 ? '' : 's'} still empty, so guidance is based on partial day data.`,
+        tone: 'neutral',
+      };
+    }
+
     if (missingNutritionCount <= 0) {
       return {
         label: 'Complete data',
@@ -2609,10 +2618,10 @@ const NutritionMealPlanner = () => {
 
     return {
       label: 'Partial nutrition data',
-      detail: `${missingNutritionCount} meal${missingNutritionCount === 1 ? '' : 's'} missing calories or protein.`,
+      detail: `${missingNutritionCount} meal${missingNutritionCount === 1 ? '' : 's'} missing calories or protein, so guidance may be directional.`,
       tone: 'warning',
     };
-  }, [activeFixItTarget?.targetDay, mealTypes, weeklyMeals]);
+  }, [activeFixItSlotSignals, activeFixItTarget?.issueType, activeFixItTarget?.targetDay, mealTypes, weeklyMeals]);
 
   const activeFixItProgressMiniState = useMemo<FixItProgressMiniState | null>(() => {
     if (!activeFixItTarget || !activeFixItTarget.targetDay) return null;


### PR DESCRIPTION
### Motivation
- Users need a quick, honest signal about how complete the nutrition data is for the active Fix It target day so guidance isn't mistaken for precise advice.
- The change must be additive, client-side only, and must not alter existing Fix It flows or UI layout.

### Description
- Implemented a target-aware `activeFixItDataCompleteness` chip in `client/src/components/NutritionMealPlanner.tsx` that examines planned meals and slot coverage for the active Fix It day and returns a small label/detail/tone state for display beside the Fix It Guidance heading.
- Added detection for missing nutrition when `calories <= 0` or `protein <= 0`, and for empty slots via `activeFixItSlotSignals.filter(slot => !slot.hasMeals).length`, and introduced a new `Partial meal coverage` (neutral) state for `missing-meals` targets while keeping existing `Complete data`, `Partial nutrition data`, and `Needs more meal details` states.
- Kept rendering and placement unchanged (chip appears next to the existing Fix It Guidance heading and shows a short detail line), and expanded the memo dependencies to include `activeFixItSlotSignals` and `activeFixItTarget?.issueType`.

### Testing
- Built the project end-to-end with `npm run build`, and the command completed successfully.
- Built the client bundle with `npm run build:client`, and the command completed successfully.
- Built the server bundle with `npm run build:server`, and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee5224c4188325847c32efd300784a)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
