### PR TITLE
Stabilize missing-details Fix It handling for empty slots

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -2671,7 +2671,7 @@ const NutritionMealPlanner = () => {
       const proteinGap = Math.max(0, Math.ceil(macroGoals.protein - dayTotals.protein));
       unresolvedCount = proteinGap > 0 ? 1 : 0;
     } else if (activeFixItTarget.issueType === 'missing-details') {
-      unresolvedCount = activeFixItSlotSignals.filter((slot) => slot.missingDetails).length;
+      unresolvedCount = activeFixItSlotSignals.filter((slot) => slot.missingDetails || !slot.hasMeals).length;
     } else if (activeFixItTarget.issueType === 'calorie-balance') {
       const targetDayTotals = calculateTodayNutritionTotals(weeklyMeals, activeFixItTarget.targetDay as string);
       const lowerBound = calorieGoal * 0.9;
@@ -2719,8 +2719,14 @@ const NutritionMealPlanner = () => {
 
     if (activeFixItTarget.issueType === 'missing-details') {
       const firstMissingDetailsSlot = activeFixItSlotSignals.find((slot) => slot.missingDetails);
-      if (!firstMissingDetailsSlot) return 'Some meals are still missing calories or protein.';
-      return `${firstMissingDetailsSlot.mealTypeLabel} is missing calories or protein.`;
+      if (firstMissingDetailsSlot) {
+        return `${firstMissingDetailsSlot.mealTypeLabel} is missing calories or protein.`;
+      }
+      const firstEmptySlot = activeFixItSlotSignals.find((slot) => !slot.hasMeals);
+      if (firstEmptySlot) {
+        return `${firstEmptySlot.mealTypeLabel} is still empty.`;
+      }
+      return 'Some meals are still missing calories or protein.';
     }
 
     if (activeFixItTarget.issueType === 'calorie-balance') {
@@ -2951,6 +2957,17 @@ const NutritionMealPlanner = () => {
           pushRecommendation({
             key: `details-${slot.mealType}`,
             text: `Complete calories/protein for ${slot.mealTypeLabel}`,
+            cta: 'Add Meal',
+            onClick: () => addMealForSlot(slot.mealType),
+          });
+        });
+      }
+      const emptySlots = slotSignals.filter((slot) => !slot.hasMeals);
+      if (emptySlots.length > 0) {
+        emptySlots.slice(0, 1).forEach((slot) => {
+          pushRecommendation({
+            key: `details-fill-${slot.mealType}`,
+            text: `Fill ${slot.mealTypeLabel} so nutrition details can be tracked`,
             cta: 'Add Meal',
             onClick: () => addMealForSlot(slot.mealType),
           });


### PR DESCRIPTION
### Motivation
- The Details Completion Queue treated empty meal slots as actionable gaps while the Fix It progress and hints only considered meals missing nutrition, which could show a falsely "resolved" Fix It state for `missing-details` targets.

### Description
- Updated the `missing-details` progress calculation to count both `missingDetails` and empty slots by changing the unresolved count filter in `client/src/components/NutritionMealPlanner.tsx`.
- Improved the unresolved hint for `missing-details` so it falls back to naming an empty slot when no macro-missing slot exists, making messaging consistent with queue state.
- Added a recommendation to the `missing-details` recommendations list to suggest filling an empty slot so UI CTAs align with queue/completion behavior; the change is contained in `client/src/components/NutritionMealPlanner.tsx`.

### Testing
- Ran `npm run build` which completed successfully.
- Ran `npm run build:client` which completed successfully.
- Ran `npm run build:server` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc05e67f88325afee1f72b8a9222c)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
