### PR TITLE
Add completion trend chip to Fix It Day completion

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -191,6 +191,10 @@ type FixItDayCompletionState = {
   remainingIssues: number;
   allResolved: boolean;
 };
+type FixItCompletionTrendChipState = {
+  label: string;
+  className: string;
+};
 type FixItDataCompletenessChipState = {
   label: string;
   detail: string;
@@ -2766,6 +2770,27 @@ const NutritionMealPlanner = () => {
     return 'No change yet';
   }, [activeFixItDayCompletion, activeFixItResolvedBaseline]);
 
+  const activeFixItCompletionTrendChip = useMemo<FixItCompletionTrendChipState | null>(() => {
+    if (!activeFixItDayCompletion || activeFixItResolvedBaseline === null) return null;
+    const delta = activeFixItDayCompletion.resolvedIssues - activeFixItResolvedBaseline;
+    if (delta > 0) {
+      return {
+        label: 'Improving',
+        className: 'border border-emerald-300 bg-emerald-100 text-emerald-800',
+      };
+    }
+    if (delta < 0) {
+      return {
+        label: 'Needs attention',
+        className: 'border border-rose-300 bg-rose-100 text-rose-800',
+      };
+    }
+    return {
+      label: 'No change',
+      className: 'border border-slate-300 bg-slate-100 text-slate-700',
+    };
+  }, [activeFixItDayCompletion, activeFixItResolvedBaseline]);
+
   const activeFixItUnresolvedHint = useMemo<string | null>(() => {
     if (!activeFixItTarget || !activeFixItTarget.targetDay || !activeFixItProgressMiniState) return null;
     if (activeFixItProgressMiniState.unresolvedCount <= 0) return null;
@@ -3752,7 +3777,14 @@ const NutritionMealPlanner = () => {
                             ? 'border-emerald-200 bg-emerald-50 text-emerald-800'
                             : 'border-orange-200 bg-white/90 text-orange-900'
                         }`}>
-                          <p className="text-xs font-semibold uppercase tracking-wide">Day completion</p>
+                          <div className="flex flex-wrap items-center gap-2">
+                            <p className="text-xs font-semibold uppercase tracking-wide">Day completion</p>
+                            {activeFixItCompletionTrendChip ? (
+                              <Badge className={activeFixItCompletionTrendChip.className}>
+                                {activeFixItCompletionTrendChip.label}
+                              </Badge>
+                            ) : null}
+                          </div>
                           <p className="mt-1 font-medium">
                             {activeFixItDayCompletion.allResolved
                               ? 'All issues resolved ✅'


### PR DESCRIPTION
### Motivation
- Provide a quick visual indicator of whether Fix It progress for a day is improving, worsening, or unchanged to help users triage days faster.
- Surface the resolved-issues delta alongside existing completion text so the UX communicates trend as well as status.

### Description
- Introduced a new `FixItCompletionTrendChipState` type that models a trend label and `className` for styling. 
- Added `activeFixItCompletionTrendChip` computed state which derives an `Improving` / `Needs attention` / `No change` chip from the existing resolved-issues delta. 
- Updated the Day completion UI to render a `Badge` with the trend chip next to the `Day completion` heading and reused the existing resolved-baseline/delta logic.

### Testing
- Ran the TypeScript type check with `tsc --noEmit` and it completed successfully. 
- Ran the unit test suite with `yarn test` and all tests passed. 
- Performed a local build with `yarn build` and linting with `yarn lint`, both completing without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24a5978208325afa8088ed3dd20db)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
