### PR TITLE
Add lightweight day-level Fix It completion momentum feedback

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -185,6 +185,12 @@ type FixItProgressMiniState = {
   message: string;
   tone: 'warning' | 'success' | 'neutral';
 };
+type FixItDayCompletionState = {
+  totalIssues: number;
+  resolvedIssues: number;
+  remainingIssues: number;
+  allResolved: boolean;
+};
 type FixItDataCompletenessChipState = {
   label: string;
   detail: string;
@@ -2704,6 +2710,41 @@ const NutritionMealPlanner = () => {
     };
   }, [activeFixItSlotSignals, activeFixItTarget, calorieGoal, macroGoals.protein, mealTypes, weeklyMeals]);
 
+  const activeFixItDayCompletion = useMemo<FixItDayCompletionState | null>(() => {
+    if (!activeFixItTarget?.targetDay) return null;
+
+    const slotCount = mealTypes.length;
+    if (slotCount <= 0) return null;
+
+    const missingMealsRemaining = activeFixItSlotSignals.filter((slot) => !slot.hasMeals).length;
+    const missingMealsResolved = Math.max(0, slotCount - missingMealsRemaining);
+
+    const missingDetailsRemaining = activeFixItSlotSignals.filter((slot) => slot.missingDetails || !slot.hasMeals).length;
+    const missingDetailsResolved = Math.max(0, slotCount - missingDetailsRemaining);
+
+    const dayProtein = activeFixItSlotSignals.reduce((sum, slot) => sum + slot.protein, 0);
+    const proteinGap = Math.max(0, Math.ceil(macroGoals.protein - dayProtein));
+    const lowProteinRemaining = proteinGap > 0 ? 1 : 0;
+    const lowProteinResolved = lowProteinRemaining === 0 ? 1 : 0;
+
+    const dayTotals = calculateTodayNutritionTotals(weeklyMeals, activeFixItTarget.targetDay);
+    const lowerBound = calorieGoal * 0.9;
+    const upperBound = calorieGoal * 1.1;
+    const calorieBalanceRemaining = calorieGoal > 0 && (dayTotals.calories < lowerBound || dayTotals.calories > upperBound) ? 1 : 0;
+    const calorieBalanceResolved = calorieBalanceRemaining === 0 ? 1 : 0;
+
+    const totalIssues = (slotCount * 2) + 2;
+    const resolvedIssues = missingMealsResolved + missingDetailsResolved + lowProteinResolved + calorieBalanceResolved;
+    const remainingIssues = Math.max(0, totalIssues - resolvedIssues);
+
+    return {
+      totalIssues,
+      resolvedIssues,
+      remainingIssues,
+      allResolved: remainingIssues === 0,
+    };
+  }, [activeFixItSlotSignals, activeFixItTarget?.targetDay, calorieGoal, macroGoals.protein, mealTypes, weeklyMeals]);
+
   const activeFixItUnresolvedHint = useMemo<string | null>(() => {
     if (!activeFixItTarget || !activeFixItTarget.targetDay || !activeFixItProgressMiniState) return null;
     if (activeFixItProgressMiniState.unresolvedCount <= 0) return null;
@@ -3682,6 +3723,25 @@ const NutritionMealPlanner = () => {
                         }`}>
                           <p className="text-xs font-semibold uppercase tracking-wide">Progress</p>
                           <p className="mt-1 font-medium">{activeFixItProgressMiniState.message}</p>
+                        </div>
+                      ) : null}
+                      {activeFixItDayCompletion ? (
+                        <div className={`rounded-md border px-3 py-2 text-sm ${
+                          activeFixItDayCompletion.allResolved
+                            ? 'border-emerald-200 bg-emerald-50 text-emerald-800'
+                            : 'border-orange-200 bg-white/90 text-orange-900'
+                        }`}>
+                          <p className="text-xs font-semibold uppercase tracking-wide">Day completion</p>
+                          <p className="mt-1 font-medium">
+                            {activeFixItDayCompletion.allResolved
+                              ? 'All issues resolved ✅'
+                              : `${activeFixItDayCompletion.resolvedIssues} of ${activeFixItDayCompletion.totalIssues} issues resolved`}
+                          </p>
+                          {activeFixItDayCompletion.allResolved ? (
+                            <p className="mt-1 text-xs text-emerald-700">Nice — this day looks balanced 👍</p>
+                          ) : (
+                            <p className="mt-1 text-xs text-gray-600">{activeFixItDayCompletion.remainingIssues} remaining for today.</p>
+                          )}
                         </div>
                       ) : null}
                       {activeFixItConfidenceQuickAction ? (


### PR DESCRIPTION
### Motivation
- Users lacked a clear day-level sense of completion after addressing individual Fix It items, so add a lightweight, in-memory completion signal scoped to the active day without changing existing queue logic.  
- Keep changes strictly additive, frontend-only, and targeted to meal-planning / nutrition signals already used by Fix It (missing meals, low protein, missing details, calorie balance).

### Description
- Added a new type `FixItDayCompletionState` and computed `activeFixItDayCompletion` in `NutritionMealPlanner` to expose `totalIssues`, `resolvedIssues`, `remainingIssues`, and `allResolved` for the active day only.  
- The computation is frontend-only, non-persistent, and derived from existing signals: per-slot missing meals, per-slot missing details, a binary low-protein issue (day-level), and a binary calorie-balance issue (day-level ±10%).  
- Added a small `Day completion` UI block inside the existing Fix It Guidance that shows either `X of Y issues resolved` or `All issues resolved ✅` and the success message `Nice — this day looks balanced 👍` when complete, without removing or altering the existing progress mini-state or details queue.  
- File changed: `client/src/components/NutritionMealPlanner.tsx` (additive modifications only).

### Testing
- Ran `npm run build` and the top-level build completed successfully.  
- Ran `npm run build:client` and client build completed successfully (Vite bundle-size warnings unchanged).  
- Ran `npm run build:server` and server bundle completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f218b7454483259f04f674fd5830ec)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
