### PR TITLE
Add confidence-aware Fix It quick action to Nutrition Meal Planner

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -190,6 +190,11 @@ type FixItDataCompletenessChipState = {
   detail: string;
   tone: 'success' | 'warning' | 'neutral';
 };
+type FixItConfidenceQuickAction = {
+  label: string;
+  detail: string;
+  onClick: () => void;
+};
 
 type TemplateBridgePayload = {
   templateName: string;
@@ -2704,6 +2709,41 @@ const NutritionMealPlanner = () => {
     return null;
   }, [activeFixItProgressMiniState, activeFixItSlotSignals, activeFixItTarget, calorieGoal, macroGoals.protein, weeklyMeals]);
 
+  const activeFixItConfidenceQuickAction = useMemo<FixItConfidenceQuickAction | null>(() => {
+    if (!activeFixItTarget || !activeFixItDataCompleteness) return null;
+    if (activeFixItDataCompleteness.tone === 'success') return null;
+
+    const targetDay = activeFixItTarget.targetDay;
+    const firstMissingDetailsSlot = activeFixItSlotSignals.find((slot) => slot.missingDetails);
+    const firstEmptySlot = activeFixItSlotSignals.find((slot) => !slot.hasMeals);
+    const firstAffectedSlot = firstMissingDetailsSlot || firstEmptySlot;
+
+    if (!targetDay) {
+      return {
+        label: 'Fill missing nutrition fields first',
+        detail: 'Open Planner to complete missing meal details before applying deeper guidance.',
+        onClick: () => setActiveTab('planner'),
+      };
+    }
+
+    if (firstAffectedSlot) {
+      return {
+        label: `Complete ${firstAffectedSlot.mealTypeLabel} details`,
+        detail: 'Focus this day and add a meal with calories + protein to improve confidence.',
+        onClick: () => {
+          focusPlannerDay(targetDay);
+          handleAddMeal(targetDay, firstAffectedSlot.mealTypeLabel);
+        },
+      };
+    }
+
+    return {
+      label: 'Review Planner details',
+      detail: 'Go to Planner to complete missing fields before following deeper guidance.',
+      onClick: () => setActiveTab('planner'),
+    };
+  }, [activeFixItDataCompleteness, activeFixItSlotSignals, activeFixItTarget]);
+
   const activeFixItSlotRecommendations = useMemo<FixItSlotRecommendation[]>(() => {
     if (!activeFixItTarget?.targetDay) return [];
 
@@ -3466,6 +3506,23 @@ const NutritionMealPlanner = () => {
                         }`}>
                           <p className="text-xs font-semibold uppercase tracking-wide">Progress</p>
                           <p className="mt-1 font-medium">{activeFixItProgressMiniState.message}</p>
+                        </div>
+                      ) : null}
+                      {activeFixItConfidenceQuickAction ? (
+                        <div className="rounded-md border border-orange-200/80 bg-white/90 px-3 py-2">
+                          <p className="text-xs font-semibold uppercase tracking-wide text-orange-800">
+                            Confidence Quick Action
+                          </p>
+                          <p className="mt-1 text-sm text-gray-700">{activeFixItConfidenceQuickAction.detail}</p>
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            className="mt-2 border-orange-300 text-orange-900 hover:bg-orange-100"
+                            onClick={activeFixItConfidenceQuickAction.onClick}
+                          >
+                            {activeFixItConfidenceQuickAction.label}
+                          </Button>
                         </div>
                       ) : null}
                       {activeFixItUnresolvedHint ? (


### PR DESCRIPTION
### Motivation
- The Fix It confidence chip indicates when guidance is based on partial or missing nutrition data but had no immediate lightweight action to improve confidence. 
- Provide a minimal, additive quick action that nudges users to complete core meal nutrition (calories + protein) before deeper guidance is applied. 

### Description
- Added a small type `FixItConfidenceQuickAction` and a computed `activeFixItConfidenceQuickAction` in `client/src/components/NutritionMealPlanner.tsx` to determine a single confidence-aware CTA when the data completeness chip is not `success`. 
- The primary dynamic CTA is `Complete {MealType} details`, which targets the first affected slot (missing-details first, then empty slot) and calls existing handlers `focusPlannerDay` + `handleAddMeal` to focus the planner day and open Add Meal for that slot. 
- If no target day exists the quick action falls back to `Fill missing nutrition fields first` which opens the Planner tab, with a secondary fallback `Review Planner details`; the change is strictly additive and reuses existing handlers. 
- Integrated the new quick action into the Fix It Guidance UI as a compact “Confidence Quick Action” block, placed near the confidence chip and progress mini-state without removing or changing existing features. 

### Testing
- Ran `npm run build` and the build completed successfully. 
- Ran `npm run build:client` and the client build completed successfully. 
- Ran `npm run build:server` and the server build completed successfully. 

Files changed: `client/src/components/NutritionMealPlanner.tsx`.

Next best meal-planner improvement: add a small “Details Completion Queue” micro-flow in Fix It Guidance that steps users through missing-detail meals one-by-one (next/skip/done) to rapidly clear confidence blockers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee879095a8832584bb45b0f4310508)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
