### PR TITLE
Add smart next-best ordering and reason hints to Details Completion Queue

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -204,6 +204,7 @@ type FixItDetailsQueueState = {
     key: string;
     mealType: string;
     mealTypeLabel: string;
+    reasonHint: string;
   } | null;
 };
 
@@ -2574,6 +2575,8 @@ const NutritionMealPlanner = () => {
         hasMeals,
         protein: totals.protein,
         calories: totals.calories,
+        missingProtein,
+        missingCalories,
         missingDetails,
       };
     });
@@ -2765,15 +2768,34 @@ const NutritionMealPlanner = () => {
   const activeFixItDetailsQueue = useMemo<FixItDetailsQueueState | null>(() => {
     if (!activeFixItTarget?.targetDay) return null;
 
-    const missingDetailSlots = activeFixItSlotSignals
-      .filter((slot) => slot.missingDetails)
-      .map((slot) => ({
-        key: `${activeFixItTarget.targetDay}-${slot.mealType}`,
-        mealType: slot.mealType,
-        mealTypeLabel: slot.mealTypeLabel,
-      }));
+    const queueSlots = activeFixItSlotSignals
+      .filter((slot) => slot.missingDetails || !slot.hasMeals)
+      .map((slot) => {
+        let priority = 4;
+        let reasonHint = 'This slot is empty, so details cannot be completed yet.';
 
-    if (missingDetailSlots.length <= 0) {
+        if (slot.hasMeals && slot.missingProtein) {
+          priority = 1;
+          reasonHint = 'Protein is missing here.';
+        } else if (slot.hasMeals && slot.missingCalories) {
+          priority = 2;
+          reasonHint = 'Calories are missing here.';
+        } else if (slot.hasMeals && slot.missingDetails) {
+          priority = 3;
+          reasonHint = 'This slot has food but incomplete details.';
+        }
+
+        return {
+          key: `${activeFixItTarget.targetDay}-${slot.mealType}`,
+          mealType: slot.mealType,
+          mealTypeLabel: slot.mealTypeLabel,
+          priority,
+          reasonHint,
+        };
+      })
+      .sort((a, b) => a.priority - b.priority);
+
+    if (queueSlots.length <= 0) {
       return {
         totalMissingCount: 0,
         remainingCount: 0,
@@ -2783,12 +2805,12 @@ const NutritionMealPlanner = () => {
       };
     }
 
-    const remainingSlots = missingDetailSlots.filter((slot) => !fixItDetailsQueueSkippedKeys.includes(slot.key));
+    const remainingSlots = queueSlots.filter((slot) => !fixItDetailsQueueSkippedKeys.includes(slot.key));
 
     return {
-      totalMissingCount: missingDetailSlots.length,
+      totalMissingCount: queueSlots.length,
       remainingCount: remainingSlots.length,
-      skippedCount: missingDetailSlots.length - remainingSlots.length,
+      skippedCount: queueSlots.length - remainingSlots.length,
       completed: remainingSlots.length <= 0,
       currentSlot: remainingSlots[0] ?? null,
     };
@@ -3615,6 +3637,9 @@ const NutritionMealPlanner = () => {
                             <>
                               <p className="mt-1 text-sm text-gray-700">
                                 Complete {activeFixItDetailsQueue.currentSlot.mealTypeLabel} details
+                              </p>
+                              <p className="mt-1 text-xs text-gray-600">
+                                {activeFixItDetailsQueue.currentSlot.reasonHint}
                               </p>
                               <p className="mt-1 text-xs text-gray-600">
                                 {`${activeFixItDetailsQueue.totalMissingCount - activeFixItDetailsQueue.remainingCount + 1} of ${activeFixItDetailsQueue.totalMissingCount} detail gaps`}


### PR DESCRIPTION
### Motivation
- Make the existing Details Completion Queue feel more intentional by surface the highest-impact missing nutrition fields first without changing data model or actions. 
- Keep the change lightweight and client-side so current planner behavior and actions (`Complete details` / `Skip` / `Done`) are preserved. 

### Description
- Implemented a single cohesive client-side ordering refinement in `client/src/components/NutritionMealPlanner.tsx` that extends slot signals with `missingProtein` and `missingCalories` and derives a prioritized queue. 
- Queue entries now include a `reasonHint` shown next to the current item; the hint text set is: `Protein is missing here.`, `Calories are missing here.`, `This slot has food but incomplete details.`, and `This slot is empty, so details cannot be completed yet.`. 
- The queue is filtered to include incomplete slots and empty slots, then sorted by priority: (1) meals with missing protein, (2) meals with missing calories, (3) meals with other incomplete nutrition fields, (4) empty slots last. 
- This is additive-only and preserves all existing UI actions and the meal data model. 

### Testing
- Built the project end-to-end with `npm run build`, and both `npm run build:client` and `npm run build:server`, all of which completed successfully in this environment. 
- Manual verification points exercised during development: the Details Completion Queue ordering changes, the current-slot `reasonHint` rendering, and that `Complete details` / `Skip` / `Done` continue to call the same handlers (no behaviour changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efacd9836c832586736f5702f0dde9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
