### PR TITLE
Normalize potent-potables category writes to canonical 'potent-potables'

### DIFF
--- a/client/src/pages/drinks/potent-potables/cognac-brandy/index.tsx
+++ b/client/src/pages/drinks/potent-potables/cognac-brandy/index.tsx
@@ -227,7 +227,7 @@ export default function CognacBrandyPage() {
       addToRecentlyViewed({
         id: selectedRecipe.id,
         name: selectedRecipe.name,
-        category: 'cognac-brandy',
+        category: 'potent-potables',
         timestamp: Date.now()
       });
       incrementDrinksMade();
@@ -259,7 +259,7 @@ export default function CognacBrandyPage() {
     addToRecentlyViewed({
       id: cocktail.id,
       name: cocktail.name,
-      category: 'cognac-brandy',
+      category: 'potent-potables',
       timestamp: Date.now()
     });
   };
@@ -488,7 +488,7 @@ export default function CognacBrandyPage() {
                               addToFavorites({
                                 id: cocktail.id,
                                 name: cocktail.name,
-                                category: 'cognac-brandy',
+                                category: 'potent-potables',
                                 timestamp: Date.now()
                               });
                             }}

--- a/client/src/pages/drinks/potent-potables/gin/index.tsx
+++ b/client/src/pages/drinks/potent-potables/gin/index.tsx
@@ -197,7 +197,7 @@ export default function GinCocktailsPage() {
       addToRecentlyViewed({
         id: selectedRecipe.id,
         name: selectedRecipe.name,
-        category: 'gin-cocktails',
+        category: 'potent-potables',
         timestamp: Date.now()
       });
       incrementDrinksMade();
@@ -493,7 +493,7 @@ export default function GinCocktailsPage() {
                           addToFavorites({
                             id: cocktail.id,
                             name: cocktail.name,
-                            category: 'Gin Cocktails',
+                            category: 'potent-potables',
                             timestamp: Date.now()
                           });
                         }}

--- a/client/src/pages/drinks/potent-potables/hot-drinks/index.tsx
+++ b/client/src/pages/drinks/potent-potables/hot-drinks/index.tsx
@@ -199,7 +199,7 @@ export default function HotDrinksPage() {
       addToRecentlyViewed({
         id: selectedRecipe.id,
         name: selectedRecipe.name,
-        category: 'hot-drinks',
+        category: 'potent-potables',
         timestamp: Date.now()
       });
       incrementDrinksMade();
@@ -486,7 +486,7 @@ export default function HotDrinksPage() {
                           addToFavorites({
                             id: drink.id,
                             name: drink.name,
-                            category: 'Hot Drinks',
+                            category: 'potent-potables',
                             timestamp: Date.now()
                           });
                         }}

--- a/client/src/pages/drinks/potent-potables/index.tsx
+++ b/client/src/pages/drinks/potent-potables/index.tsx
@@ -631,7 +631,7 @@ export default function PotentPotablesPage() {
                     </div>
                     <div className="absolute top-2 right-2">
                       <Button variant="ghost" size="sm" className="bg-white/80 hover:bg-white text-gray-600"
-                        onClick={(e) => { e.stopPropagation(); addToFavorites({ id: cocktail.id, name: cocktail.name, category: 'cocktails', timestamp: Date.now() }); }}>
+                        onClick={(e) => { e.stopPropagation(); addToFavorites({ id: cocktail.id, name: cocktail.name, category: 'potent-potables', timestamp: Date.now() }); }}>
                         <Heart className={`h-4 w-4 ${isFavorite(cocktail.id) ? 'fill-red-500 text-red-500' : ''}`} />
                       </Button>
                     </div>

--- a/client/src/pages/drinks/potent-potables/liqueurs/index.tsx
+++ b/client/src/pages/drinks/potent-potables/liqueurs/index.tsx
@@ -193,7 +193,7 @@ export default function LiqueursPage() {
       addToRecentlyViewed({
         id: selectedRecipe.id,
         name: selectedRecipe.name,
-        category: 'liqueurs',
+        category: 'potent-potables',
         timestamp: Date.now()
       });
       incrementDrinksMade();
@@ -484,7 +484,7 @@ export default function LiqueursPage() {
                           addToFavorites({
                             id: cocktail.id,
                             name: cocktail.name,
-                            category: 'Liqueurs',
+                            category: 'potent-potables',
                             timestamp: Date.now()
                           });
                         }}

--- a/client/src/pages/drinks/potent-potables/martinis/index.tsx
+++ b/client/src/pages/drinks/potent-potables/martinis/index.tsx
@@ -204,7 +204,7 @@ export default function MartinisPage() {
       addToRecentlyViewed({
         id: selectedRecipe.id,
         name: selectedRecipe.name,
-        category: 'martinis',
+        category: 'potent-potables',
         timestamp: Date.now()
       });
       incrementDrinksMade();
@@ -237,7 +237,7 @@ export default function MartinisPage() {
     addToRecentlyViewed({
       id: martini.id,
       name: martini.name,
-      category: 'Martinis',
+      category: 'potent-potables',
       timestamp: Date.now()
     });
   };
@@ -510,7 +510,7 @@ export default function MartinisPage() {
                           addToFavorites({
                             id: martini.id,
                             name: martini.name,
-                            category: 'Martinis',
+                            category: 'potent-potables',
                             timestamp: Date.now()
                           });
                         }}
@@ -681,7 +681,7 @@ export default function MartinisPage() {
                             e.stopPropagation();
                             handleShareMartini(martini, servings);
                           }}>
-                            <Share2 className="w-4 w-4 mr-1" /> Share
+                            <Share2 className="w-4 h-4 mr-1" /> Share
                           </Button>
                           <Button
                             variant="outline"

--- a/client/src/pages/drinks/potent-potables/mocktails/index.tsx
+++ b/client/src/pages/drinks/potent-potables/mocktails/index.tsx
@@ -214,7 +214,7 @@ export default function MocktailsPage() {
       addToRecentlyViewed({
         id: selectedRecipe.id,
         name: selectedRecipe.name,
-        category: 'Mocktails',
+        category: 'potent-potables',
         timestamp: Date.now()
       });
       incrementDrinksMade();
@@ -252,7 +252,7 @@ export default function MocktailsPage() {
     addToRecentlyViewed({
       id: mocktail.id,
       name: mocktail.name,
-      category: 'Mocktails',
+      category: 'potent-potables',
       timestamp: Date.now()
     });
   };
@@ -481,7 +481,7 @@ export default function MocktailsPage() {
                         addToFavorites({
                           id: mocktail.id,
                           name: mocktail.name,
-                          category: 'Mocktails',
+                          category: 'potent-potables',
                           timestamp: Date.now()
                         });
                       }}

--- a/client/src/pages/drinks/potent-potables/rum/index.tsx
+++ b/client/src/pages/drinks/potent-potables/rum/index.tsx
@@ -199,7 +199,7 @@ export default function RumCocktailsPage() {
       addToRecentlyViewed({
         id: selectedRecipe.id,
         name: selectedRecipe.name,
-        category: 'rum-cocktails',
+        category: 'potent-potables',
         timestamp: Date.now()
       });
       incrementDrinksMade();
@@ -222,7 +222,7 @@ export default function RumCocktailsPage() {
     addToRecentlyViewed({
       id: cocktail.id,
       name: cocktail.name,
-      category: 'rum-cocktails',
+      category: 'potent-potables',
       timestamp: Date.now()
     });
   };
@@ -436,7 +436,7 @@ export default function RumCocktailsPage() {
                           addToFavorites({
                             id: cocktail.id,
                             name: cocktail.name,
-                            category: 'Rum Cocktails',
+                            category: 'potent-potables',
                             timestamp: Date.now()
                           });
                         }}

--- a/client/src/pages/drinks/potent-potables/scotch-irish-whiskey/index.tsx
+++ b/client/src/pages/drinks/potent-potables/scotch-irish-whiskey/index.tsx
@@ -194,7 +194,7 @@ export default function ScotchIrishWhiskeyPage() {
       addToRecentlyViewed({
         id: selectedRecipe.id,
         name: selectedRecipe.name,
-        category: 'scotch-irish-whiskey',
+        category: 'potent-potables',
         timestamp: Date.now()
       });
       incrementDrinksMade();
@@ -217,7 +217,7 @@ export default function ScotchIrishWhiskeyPage() {
     addToRecentlyViewed({
       id: cocktail.id,
       name: cocktail.name,
-      category: 'scotch-irish-whiskey',
+      category: 'potent-potables',
       timestamp: Date.now()
     });
   };
@@ -429,7 +429,7 @@ export default function ScotchIrishWhiskeyPage() {
                           addToFavorites({
                             id: cocktail.id,
                             name: cocktail.name,
-                            category: 'Scotch & Irish Whiskey',
+                            category: 'potent-potables',
                             timestamp: Date.now()
                           });
                         }}

--- a/client/src/pages/drinks/potent-potables/seasonal/index.tsx
+++ b/client/src/pages/drinks/potent-potables/seasonal/index.tsx
@@ -236,7 +236,7 @@ export default function SeasonalCocktailsPage() {
       addToRecentlyViewed({
         id: selectedRecipe.id,
         name: selectedRecipe.name,
-        category: 'seasonal-cocktails',
+        category: 'potent-potables',
         timestamp: Date.now()
       });
       incrementDrinksMade();
@@ -271,7 +271,7 @@ export default function SeasonalCocktailsPage() {
     addToRecentlyViewed({
       id: cocktail.id,
       name: cocktail.name,
-      category: 'Seasonal Cocktails',
+      category: 'potent-potables',
       timestamp: Date.now()
     });
   };
@@ -493,7 +493,7 @@ export default function SeasonalCocktailsPage() {
                           addToFavorites({
                             id: cocktail.id,
                             name: cocktail.name,
-                            category: 'Seasonal Cocktails',
+                            category: 'potent-potables',
                             timestamp: Date.now()
                           });
                         }}

--- a/client/src/pages/drinks/potent-potables/spritz/index.tsx
+++ b/client/src/pages/drinks/potent-potables/spritz/index.tsx
@@ -197,7 +197,7 @@ export default function SpritzMimosasPage() {
       addToRecentlyViewed({
         id: selectedRecipe.id,
         name: selectedRecipe.name,
-        category: 'spritz-mimosas',
+        category: 'potent-potables',
         timestamp: Date.now()
       });
       incrementDrinksMade();
@@ -475,7 +475,7 @@ export default function SpritzMimosasPage() {
                           addToFavorites({
                             id: cocktail.id,
                             name: cocktail.name,
-                            category: 'Spritz & Mimosas',
+                            category: 'potent-potables',
                             timestamp: Date.now()
                           });
                         }}

--- a/client/src/pages/drinks/potent-potables/tequila-mezcal/index.tsx
+++ b/client/src/pages/drinks/potent-potables/tequila-mezcal/index.tsx
@@ -199,7 +199,7 @@ export default function TequilaMezcalPage() {
       addToRecentlyViewed({
         id: selectedRecipe.id,
         name: selectedRecipe.name,
-        category: 'tequila-mezcal',
+        category: 'potent-potables',
         timestamp: Date.now()
       });
       incrementDrinksMade();
@@ -222,7 +222,7 @@ export default function TequilaMezcalPage() {
     addToRecentlyViewed({
       id: cocktail.id,
       name: cocktail.name,
-      category: 'tequila-mezcal',
+      category: 'potent-potables',
       timestamp: Date.now()
     });
   };
@@ -436,7 +436,7 @@ export default function TequilaMezcalPage() {
                           addToFavorites({
                             id: cocktail.id,
                             name: cocktail.name,
-                            category: 'Tequila & Mezcal',
+                            category: 'potent-potables',
                             timestamp: Date.now()
                           });
                         }}

--- a/client/src/pages/drinks/potent-potables/vodka/index.tsx
+++ b/client/src/pages/drinks/potent-potables/vodka/index.tsx
@@ -208,7 +208,7 @@ export default function VodkaCocktailsPage() {
       addToRecentlyViewed({
         id: selectedRecipe.id,
         name: selectedRecipe.name,
-        category: 'vodka-cocktails',
+        category: 'potent-potables',
         timestamp: Date.now()
       });
       incrementDrinksMade();
@@ -496,7 +496,7 @@ export default function VodkaCocktailsPage() {
                           addToFavorites({
                             id: cocktail.id,
                             name: cocktail.name,
-                            category: 'Vodka Cocktails',
+                            category: 'potent-potables',
                             timestamp: Date.now()
                           });
                         }}

--- a/client/src/pages/drinks/potent-potables/whiskey-bourbon/index.tsx
+++ b/client/src/pages/drinks/potent-potables/whiskey-bourbon/index.tsx
@@ -205,7 +205,7 @@ export default function WhiskeyBourbonPage() {
       addToRecentlyViewed({
         id: selectedRecipe.id,
         name: selectedRecipe.name,
-        category: 'whiskey-bourbon',
+        category: 'potent-potables',
         timestamp: Date.now()
       });
       incrementDrinksMade();
@@ -502,7 +502,7 @@ export default function WhiskeyBourbonPage() {
                           addToFavorites({
                             id: cocktail.id,
                             name: cocktail.name,
-                            category: 'Whiskey & Bourbon',
+                            category: 'potent-potables',
                             timestamp: Date.now()
                           });
                         }}


### PR DESCRIPTION
Every potent-potables subcategory page wrote a different string into DrinkItem.category — some files even mixed kebab-case and TitleCase in the same file ('martinis' alongside 'Martinis'). The DrinkItem type only allows 'smoothies' | 'protein-shakes' | 'detoxes' | 'potent-potables' | 'workout-drinks', so every PP subcategory should write 'potent-potables' to match how smoothies/protein/detoxes/caffeinated already work.

Also fixes a duplicate-class typo in the martinis Share button (<Share2 className="w-4 w-4 mr-1" /> → "w-4 h-4 mr-1").

The hub page (potent-potables/index.tsx) still reads both 'potent-potables' and 'cocktails' when filtering favorites, so existing data stored under the old strings is unaffected.

https://claude.ai/code/session_01NboRL52pD7M9MBSFewdCVF
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
