### PR TITLE
Add in-session Fix It completion delta indicator

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -307,6 +307,7 @@ const NutritionMealPlanner = () => {
   const [pendingTemplateBridgePreview, setPendingTemplateBridgePreview] = useState<PendingTemplateBridgePreview | null>(null);
   const [recentPinnedTemplates, setRecentPinnedTemplates] = useState<RecentPinnedTemplateUsage[]>([]);
   const [activeFixItTarget, setActiveFixItTarget] = useState<ActiveFixItTarget | null>(null);
+  const [activeFixItResolvedBaseline, setActiveFixItResolvedBaseline] = useState<number | null>(null);
   const [fixItDetailsQueueSkippedKeys, setFixItDetailsQueueSkippedKeys] = useState<string[]>([]);
   const [fixItDetailsQueueSkipReasonByKey, setFixItDetailsQueueSkipReasonByKey] = useState<Record<string, FixItDetailsQueueSkipReasonId>>({});
   const [fixItDetailsQueuePendingSkipReason, setFixItDetailsQueuePendingSkipReason] = useState<FixItDetailsQueueSkipReasonId>(DEFAULT_FIX_IT_DETAILS_QUEUE_SKIP_REASON);
@@ -2745,6 +2746,26 @@ const NutritionMealPlanner = () => {
     };
   }, [activeFixItSlotSignals, activeFixItTarget?.targetDay, calorieGoal, macroGoals.protein, mealTypes, weeklyMeals]);
 
+  const activeFixItBaselineKey = activeFixItTarget
+    ? `${activeFixItTarget.issueType}:${activeFixItTarget.targetDay ?? ''}:${activeFixItTarget.targetDate ?? ''}`
+    : null;
+
+  useEffect(() => {
+    if (!activeFixItBaselineKey) {
+      setActiveFixItResolvedBaseline(null);
+      return;
+    }
+    setActiveFixItResolvedBaseline(activeFixItDayCompletion?.resolvedIssues ?? null);
+  }, [activeFixItBaselineKey]);
+
+  const activeFixItCompletionDeltaText = useMemo<string | null>(() => {
+    if (!activeFixItDayCompletion || activeFixItResolvedBaseline === null) return null;
+    const delta = activeFixItDayCompletion.resolvedIssues - activeFixItResolvedBaseline;
+    if (delta > 0) return `+${delta} resolved since opening Fix It`;
+    if (delta < 0) return `${Math.abs(delta)} new issues appeared`;
+    return 'No change yet';
+  }, [activeFixItDayCompletion, activeFixItResolvedBaseline]);
+
   const activeFixItUnresolvedHint = useMemo<string | null>(() => {
     if (!activeFixItTarget || !activeFixItTarget.targetDay || !activeFixItProgressMiniState) return null;
     if (activeFixItProgressMiniState.unresolvedCount <= 0) return null;
@@ -3742,6 +3763,9 @@ const NutritionMealPlanner = () => {
                           ) : (
                             <p className="mt-1 text-xs text-gray-600">{activeFixItDayCompletion.remainingIssues} remaining for today.</p>
                           )}
+                          {activeFixItCompletionDeltaText ? (
+                            <p className="mt-1 text-xs text-gray-600">{activeFixItCompletionDeltaText}</p>
+                          ) : null}
                         </div>
                       ) : null}
                       {activeFixItConfidenceQuickAction ? (


### PR DESCRIPTION
### Motivation
- Users cannot see how much progress they made in-session after opening a Fix It target, which makes it harder to track small improvements during the Fix It flow. 
- Add a lightweight, non-persistent UI hint scoped to the active Fix It target so users get immediate feedback without changing completion logic or persisting data. 

### Description
- Added a new in-memory state `activeFixItResolvedBaseline` to capture the resolved-issues count when a Fix It target is opened. 
- Derives a `activeFixItBaselineKey` from `issueType`, `targetDay`, and `targetDate` and uses a `useEffect` to capture/reset the baseline when the active target key changes. 
- Computes `activeFixItCompletionDeltaText` (one of `+N resolved since opening Fix It`, `No change yet`, or `N new issues appeared`) via `useMemo` by comparing current `activeFixItDayCompletion.resolvedIssues` with the baseline. 
- Renders the delta line under the existing Day completion block without altering existing completion calculations or persisting any new data. 
- Files changed: `client/src/components/NutritionMealPlanner.tsx`. 

### Testing
- Ran `npm run build` successfully in this environment. 
- Ran `npm run build:client` successfully in this environment. 
- Ran `npm run build:server` successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23100109883258b10c98adaef186a)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
