### PR TITLE
Keep fix-it queue skip/snooze states mutually exclusive; remove duplicate `sortedDrinkCategories` declaration

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -2859,6 +2859,12 @@ const NutritionMealPlanner = () => {
       ...prev,
       [slotKey]: reasonId,
     }));
+    setFixItDetailsQueueSnoozedByKey((prev) => {
+      if (!prev[slotKey]) return prev;
+      const next = { ...prev };
+      delete next[slotKey];
+      return next;
+    });
     setFixItDetailsQueuePendingSkipReason(DEFAULT_FIX_IT_DETAILS_QUEUE_SKIP_REASON);
   };
 
@@ -2868,6 +2874,13 @@ const NutritionMealPlanner = () => {
       ...prev,
       [slotKey]: snoozeId,
     }));
+    setFixItDetailsQueueSkippedKeys((prev) => prev.filter((key) => key !== slotKey));
+    setFixItDetailsQueueSkipReasonByKey((prev) => {
+      if (!prev[slotKey]) return prev;
+      const next = { ...prev };
+      delete next[slotKey];
+      return next;
+    });
   };
 
   const handleQueueRevisitSnoozed = () => {

--- a/client/src/pages/drinks/index.tsx
+++ b/client/src/pages/drinks/index.tsx
@@ -194,8 +194,6 @@ const userStats = {
   streak: 7
 };
 
-const sortedDrinkCategories = sortByName(drinkCategories);
-
 export default function DrinksPage() {
   const [location, setLocation] = useLocation();
 


### PR DESCRIPTION
### Motivation
- Prevent a fix-it slot from being both skipped and snoozed at the same time to keep queue state consistent.
- Remove an accidental duplicate declaration of `sortedDrinkCategories` to avoid redeclaration issues.

### Description
- In `NutritionMealPlanner.tsx` update `handleQueueSkipCurrent` to clear any existing snooze entry for the skipped `slotKey` by deleting it from `fixItDetailsQueueSnoozedByKey`.
- In `NutritionMealPlanner.tsx` update `handleQueueSnoozeCurrent` to remove the `slotKey` from `fixItDetailsQueueSkippedKeys` and delete its entry from `fixItDetailsQueueSkipReasonByKey` so skipped and snoozed states are exclusive.
- Remove the duplicate `const sortedDrinkCategories = sortByName(drinkCategories);` line from `client/src/pages/drinks/index.tsx`.

### Testing
- Ran TypeScript compilation (`tsc`) and the project build; compilation succeeded.
- Ran the unit test suite (`npm test`) and the tests passed.
- Ran linting (`npm run lint`) and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f208d947d08325902bb812381d88c3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
