### PR TITLE
Standardize drinks section: tab IDs, type union, XP rewards, PP search/share

### DIFF
--- a/client/src/contexts/DrinksContext.tsx
+++ b/client/src/contexts/DrinksContext.tsx
@@ -5,7 +5,7 @@ import React, { createContext, useContext, useState, useEffect } from 'react';
 export interface DrinkItem {
   id: string;
   name: string;
-  category: 'smoothies' | 'protein-shakes' | 'detoxes' | 'potent-potables' | 'workout-drinks';
+  category: 'smoothies' | 'protein-shakes' | 'detoxes' | 'potent-potables' | 'workout-drinks' | 'caffeinated';
   description?: string;
   image?: string;
   ingredients?: string[];

--- a/client/src/pages/drinks/caffeinated/matcha/index.tsx
+++ b/client/src/pages/drinks/caffeinated/matcha/index.tsx
@@ -137,7 +137,7 @@ export default function MatchaDrinksPage() {
   const [maxCalories, setMaxCalories] = useState<number | "all">("all");
   const [onlyZeroSugar, setOnlyZeroSugar] = useState(false);
   const [sortBy, setSortBy] = useState<"rating" | "caffeine" | "cost" | "calories">("rating");
-  const [activeTab, setActiveTab] = useState<"browse" | "drink-types" | "benefits" | "featured" | "trending">("browse");
+  const [activeTab, setActiveTab] = useState<"browse" | "types" | "benefits" | "featured" | "trending">("browse");
   const [showUniversalSearch, setShowUniversalSearch] = useState(false);
 
   const [selectedRecipe, setSelectedRecipe] = useState<any | null>(null);
@@ -423,7 +423,7 @@ export default function MatchaDrinksPage() {
         <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-1 bg-gray-100 rounded-lg p-1">
           {[
             { id: "browse", label: "Browse All", icon: Search },
-            { id: "drink-types", label: "Drink Types", icon: Leaf },
+            { id: "types", label: "Drink Types", icon: Leaf },
             { id: "benefits", label: "Benefits", icon: Heart },
             { id: "featured", label: "Featured", icon: Star },
             { id: "trending", label: "Trending", icon: Zap },

--- a/client/src/pages/drinks/caffeinated/tea/index.tsx
+++ b/client/src/pages/drinks/caffeinated/tea/index.tsx
@@ -186,7 +186,7 @@ export default function TeaPage() {
   const [maxCalories, setMaxCalories] = useState<number | 'all'>('all');
   const [onlyNaturalSweetener, setOnlyNaturalSweetener] = useState(false);
   const [sortBy, setSortBy] = useState<'rating' | 'protein' | 'cost' | 'calories'>('rating');
-  const [activeTab, setActiveTab] = useState<'browse'|'drink-types'|'benefits'|'featured'|'trending'>('browse');
+  const [activeTab, setActiveTab] = useState<'browse'|'types'|'benefits'|'featured'|'trending'>('browse');
   const [showUniversalSearch, setShowUniversalSearch] = useState(false);
 
   // RecipeKit state
@@ -282,7 +282,7 @@ export default function TeaPage() {
       };
       addToRecentlyViewed(drinkData);
       incrementDrinksMade();
-      addPoints(20);
+      addPoints(25);
     }
     setShowKit(false);
     setSelectedRecipe(null);
@@ -527,7 +527,7 @@ export default function TeaPage() {
         <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-1 bg-gray-100 rounded-lg p-1">
           {[
             { id: 'browse', label: 'Browse All', icon: Search },
-            { id: 'drink-types', label: 'Tea Types', icon: Leaf },
+            { id: 'types', label: 'Drink Types', icon: Leaf },
             { id: 'benefits', label: 'Benefits', icon: Heart },
             { id: 'featured', label: 'Featured', icon: Star },
             { id: 'trending', label: 'Trending', icon: Zap }
@@ -842,7 +842,7 @@ export default function TeaPage() {
         )}
 
         {/* Tea Types Tab */}
-        {activeTab === 'drink-types' && (
+        {activeTab === 'types' && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {teaTypes.map(type => {
               const Icon = type.icon;

--- a/client/src/pages/drinks/index.tsx
+++ b/client/src/pages/drinks/index.tsx
@@ -194,8 +194,6 @@ const userStats = {
   streak: 7
 };
 
-const sortedDrinkCategories = sortByName(drinkCategories);
-
 export default function DrinksPage() {
   const [location, setLocation] = useLocation();
 

--- a/client/src/pages/drinks/potent-potables/cocktails/index.tsx
+++ b/client/src/pages/drinks/potent-potables/cocktails/index.tsx
@@ -405,15 +405,19 @@ export default function ClassicCocktailsPage() {
               </div>
               
               <div className="flex items-center gap-4">
+                <Button variant="outline" size="sm" onClick={() => setShowUniversalSearch(true)}>
+                  <Search className="h-4 w-4 mr-2" />
+                  Universal Search
+                </Button>
                 <div className="flex items-center gap-2 text-sm text-gray-600">
                   <GlassWater className="fill-blue-500 text-blue-500" />
                   <span>Level {userProgress.level}</span>
                   <div className="w-px h-4 bg-gray-300" />
                   <span>{userProgress.totalPoints} XP</span>
                 </div>
-                <Button size="sm" className="bg-blue-600 hover:bg-blue-700">
-                  <Camera className="h-4 w-4 mr-2" />
-                  Share Recipe
+                <Button size="sm" className="bg-blue-600 hover:bg-blue-700" onClick={handleSharePage}>
+                  <Share2 className="h-4 w-4 mr-2" />
+                  Share Page
                 </Button>
               </div>
             </div>

--- a/client/src/pages/drinks/potent-potables/cocktails/index.tsx
+++ b/client/src/pages/drinks/potent-potables/cocktails/index.tsx
@@ -16,6 +16,7 @@ import {
 , Coffee} from 'lucide-react';
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
+import UniversalSearch from '@/components/UniversalSearch';
 import { classicCocktails } from "@/data/drinks/potent-potables/cocktails";
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 
@@ -188,6 +189,8 @@ export default function ClassicCocktailsPage() {
   const [sortBy, setSortBy] = useState('rating');
   const [selectedCocktail, setSelectedCocktail] = useState<typeof classicCocktails[0] | null>(null);
   
+  const [showUniversalSearch, setShowUniversalSearch] = useState(false);
+
   // RecipeKit state
   const [selectedRecipe, setSelectedRecipe] = useState<any | null>(null);
   const [showKit, setShowKit] = useState(false);
@@ -214,6 +217,29 @@ export default function ClassicCocktailsPage() {
       };
     });
   }, []);
+
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Classic Cocktails',
+      text: 'Explore classic cocktails from timeless recipes with expert techniques.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
 
   const handleShareCocktail = async (cocktail: any, servingsOverride?: number) => {
     const url = typeof window !== 'undefined' ? window.location.href : '';
@@ -322,6 +348,23 @@ export default function ClassicCocktailsPage() {
   return (
     <RequireAgeGate>
       <div className="min-h-screen bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50">
+        {/* Universal Search Modal */}
+        {showUniversalSearch && (
+          <div className="fixed inset-0 bg-black/50 z-50 flex items-start justify-center pt-20" onClick={() => setShowUniversalSearch(false)}>
+            <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl mx-4 max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+              <div className="sticky top-0 bg-white border-b border-gray-200 p-4 flex items-center justify-between z-10">
+                <h2 className="text-lg font-semibold">Search All Drinks</h2>
+                <Button variant="ghost" size="sm" onClick={() => setShowUniversalSearch(false)}>
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+              <div className="p-4">
+                <UniversalSearch onClose={() => setShowUniversalSearch(false)} />
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* RecipeKit Modal */}
         {selectedRecipe && (
           <RecipeKit

--- a/client/src/pages/drinks/potent-potables/cocktails/index.tsx
+++ b/client/src/pages/drinks/potent-potables/cocktails/index.tsx
@@ -267,7 +267,7 @@ export default function ClassicCocktailsPage() {
         timestamp: Date.now()
       });
       incrementDrinksMade();
-      addPoints(40);
+      addPoints(35);
     }
     setShowKit(false);
     setSelectedRecipe(null);
@@ -315,7 +315,7 @@ export default function ClassicCocktailsPage() {
 
   const handleMakeCocktail = (cocktail: typeof classicCocktails[0]) => {
     incrementDrinksMade();
-    addPoints(40, 'Made a classic cocktail');
+    addPoints(35, 'Made a classic cocktail');
     setSelectedCocktail(null);
   };
 

--- a/client/src/pages/drinks/potent-potables/cognac-brandy/index.tsx
+++ b/client/src/pages/drinks/potent-potables/cognac-brandy/index.tsx
@@ -9,11 +9,12 @@ import RequireAgeGate from "@/components/RequireAgeGate";
 import { 
   Wine, Clock, Heart, Target, Sparkles, Grape,
   Search, Share2, ArrowLeft, Plus, Camera, Flame, GlassWater,
-  TrendingUp, Award, Crown, Zap, Apple, Leaf, Martini,
+  TrendingUp, Award, Crown, Zap, Apple, Leaf, Martini, X,
   Clipboard, RotateCcw, Check, BookOpen, Home, Droplets, Cherry
 , Coffee} from 'lucide-react';
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
+import UniversalSearch from '@/components/UniversalSearch';
 import { cognacCocktails } from "@/data/drinks/potent-potables/cognac-brandy";
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 
@@ -152,6 +153,8 @@ export default function CognacBrandyPage() {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCocktail, setSelectedCocktail] = useState<typeof cognacCocktails[0] | null>(null);
   
+  const [showUniversalSearch, setShowUniversalSearch] = useState(false);
+
   // RecipeKit state
   const [selectedRecipe, setSelectedRecipe] = useState<any | null>(null);
   const [showKit, setShowKit] = useState(false);
@@ -178,6 +181,29 @@ export default function CognacBrandyPage() {
       };
     });
   }, []);
+
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Cognac & Brandy',
+      text: 'Discover elegant cognac and brandy cocktails and sipping suggestions.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
 
   const handleShareCocktail = async (cocktail: any, servingsOverride?: number) => {
     const url = typeof window !== 'undefined' ? window.location.href : '';
@@ -273,6 +299,23 @@ export default function CognacBrandyPage() {
   return (
     <RequireAgeGate>
       <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50">
+        {/* Universal Search Modal */}
+        {showUniversalSearch && (
+          <div className="fixed inset-0 bg-black/50 z-50 flex items-start justify-center pt-20" onClick={() => setShowUniversalSearch(false)}>
+            <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl mx-4 max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+              <div className="sticky top-0 bg-white border-b border-gray-200 p-4 flex items-center justify-between z-10">
+                <h2 className="text-lg font-semibold">Search All Drinks</h2>
+                <Button variant="ghost" size="sm" onClick={() => setShowUniversalSearch(false)}>
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+              <div className="p-4">
+                <UniversalSearch onClose={() => setShowUniversalSearch(false)} />
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* RecipeKit Modal */}
         {selectedRecipe && (
           <RecipeKit
@@ -313,15 +356,19 @@ export default function CognacBrandyPage() {
               </div>
               
               <div className="flex items-center gap-4">
+                <Button variant="outline" size="sm" onClick={() => setShowUniversalSearch(true)}>
+                  <Search className="h-4 w-4 mr-2" />
+                  Universal Search
+                </Button>
                 <div className="flex items-center gap-2 text-sm text-gray-600">
                   <GlassWater className="fill-orange-500 text-orange-500" />
                   <span>Level {userProgress.level}</span>
                   <div className="w-px h-4 bg-gray-300" />
                   <span>{userProgress.totalPoints} XP</span>
                 </div>
-                <Button size="sm" className="bg-orange-600 hover:bg-orange-700">
-                  <Camera className="h-4 w-4 mr-2" />
-                  Share Recipe
+                <Button size="sm" className="bg-orange-600 hover:bg-orange-700" onClick={handleSharePage}>
+                  <Share2 className="h-4 w-4 mr-2" />
+                  Share Page
                 </Button>
               </div>
             </div>

--- a/client/src/pages/drinks/potent-potables/cognac-brandy/index.tsx
+++ b/client/src/pages/drinks/potent-potables/cognac-brandy/index.tsx
@@ -231,7 +231,7 @@ export default function CognacBrandyPage() {
         timestamp: Date.now()
       });
       incrementDrinksMade();
-      addPoints(45);
+      addPoints(35);
     }
     setShowKit(false);
     setSelectedRecipe(null);
@@ -266,7 +266,7 @@ export default function CognacBrandyPage() {
 
   const handleMakeCocktail = (cocktail: typeof cognacCocktails[0]) => {
     incrementDrinksMade();
-    addPoints(45, 'Made a cognac/brandy cocktail');
+    addPoints(35, 'Made a cognac/brandy cocktail');
     setSelectedCocktail(null);
   };
 

--- a/client/src/pages/drinks/potent-potables/daiquiri/index.tsx
+++ b/client/src/pages/drinks/potent-potables/daiquiri/index.tsx
@@ -157,7 +157,7 @@ export default function DaiquiriPage() {
     if (selectedRecipe) {
       addToRecentlyViewed({ id: selectedRecipe.id, name: selectedRecipe.name, category: "daiquiri", timestamp: Date.now() });
       incrementDrinksMade();
-      addPoints(45);
+      addPoints(35);
     }
     setShowKit(false);
     setSelectedRecipe(null);

--- a/client/src/pages/drinks/potent-potables/daiquiri/index.tsx
+++ b/client/src/pages/drinks/potent-potables/daiquiri/index.tsx
@@ -5,9 +5,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import RequireAgeGate from "@/components/RequireAgeGate";
-import { GlassWater, Search, Share2, ArrowLeft, Heart, Check, RotateCcw, Crown, Sparkles, Droplets, Apple, Snowflake, Flame, Martini, Wine, Zap, Leaf, Home, Clipboard, Coffee } from "lucide-react";
+import { GlassWater, Search, Share2, ArrowLeft, Heart, Check, RotateCcw, Crown, Sparkles, Droplets, Apple, Snowflake, Flame, Martini, Wine, Zap, Leaf, Home, Clipboard, Coffee, X } from "lucide-react";
 import { useDrinks } from "@/contexts/DrinksContext";
 import RecipeKit from "@/components/recipes/RecipeKit";
+import UniversalSearch from '@/components/UniversalSearch';
 import { daiquiris } from "@/data/drinks/potent-potables/daiquiri";
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 import { redirectToCanonicalRecipe } from '@/lib/canonical-routing';
@@ -99,6 +100,7 @@ const otherDrinkHubs = [
 export default function DaiquiriPage() {
   const { addToFavorites, isFavorite, addToRecentlyViewed, userProgress, incrementDrinksMade, addPoints } = useDrinks();
 
+  const [showUniversalSearch, setShowUniversalSearch] = useState(false);
   const [activeTab, setActiveTab] = useState<"browse" | "style" | "featured">("browse");
   const [selectedStyle, setSelectedStyle] = useState("all");
   const [sortBy, setSortBy] = useState("trending");
@@ -163,6 +165,29 @@ export default function DaiquiriPage() {
     setSelectedRecipe(null);
   };
 
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Daiquiris',
+      text: 'Explore fresh and frozen daiquiri recipes with tropical flavors.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
+
   const handleShare = async (cocktail: any, servingsOverride?: number) => {
     const url = typeof window !== "undefined" ? window.location.href : "";
     const servings = servingsOverride ?? servingsById[cocktail.id] ?? 1;
@@ -190,6 +215,23 @@ export default function DaiquiriPage() {
   return (
     <RequireAgeGate>
       <div className="min-h-screen bg-gradient-to-br from-teal-50 via-emerald-50 to-cyan-50">
+        {/* Universal Search Modal */}
+        {showUniversalSearch && (
+          <div className="fixed inset-0 bg-black/50 z-50 flex items-start justify-center pt-20" onClick={() => setShowUniversalSearch(false)}>
+            <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl mx-4 max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+              <div className="sticky top-0 bg-white border-b border-gray-200 p-4 flex items-center justify-between z-10">
+                <h2 className="text-lg font-semibold">Search All Drinks</h2>
+                <Button variant="ghost" size="sm" onClick={() => setShowUniversalSearch(false)}>
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+              <div className="p-4">
+                <UniversalSearch onClose={() => setShowUniversalSearch(false)} />
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* RecipeKit Modal */}
         {selectedRecipe && (
           <RecipeKit
@@ -228,11 +270,21 @@ export default function DaiquiriPage() {
                   <Badge className="bg-teal-100 text-teal-800">Rum Classics</Badge>
                 </div>
               </div>
-              <div className="flex items-center gap-4 text-sm text-gray-600">
-                <Droplets className="fill-teal-500 text-teal-500" />
-                <span>Level {userProgress.level}</span>
-                <div className="w-px h-4 bg-gray-300" />
-                <span>{userProgress.totalPoints} XP</span>
+              <div className="flex items-center gap-4">
+                <Button variant="outline" size="sm" onClick={() => setShowUniversalSearch(true)}>
+                  <Search className="h-4 w-4 mr-2" />
+                  Universal Search
+                </Button>
+                <div className="flex items-center gap-2 text-sm text-gray-600">
+                  <Droplets className="fill-teal-500 text-teal-500" />
+                  <span>Level {userProgress.level}</span>
+                  <div className="w-px h-4 bg-gray-300" />
+                  <span>{userProgress.totalPoints} XP</span>
+                </div>
+                <Button size="sm" className="bg-teal-600 hover:bg-teal-700" onClick={handleSharePage}>
+                  <Share2 className="h-4 w-4 mr-2" />
+                  Share Page
+                </Button>
               </div>
             </div>
           </div>

--- a/client/src/pages/drinks/potent-potables/gin/index.tsx
+++ b/client/src/pages/drinks/potent-potables/gin/index.tsx
@@ -7,13 +7,14 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import RequireAgeGate from "@/components/RequireAgeGate";
 import { 
-  Droplets, Clock, Heart, Target, Sparkles, Wine, 
-  Search, Share2, ArrowLeft, GlassWater, Flame,
+  Droplets, Clock, Heart, Target, Sparkles, Wine,
+  Search, Share2, ArrowLeft, GlassWater, Flame, X,
   TrendingUp, Award, Zap, Crown, Apple, Leaf,
   Clipboard, RotateCcw, Check, Home, Martini
 , Coffee} from 'lucide-react';
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
+import UniversalSearch from '@/components/UniversalSearch';
 import TrendingDrinksByCategory from "@/components/drinks/TrendingDrinksByCategory";
 import { ginRecipes } from "@/data/drinks/potent-potables/gin";
 import { resolveCanonicalDrinkSlug } from "@/data/drinks/canonical";
@@ -114,6 +115,7 @@ export default function GinCocktailsPage() {
     incrementDrinksMade
   } = useDrinks();
 
+  const [showUniversalSearch, setShowUniversalSearch] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [selectedMethod, setSelectedMethod] = useState('All Methods');
   const [sortBy, setSortBy] = useState('trending');
@@ -148,6 +150,29 @@ export default function GinCocktailsPage() {
       };
     });
   }, []);
+
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Gin Cocktails',
+      text: 'Explore botanical gin cocktails from classic to contemporary.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
 
   const handleShareCocktail = async (cocktail: any, servingsOverride?: number) => {
     const url = typeof window !== 'undefined' ? window.location.href : '';
@@ -233,6 +258,23 @@ export default function GinCocktailsPage() {
   return (
     <RequireAgeGate>
       <div className="min-h-screen bg-gradient-to-br from-blue-50 via-teal-50 to-cyan-50">
+        {/* Universal Search Modal */}
+        {showUniversalSearch && (
+          <div className="fixed inset-0 bg-black/50 z-50 flex items-start justify-center pt-20" onClick={() => setShowUniversalSearch(false)}>
+            <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl mx-4 max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+              <div className="sticky top-0 bg-white border-b border-gray-200 p-4 flex items-center justify-between z-10">
+                <h2 className="text-lg font-semibold">Search All Drinks</h2>
+                <Button variant="ghost" size="sm" onClick={() => setShowUniversalSearch(false)}>
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+              <div className="p-4">
+                <UniversalSearch onClose={() => setShowUniversalSearch(false)} />
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* RecipeKit Modal */}
         {selectedRecipe && (
           <RecipeKit
@@ -271,11 +313,21 @@ export default function GinCocktailsPage() {
                   <Badge className="bg-blue-100 text-blue-800">Botanical Spirits</Badge>
                 </div>
               </div>
-              <div className="flex items-center gap-4 text-sm text-gray-600">
-                <GlassWater className="fill-blue-500 text-blue-500" />
-                <span>Level {userProgress.level}</span>
-                <div className="w-px h-4 bg-gray-300" />
-                <span>{userProgress.totalPoints} XP</span>
+              <div className="flex items-center gap-4">
+                <Button variant="outline" size="sm" onClick={() => setShowUniversalSearch(true)}>
+                  <Search className="h-4 w-4 mr-2" />
+                  Universal Search
+                </Button>
+                <div className="flex items-center gap-2 text-sm text-gray-600">
+                  <GlassWater className="fill-blue-500 text-blue-500" />
+                  <span>Level {userProgress.level}</span>
+                  <div className="w-px h-4 bg-gray-300" />
+                  <span>{userProgress.totalPoints} XP</span>
+                </div>
+                <Button size="sm" className="bg-blue-600 hover:bg-blue-700" onClick={handleSharePage}>
+                  <Share2 className="h-4 w-4 mr-2" />
+                  Share Page
+                </Button>
               </div>
             </div>
           </div>

--- a/client/src/pages/drinks/potent-potables/hot-drinks/index.tsx
+++ b/client/src/pages/drinks/potent-potables/hot-drinks/index.tsx
@@ -7,13 +7,14 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import RequireAgeGate from "@/components/RequireAgeGate";
 import {
-  Coffee, Clock, Heart, Target, Sparkles, Wine, 
-  Search, Share2, ArrowLeft, GlassWater, Flame,
+  Coffee, Clock, Heart, Target, Sparkles, Wine,
+  Search, Share2, ArrowLeft, GlassWater, Flame, X,
   TrendingUp, Award, Zap, Crown, Apple, Leaf,
   Clipboard, RotateCcw, Check, Home, Martini, Droplets
 } from 'lucide-react';
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
+import UniversalSearch from '@/components/UniversalSearch';
 import { hotDrinks } from "@/data/drinks/potent-potables/hot-drinks";
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 
@@ -116,6 +117,7 @@ export default function HotDrinksPage() {
     incrementDrinksMade
   } = useDrinks();
 
+  const [showUniversalSearch, setShowUniversalSearch] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [selectedMethod, setSelectedMethod] = useState('All Methods');
   const [sortBy, setSortBy] = useState('trending');
@@ -150,6 +152,29 @@ export default function HotDrinksPage() {
       };
     });
   }, []);
+
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Hot Drinks',
+      text: 'Warm up with a collection of hot cocktails and mulled drinks.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
 
   const handleShareDrink = async (drink: any, servingsOverride?: number) => {
     const url = typeof window !== 'undefined' ? window.location.href : '';
@@ -236,6 +261,23 @@ export default function HotDrinksPage() {
   return (
     <RequireAgeGate>
       <div className="min-h-screen bg-gradient-to-br from-red-50 via-orange-50 to-amber-50">
+        {/* Universal Search Modal */}
+        {showUniversalSearch && (
+          <div className="fixed inset-0 bg-black/50 z-50 flex items-start justify-center pt-20" onClick={() => setShowUniversalSearch(false)}>
+            <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl mx-4 max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+              <div className="sticky top-0 bg-white border-b border-gray-200 p-4 flex items-center justify-between z-10">
+                <h2 className="text-lg font-semibold">Search All Drinks</h2>
+                <Button variant="ghost" size="sm" onClick={() => setShowUniversalSearch(false)}>
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+              <div className="p-4">
+                <UniversalSearch onClose={() => setShowUniversalSearch(false)} />
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* RecipeKit Modal */}
         {selectedRecipe && (
           <RecipeKit
@@ -274,11 +316,21 @@ export default function HotDrinksPage() {
                   <Badge className="bg-red-100 text-red-800">Warm Cocktails</Badge>
                 </div>
               </div>
-              <div className="flex items-center gap-4 text-sm text-gray-600">
-                <GlassWater className="fill-red-500 text-red-500" />
-                <span>Level {userProgress.level}</span>
-                <div className="w-px h-4 bg-gray-300" />
-                <span>{userProgress.totalPoints} XP</span>
+              <div className="flex items-center gap-4">
+                <Button variant="outline" size="sm" onClick={() => setShowUniversalSearch(true)}>
+                  <Search className="h-4 w-4 mr-2" />
+                  Universal Search
+                </Button>
+                <div className="flex items-center gap-2 text-sm text-gray-600">
+                  <GlassWater className="fill-red-500 text-red-500" />
+                  <span>Level {userProgress.level}</span>
+                  <div className="w-px h-4 bg-gray-300" />
+                  <span>{userProgress.totalPoints} XP</span>
+                </div>
+                <Button size="sm" className="bg-amber-600 hover:bg-amber-700" onClick={handleSharePage}>
+                  <Share2 className="h-4 w-4 mr-2" />
+                  Share Page
+                </Button>
               </div>
             </div>
           </div>

--- a/client/src/pages/drinks/potent-potables/liqueurs/index.tsx
+++ b/client/src/pages/drinks/potent-potables/liqueurs/index.tsx
@@ -5,9 +5,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import RequireAgeGate from "@/components/RequireAgeGate";
-import { Wine, Clock, Heart, Target, Sparkles, Droplets, Search, Share2, ArrowLeft, GlassWater, Flame, TrendingUp, Award, Zap, Crown, Apple, Leaf, Clipboard, RotateCcw, Check, Home, Martini, Cherry, Coffee } from "lucide-react";
+import { Wine, Clock, Heart, Target, Sparkles, Droplets, Search, Share2, ArrowLeft, GlassWater, Flame, TrendingUp, Award, Zap, Crown, Apple, Leaf, Clipboard, RotateCcw, Check, Home, Martini, Cherry, Coffee, X } from "lucide-react";
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
+import UniversalSearch from '@/components/UniversalSearch';
 import { liqueurCocktails } from "@/data/drinks/potent-potables/liqueurs";
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 import { redirectToCanonicalRecipe } from '@/lib/canonical-routing';
@@ -110,6 +111,7 @@ export default function LiqueursPage() {
     incrementDrinksMade
   } = useDrinks();
 
+  const [showUniversalSearch, setShowUniversalSearch] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [selectedMethod, setSelectedMethod] = useState('All Methods');
   const [sortBy, setSortBy] = useState('trending');
@@ -144,6 +146,29 @@ export default function LiqueursPage() {
       };
     });
   }, []);
+
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Liqueur Cocktails',
+      text: 'Discover creative cocktails and recipes featuring premium liqueurs.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
 
   const handleShareCocktail = async (cocktail: any, servingsOverride?: number) => {
     const url = typeof window !== 'undefined' ? window.location.href : '';
@@ -234,6 +259,23 @@ export default function LiqueursPage() {
   return (
     <RequireAgeGate>
       <div className="min-h-screen bg-gradient-to-br from-purple-50 via-pink-50 to-rose-50">
+        {/* Universal Search Modal */}
+        {showUniversalSearch && (
+          <div className="fixed inset-0 bg-black/50 z-50 flex items-start justify-center pt-20" onClick={() => setShowUniversalSearch(false)}>
+            <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl mx-4 max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+              <div className="sticky top-0 bg-white border-b border-gray-200 p-4 flex items-center justify-between z-10">
+                <h2 className="text-lg font-semibold">Search All Drinks</h2>
+                <Button variant="ghost" size="sm" onClick={() => setShowUniversalSearch(false)}>
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+              <div className="p-4">
+                <UniversalSearch onClose={() => setShowUniversalSearch(false)} />
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* RecipeKit Modal */}
         {selectedRecipe && (
           <RecipeKit
@@ -272,11 +314,21 @@ export default function LiqueursPage() {
                   <Badge className="bg-purple-100 text-purple-800">Sweet Spirits</Badge>
                 </div>
               </div>
-              <div className="flex items-center gap-4 text-sm text-gray-600">
-                <GlassWater className="fill-purple-500 text-purple-500" />
-                <span>Level {userProgress.level}</span>
-                <div className="w-px h-4 bg-gray-300" />
-                <span>{userProgress.totalPoints} XP</span>
+              <div className="flex items-center gap-4">
+                <Button variant="outline" size="sm" onClick={() => setShowUniversalSearch(true)}>
+                  <Search className="h-4 w-4 mr-2" />
+                  Universal Search
+                </Button>
+                <div className="flex items-center gap-2 text-sm text-gray-600">
+                  <GlassWater className="fill-purple-500 text-purple-500" />
+                  <span>Level {userProgress.level}</span>
+                  <div className="w-px h-4 bg-gray-300" />
+                  <span>{userProgress.totalPoints} XP</span>
+                </div>
+                <Button size="sm" className="bg-purple-600 hover:bg-purple-700" onClick={handleSharePage}>
+                  <Share2 className="h-4 w-4 mr-2" />
+                  Share Page
+                </Button>
               </div>
             </div>
           </div>

--- a/client/src/pages/drinks/potent-potables/martinis/index.tsx
+++ b/client/src/pages/drinks/potent-potables/martinis/index.tsx
@@ -5,9 +5,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import RequireAgeGate from "@/components/RequireAgeGate";
-import { Martini, Clock, Heart, Target, Sparkles, Wine, Search, Share2, ArrowLeft, Plus, Camera, Flame, GlassWater, TrendingUp, Award, Zap, Crown, Cherry, Home, Droplets, Apple, Leaf, Clipboard, RotateCcw, Check, Coffee } from "lucide-react";
+import { Martini, Clock, Heart, Target, Sparkles, Wine, Search, Share2, ArrowLeft, Plus, Camera, Flame, GlassWater, TrendingUp, Award, Zap, Crown, Cherry, Home, Droplets, Apple, Leaf, Clipboard, RotateCcw, Check, Coffee, X } from "lucide-react";
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
+import UniversalSearch from '@/components/UniversalSearch';
 import { martinis } from "@/data/drinks/potent-potables/martinis";
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 import { redirectToCanonicalRecipe } from '@/lib/canonical-routing';
@@ -119,6 +120,7 @@ export default function MartinisPage() {
     incrementDrinksMade
   } = useDrinks();
 
+  const [showUniversalSearch, setShowUniversalSearch] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [selectedSpirit, setSelectedSpirit] = useState('All Spirits');
   const [selectedMethod, setSelectedMethod] = useState('All Methods');
@@ -155,6 +157,29 @@ export default function MartinisPage() {
       };
     });
   }, []);
+
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Martinis',
+      text: 'Explore classic and creative martini recipes for every taste.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
 
   const handleShareMartini = async (martini: any, servingsOverride?: number) => {
     const url = typeof window !== 'undefined' ? window.location.href : '';
@@ -251,6 +276,23 @@ export default function MartinisPage() {
   return (
     <RequireAgeGate>
       <div className="min-h-screen bg-gradient-to-br from-purple-50 via-pink-50 to-purple-50">
+        {/* Universal Search Modal */}
+        {showUniversalSearch && (
+          <div className="fixed inset-0 bg-black/50 z-50 flex items-start justify-center pt-20" onClick={() => setShowUniversalSearch(false)}>
+            <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl mx-4 max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+              <div className="sticky top-0 bg-white border-b border-gray-200 p-4 flex items-center justify-between z-10">
+                <h2 className="text-lg font-semibold">Search All Drinks</h2>
+                <Button variant="ghost" size="sm" onClick={() => setShowUniversalSearch(false)}>
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+              <div className="p-4">
+                <UniversalSearch onClose={() => setShowUniversalSearch(false)} />
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* RecipeKit Modal */}
         {selectedRecipe && (
           <RecipeKit
@@ -289,11 +331,21 @@ export default function MartinisPage() {
                   <Badge className="bg-purple-100 text-purple-800">Elegant Classics</Badge>
                 </div>
               </div>
-              <div className="flex items-center gap-4 text-sm text-gray-600">
-                <GlassWater className="fill-purple-500 text-purple-500" />
-                <span>Level {userProgress.level}</span>
-                <div className="w-px h-4 bg-gray-300" />
-                <span>{userProgress.totalPoints} XP</span>
+              <div className="flex items-center gap-4">
+                <Button variant="outline" size="sm" onClick={() => setShowUniversalSearch(true)}>
+                  <Search className="h-4 w-4 mr-2" />
+                  Universal Search
+                </Button>
+                <div className="flex items-center gap-2 text-sm text-gray-600">
+                  <GlassWater className="fill-purple-500 text-purple-500" />
+                  <span>Level {userProgress.level}</span>
+                  <div className="w-px h-4 bg-gray-300" />
+                  <span>{userProgress.totalPoints} XP</span>
+                </div>
+                <Button size="sm" className="bg-indigo-600 hover:bg-indigo-700" onClick={handleSharePage}>
+                  <Share2 className="h-4 w-4 mr-2" />
+                  Share Page
+                </Button>
               </div>
             </div>
           </div>

--- a/client/src/pages/drinks/potent-potables/mocktails/index.tsx
+++ b/client/src/pages/drinks/potent-potables/mocktails/index.tsx
@@ -218,7 +218,7 @@ export default function MocktailsPage() {
         timestamp: Date.now()
       });
       incrementDrinksMade();
-      addPoints(20);
+      addPoints(25);
     }
     setShowKit(false);
     setSelectedRecipe(null);
@@ -259,7 +259,7 @@ export default function MocktailsPage() {
 
   const handleMakeMocktail = (mocktail: typeof mocktails[0]) => {
     incrementDrinksMade();
-    addPoints(20, 'Made a mocktail');
+    addPoints(25, 'Made a mocktail');
     setSelectedMocktail(null);
   };
 

--- a/client/src/pages/drinks/potent-potables/mocktails/index.tsx
+++ b/client/src/pages/drinks/potent-potables/mocktails/index.tsx
@@ -4,9 +4,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Martini, Clock, Heart, Star, Target, Sparkles, Leaf, Wine, Search, Share2, ArrowLeft, Plus, Zap, Cherry, Camera, Flame, GlassWater, Award, TrendingUp, Crown, Home, Droplets, Apple, Clipboard, RotateCcw, Check, Coffee } from "lucide-react";
+import { Martini, Clock, Heart, Star, Target, Sparkles, Leaf, Wine, Search, Share2, ArrowLeft, Plus, Zap, Cherry, Camera, Flame, GlassWater, Award, TrendingUp, Crown, Home, Droplets, Apple, Clipboard, RotateCcw, Check, Coffee, X } from "lucide-react";
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
+import UniversalSearch from '@/components/UniversalSearch';
 import { mocktails } from "@/data/drinks/potent-potables/mocktails";
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 import { redirectToCanonicalRecipe } from '@/lib/canonical-routing';
@@ -131,6 +132,7 @@ export default function MocktailsPage() {
     incrementDrinksMade
   } = useDrinks();
 
+  const [showUniversalSearch, setShowUniversalSearch] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [selectedOccasion, setSelectedOccasion] = useState('All Occasions');
   const [sortBy, setSortBy] = useState('trending');
@@ -183,6 +185,29 @@ export default function MocktailsPage() {
       try {
         await navigator.clipboard.writeText(`${mocktail.name}\n${text}\n${url}`);
         alert('Recipe copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
+
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Mocktails',
+      text: 'Enjoy sophisticated non-alcoholic mocktail recipes for any occasion.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
       } catch {
         alert('Unable to share on this device.');
       }
@@ -265,6 +290,23 @@ export default function MocktailsPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-pink-50 via-purple-50 to-blue-50">
+      {/* Universal Search Modal */}
+      {showUniversalSearch && (
+        <div className="fixed inset-0 bg-black/50 z-50 flex items-start justify-center pt-20" onClick={() => setShowUniversalSearch(false)}>
+          <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl mx-4 max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+            <div className="sticky top-0 bg-white border-b border-gray-200 p-4 flex items-center justify-between z-10">
+              <h2 className="text-lg font-semibold">Search All Drinks</h2>
+              <Button variant="ghost" size="sm" onClick={() => setShowUniversalSearch(false)}>
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+            <div className="p-4">
+              <UniversalSearch onClose={() => setShowUniversalSearch(false)} />
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* RecipeKit Modal */}
       {selectedRecipe && (
         <RecipeKit
@@ -302,9 +344,21 @@ export default function MocktailsPage() {
               </h1>
               <p className="text-purple-100 text-lg">Sophisticated non-alcoholic cocktails for every occasion</p>
             </div>
-            <div className="text-right">
-              <div className="text-3xl font-bold">{filteredMocktails.length}</div>
-              <div className="text-purple-100">Recipes</div>
+            <div className="flex flex-col items-end gap-3">
+              <div className="text-right">
+                <div className="text-3xl font-bold">{filteredMocktails.length}</div>
+                <div className="text-purple-100">Recipes</div>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" className="text-white border-white/50 hover:bg-white/20" onClick={() => setShowUniversalSearch(true)}>
+                  <Search className="h-4 w-4 mr-2" />
+                  Universal Search
+                </Button>
+                <Button size="sm" className="bg-white/20 hover:bg-white/30 text-white border border-white/50" onClick={handleSharePage}>
+                  <Share2 className="h-4 w-4 mr-2" />
+                  Share Page
+                </Button>
+              </div>
             </div>
           </div>
         </div>

--- a/client/src/pages/drinks/potent-potables/rum/index.tsx
+++ b/client/src/pages/drinks/potent-potables/rum/index.tsx
@@ -203,7 +203,7 @@ export default function RumCocktailsPage() {
         timestamp: Date.now()
       });
       incrementDrinksMade();
-      addPoints(40);
+      addPoints(35);
     }
     setShowKit(false);
     setSelectedRecipe(null);
@@ -229,7 +229,7 @@ export default function RumCocktailsPage() {
 
   const handleMakeCocktail = (cocktail: typeof rumCocktails[0]) => {
     incrementDrinksMade();
-    addPoints(40, 'Made a rum cocktail');
+    addPoints(35, 'Made a rum cocktail');
     setSelectedCocktail(null);
   };
 

--- a/client/src/pages/drinks/potent-potables/rum/index.tsx
+++ b/client/src/pages/drinks/potent-potables/rum/index.tsx
@@ -11,10 +11,11 @@ import {
   Search, Share2, ArrowLeft, Plus, Camera, Flame, GlassWater,
   TrendingUp, Award, Crown, Coffee, Leaf, Zap, Cherry, Waves,
   Droplets, BookOpen, Home, Apple, Wine, Martini,
-  Clipboard, RotateCcw, Check
+  Clipboard, RotateCcw, Check, X
 } from 'lucide-react';
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
+import UniversalSearch from '@/components/UniversalSearch';
 import { rumCocktails } from "@/data/drinks/potent-potables/rum";
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 
@@ -124,6 +125,7 @@ export default function RumCocktailsPage() {
   // RecipeKit state
   const [selectedRecipe, setSelectedRecipe] = useState<any | null>(null);
   const [showKit, setShowKit] = useState(false);
+  const [showUniversalSearch, setShowUniversalSearch] = useState(false);
   const [servingsById, setServingsById] = useState<Record<string, number>>({});
   const [metricFlags, setMetricFlags] = useState<Record<string, boolean>>({});
 
@@ -168,6 +170,29 @@ export default function RumCocktailsPage() {
       try {
         await navigator.clipboard.writeText(`${cocktail.name}\n${text}\n${url}`);
         alert('Recipe copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
+
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Rum Cocktails',
+      text: 'Explore tropical and classic rum cocktails from around the world.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
       } catch {
         alert('Unable to share on this device.');
       }
@@ -236,6 +261,23 @@ export default function RumCocktailsPage() {
   return (
     <RequireAgeGate>
       <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50">
+        {/* Universal Search Modal */}
+        {showUniversalSearch && (
+          <div className="fixed inset-0 bg-black/50 z-50 flex items-start justify-center pt-20" onClick={() => setShowUniversalSearch(false)}>
+            <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl mx-4 max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+              <div className="sticky top-0 bg-white border-b border-gray-200 p-4 flex items-center justify-between z-10">
+                <h2 className="text-lg font-semibold">Search All Drinks</h2>
+                <Button variant="ghost" size="sm" onClick={() => setShowUniversalSearch(false)}>
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+              <div className="p-4">
+                <UniversalSearch onClose={() => setShowUniversalSearch(false)} />
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* RecipeKit Modal */}
         {selectedRecipe && (
           <RecipeKit
@@ -259,7 +301,7 @@ export default function RumCocktailsPage() {
         {/* Hero Section */}
         <div className="bg-gradient-to-r from-amber-600 via-orange-600 to-red-600 text-white py-16 px-4">
           <div className="max-w-7xl mx-auto">
-            <div className="flex items-center gap-3 mb-4">
+            <div className="flex items-center justify-between mb-4">
               <Link href="/drinks/potent-potables">
                 <Button
                   variant="ghost"
@@ -270,6 +312,16 @@ export default function RumCocktailsPage() {
                   Back to Potent Potables
                 </Button>
               </Link>
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" className="text-white border-white/50 hover:bg-white/20" onClick={() => setShowUniversalSearch(true)}>
+                  <Search className="h-4 w-4 mr-2" />
+                  Universal Search
+                </Button>
+                <Button size="sm" className="bg-white/20 hover:bg-white/30 text-white border border-white/50" onClick={handleSharePage}>
+                  <Share2 className="h-4 w-4 mr-2" />
+                  Share Page
+                </Button>
+              </div>
             </div>
             
             <div className="flex items-center gap-4 mb-6">

--- a/client/src/pages/drinks/potent-potables/scotch-irish-whiskey/index.tsx
+++ b/client/src/pages/drinks/potent-potables/scotch-irish-whiskey/index.tsx
@@ -5,9 +5,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import RequireAgeGate from "@/components/RequireAgeGate";
-import { Castle, Clock, Heart, Star, Target, Sparkles, Mountain, Search, Share2, ArrowLeft, Plus, Camera, Flame, GlassWater, TrendingUp, Award, Crown, Zap, Droplets, BookOpen, Home, Apple, Leaf, Wine, Martini, Clipboard, RotateCcw, Check, Coffee } from "lucide-react";
+import { Castle, Clock, Heart, Star, Target, Sparkles, Mountain, Search, Share2, ArrowLeft, Plus, Camera, Flame, GlassWater, TrendingUp, Award, Crown, Zap, Droplets, BookOpen, Home, Apple, Leaf, Wine, Martini, Clipboard, RotateCcw, Check, Coffee, X } from "lucide-react";
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
+import UniversalSearch from '@/components/UniversalSearch';
 import { scotchIrishCocktails } from "@/data/drinks/potent-potables/scotch-irish-whiskey";
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 import { redirectToCanonicalRecipe } from '@/lib/canonical-routing';
@@ -119,6 +120,7 @@ export default function ScotchIrishWhiskeyPage() {
   // RecipeKit state
   const [selectedRecipe, setSelectedRecipe] = useState<any | null>(null);
   const [showKit, setShowKit] = useState(false);
+  const [showUniversalSearch, setShowUniversalSearch] = useState(false);
   const [servingsById, setServingsById] = useState<Record<string, number>>({});
   const [metricFlags, setMetricFlags] = useState<Record<string, boolean>>({});
 
@@ -163,6 +165,29 @@ export default function ScotchIrishWhiskeyPage() {
       try {
         await navigator.clipboard.writeText(`${cocktail.name}\n${text}\n${url}`);
         alert('Recipe copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
+
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Scotch & Irish Whiskey',
+      text: 'Discover the finest Scotch and Irish whiskey cocktails and serves.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
       } catch {
         alert('Unable to share on this device.');
       }
@@ -231,6 +256,23 @@ export default function ScotchIrishWhiskeyPage() {
   return (
     <RequireAgeGate>
       <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-green-50">
+        {/* Universal Search Modal */}
+        {showUniversalSearch && (
+          <div className="fixed inset-0 bg-black/50 z-50 flex items-start justify-center pt-20" onClick={() => setShowUniversalSearch(false)}>
+            <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl mx-4 max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+              <div className="sticky top-0 bg-white border-b border-gray-200 p-4 flex items-center justify-between z-10">
+                <h2 className="text-lg font-semibold">Search All Drinks</h2>
+                <Button variant="ghost" size="sm" onClick={() => setShowUniversalSearch(false)}>
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+              <div className="p-4">
+                <UniversalSearch onClose={() => setShowUniversalSearch(false)} />
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* RecipeKit Modal */}
         {selectedRecipe && (
           <RecipeKit
@@ -254,7 +296,7 @@ export default function ScotchIrishWhiskeyPage() {
         {/* Hero Section */}
         <div className="bg-gradient-to-r from-amber-700 via-orange-700 to-green-700 text-white py-16 px-4">
           <div className="max-w-7xl mx-auto">
-            <div className="flex items-center gap-3 mb-4">
+            <div className="flex items-center justify-between mb-4">
               <Link href="/drinks/potent-potables">
                 <Button
                   variant="ghost"
@@ -265,6 +307,16 @@ export default function ScotchIrishWhiskeyPage() {
                   Back to Potent Potables
                 </Button>
               </Link>
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" className="text-white border-white/50 hover:bg-white/20" onClick={() => setShowUniversalSearch(true)}>
+                  <Search className="h-4 w-4 mr-2" />
+                  Universal Search
+                </Button>
+                <Button size="sm" className="bg-white/20 hover:bg-white/30 text-white border border-white/50" onClick={handleSharePage}>
+                  <Share2 className="h-4 w-4 mr-2" />
+                  Share Page
+                </Button>
+              </div>
             </div>
             
             <div className="flex items-center gap-4 mb-6">

--- a/client/src/pages/drinks/potent-potables/scotch-irish-whiskey/index.tsx
+++ b/client/src/pages/drinks/potent-potables/scotch-irish-whiskey/index.tsx
@@ -198,7 +198,7 @@ export default function ScotchIrishWhiskeyPage() {
         timestamp: Date.now()
       });
       incrementDrinksMade();
-      addPoints(40);
+      addPoints(35);
     }
     setShowKit(false);
     setSelectedRecipe(null);
@@ -224,7 +224,7 @@ export default function ScotchIrishWhiskeyPage() {
 
   const handleMakeCocktail = (cocktail: typeof scotchIrishCocktails[0]) => {
     incrementDrinksMade();
-    addPoints(40, 'Made a Scotch/Irish cocktail');
+    addPoints(35, 'Made a Scotch/Irish cocktail');
     setSelectedCocktail(null);
   };
 

--- a/client/src/pages/drinks/potent-potables/seasonal/index.tsx
+++ b/client/src/pages/drinks/potent-potables/seasonal/index.tsx
@@ -240,7 +240,7 @@ export default function SeasonalCocktailsPage() {
         timestamp: Date.now()
       });
       incrementDrinksMade();
-      addPoints(30);
+      addPoints(35);
     }
     setShowKit(false);
     setSelectedRecipe(null);
@@ -278,7 +278,7 @@ export default function SeasonalCocktailsPage() {
 
   const handleMakeCocktail = (cocktail: typeof seasonalCocktails[0]) => {
     incrementDrinksMade();
-    addPoints(30, 'Made a seasonal cocktail');
+    addPoints(35, 'Made a seasonal cocktail');
     setSelectedCocktail(null);
   };
 

--- a/client/src/pages/drinks/potent-potables/seasonal/index.tsx
+++ b/client/src/pages/drinks/potent-potables/seasonal/index.tsx
@@ -5,9 +5,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import RequireAgeGate from "@/components/RequireAgeGate";
-import { Snowflake, Sun, Leaf, Flower2, Clock, Heart, Target, Sparkles, Wine, Search, Share2, ArrowLeft, Plus, Camera, Flame, GlassWater, TrendingUp, Award, Cherry, Cloud, Zap, Home, Droplets, Apple, Martini, Crown, Clipboard, RotateCcw, Check, Coffee } from "lucide-react";
+import { Snowflake, Sun, Leaf, Flower2, Clock, Heart, Target, Sparkles, Wine, Search, Share2, ArrowLeft, Plus, Camera, Flame, GlassWater, TrendingUp, Award, Cherry, Cloud, Zap, Home, Droplets, Apple, Martini, Crown, Clipboard, RotateCcw, Check, Coffee, X } from "lucide-react";
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
+import UniversalSearch from '@/components/UniversalSearch';
 import { seasonalCocktails } from "@/data/drinks/potent-potables/seasonal";
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 import { redirectToCanonicalRecipe } from '@/lib/canonical-routing';
@@ -164,6 +165,7 @@ export default function SeasonalCocktailsPage() {
   // RecipeKit state
   const [selectedRecipe, setSelectedRecipe] = useState<any | null>(null);
   const [showKit, setShowKit] = useState(false);
+  const [showUniversalSearch, setShowUniversalSearch] = useState(false);
   const [servingsById, setServingsById] = useState<Record<string, number>>({});
   const [metricFlags, setMetricFlags] = useState<Record<string, boolean>>({});
 
@@ -205,6 +207,29 @@ export default function SeasonalCocktailsPage() {
       try {
         await navigator.clipboard.writeText(`${cocktail.name}\n${text}\n${url}`);
         alert('Recipe copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
+
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Seasonal Cocktails',
+      text: 'Celebrate every season with themed cocktails and special occasion drinks.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
       } catch {
         alert('Unable to share on this device.');
       }
@@ -287,6 +312,23 @@ export default function SeasonalCocktailsPage() {
   return (
     <RequireAgeGate>
       <div className="min-h-screen bg-gradient-to-br from-blue-50 via-pink-50 to-orange-50">
+        {/* Universal Search Modal */}
+        {showUniversalSearch && (
+          <div className="fixed inset-0 bg-black/50 z-50 flex items-start justify-center pt-20" onClick={() => setShowUniversalSearch(false)}>
+            <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl mx-4 max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+              <div className="sticky top-0 bg-white border-b border-gray-200 p-4 flex items-center justify-between z-10">
+                <h2 className="text-lg font-semibold">Search All Drinks</h2>
+                <Button variant="ghost" size="sm" onClick={() => setShowUniversalSearch(false)}>
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+              <div className="p-4">
+                <UniversalSearch onClose={() => setShowUniversalSearch(false)} />
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* RecipeKit Modal */}
         {selectedRecipe && (
           <RecipeKit
@@ -327,9 +369,21 @@ export default function SeasonalCocktailsPage() {
                   Current Season: {currentSeason}
                 </Badge>
               </div>
-              <div className="text-right">
-                <div className="text-3xl font-bold">{filteredCocktails.length}</div>
-                <div className="text-blue-100">Recipes</div>
+              <div className="flex flex-col items-end gap-3">
+                <div className="text-right">
+                  <div className="text-3xl font-bold">{filteredCocktails.length}</div>
+                  <div className="text-blue-100">Recipes</div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button variant="outline" size="sm" className="text-white border-white/50 hover:bg-white/20" onClick={() => setShowUniversalSearch(true)}>
+                    <Search className="h-4 w-4 mr-2" />
+                    Universal Search
+                  </Button>
+                  <Button size="sm" className="bg-white/20 hover:bg-white/30 text-white border border-white/50" onClick={handleSharePage}>
+                    <Share2 className="h-4 w-4 mr-2" />
+                    Share Page
+                  </Button>
+                </div>
               </div>
             </div>
           </div>

--- a/client/src/pages/drinks/potent-potables/spritz/index.tsx
+++ b/client/src/pages/drinks/potent-potables/spritz/index.tsx
@@ -11,9 +11,10 @@ import {
   Search, Share2, ArrowLeft, GlassWater, Flame,
   TrendingUp, Award, Zap, Crown, Apple, Leaf,
   Clipboard, RotateCcw, Check, Home, Martini, Sun
-, Coffee} from 'lucide-react';
+, Coffee, X} from 'lucide-react';
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
+import UniversalSearch from '@/components/UniversalSearch';
 import { spritzCocktails } from "@/data/drinks/potent-potables/spritz";
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 
@@ -125,6 +126,7 @@ export default function SpritzMimosasPage() {
   // RecipeKit state
   const [selectedRecipe, setSelectedRecipe] = useState<any | null>(null);
   const [showKit, setShowKit] = useState(false);
+  const [showUniversalSearch, setShowUniversalSearch] = useState(false);
   const [servingsById, setServingsById] = useState<Record<string, number>>({});
   const [metricFlags, setMetricFlags] = useState<Record<string, boolean>>({});
 
@@ -166,6 +168,29 @@ export default function SpritzMimosasPage() {
       try {
         await navigator.clipboard.writeText(`${cocktail.name}\n${text}\n${url}`);
         alert('Recipe copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
+
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Spritz Cocktails',
+      text: 'Enjoy light and bubbly spritz cocktails perfect for any gathering.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
       } catch {
         alert('Unable to share on this device.');
       }
@@ -234,6 +259,23 @@ export default function SpritzMimosasPage() {
   return (
     <RequireAgeGate>
       <div className="min-h-screen bg-gradient-to-br from-yellow-50 via-orange-50 to-amber-50">
+        {/* Universal Search Modal */}
+        {showUniversalSearch && (
+          <div className="fixed inset-0 bg-black/50 z-50 flex items-start justify-center pt-20" onClick={() => setShowUniversalSearch(false)}>
+            <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl mx-4 max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+              <div className="sticky top-0 bg-white border-b border-gray-200 p-4 flex items-center justify-between z-10">
+                <h2 className="text-lg font-semibold">Search All Drinks</h2>
+                <Button variant="ghost" size="sm" onClick={() => setShowUniversalSearch(false)}>
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+              <div className="p-4">
+                <UniversalSearch onClose={() => setShowUniversalSearch(false)} />
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* RecipeKit Modal */}
         {selectedRecipe && (
           <RecipeKit
@@ -272,11 +314,21 @@ export default function SpritzMimosasPage() {
                   <Badge className="bg-yellow-100 text-yellow-800">Bubbly Brunch</Badge>
                 </div>
               </div>
-              <div className="flex items-center gap-4 text-sm text-gray-600">
-                <GlassWater className="fill-yellow-500 text-yellow-500" />
-                <span>Level {userProgress.level}</span>
-                <div className="w-px h-4 bg-gray-300" />
-                <span>{userProgress.totalPoints} XP</span>
+              <div className="flex items-center gap-4">
+                <Button variant="outline" size="sm" onClick={() => setShowUniversalSearch(true)}>
+                  <Search className="h-4 w-4 mr-2" />
+                  Universal Search
+                </Button>
+                <div className="flex items-center gap-2 text-sm text-gray-600">
+                  <GlassWater className="fill-yellow-500 text-yellow-500" />
+                  <span>Level {userProgress.level}</span>
+                  <div className="w-px h-4 bg-gray-300" />
+                  <span>{userProgress.totalPoints} XP</span>
+                </div>
+                <Button size="sm" className="bg-orange-600 hover:bg-orange-700" onClick={handleSharePage}>
+                  <Share2 className="h-4 w-4 mr-2" />
+                  Share Page
+                </Button>
               </div>
             </div>
           </div>

--- a/client/src/pages/drinks/potent-potables/tequila-mezcal/index.tsx
+++ b/client/src/pages/drinks/potent-potables/tequila-mezcal/index.tsx
@@ -203,7 +203,7 @@ export default function TequilaMezcalPage() {
         timestamp: Date.now()
       });
       incrementDrinksMade();
-      addPoints(40);
+      addPoints(35);
     }
     setShowKit(false);
     setSelectedRecipe(null);
@@ -229,7 +229,7 @@ export default function TequilaMezcalPage() {
 
   const handleMakeCocktail = (cocktail: typeof tequilaMezcalCocktails[0]) => {
     incrementDrinksMade();
-    addPoints(40, 'Made a tequila/mezcal cocktail');
+    addPoints(35, 'Made a tequila/mezcal cocktail');
     setSelectedCocktail(null);
   };
 

--- a/client/src/pages/drinks/potent-potables/tequila-mezcal/index.tsx
+++ b/client/src/pages/drinks/potent-potables/tequila-mezcal/index.tsx
@@ -11,10 +11,11 @@ import {
   Search, Share2, ArrowLeft, Plus, Camera, GlassWater,
   TrendingUp, Award, Crown, Coffee, Leaf, Zap, Cherry, Citrus,
   Droplets, BookOpen, Home, Apple, Wine, Martini,
-  Clipboard, RotateCcw, Check
+  Clipboard, RotateCcw, Check, X
 } from 'lucide-react';
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
+import UniversalSearch from '@/components/UniversalSearch';
 import { tequilaMezcalCocktails } from "@/data/drinks/potent-potables/tequila-mezcal";
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 
@@ -124,6 +125,7 @@ export default function TequilaMezcalPage() {
   // RecipeKit state
   const [selectedRecipe, setSelectedRecipe] = useState<any | null>(null);
   const [showKit, setShowKit] = useState(false);
+  const [showUniversalSearch, setShowUniversalSearch] = useState(false);
   const [servingsById, setServingsById] = useState<Record<string, number>>({});
   const [metricFlags, setMetricFlags] = useState<Record<string, boolean>>({});
 
@@ -168,6 +170,29 @@ export default function TequilaMezcalPage() {
       try {
         await navigator.clipboard.writeText(`${cocktail.name}\n${text}\n${url}`);
         alert('Recipe copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
+
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Tequila & Mezcal',
+      text: 'Explore smoky and vibrant tequila and mezcal cocktail recipes.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
       } catch {
         alert('Unable to share on this device.');
       }
@@ -236,6 +261,23 @@ export default function TequilaMezcalPage() {
   return (
     <RequireAgeGate>
       <div className="min-h-screen bg-gradient-to-br from-lime-50 via-green-50 to-emerald-50">
+        {/* Universal Search Modal */}
+        {showUniversalSearch && (
+          <div className="fixed inset-0 bg-black/50 z-50 flex items-start justify-center pt-20" onClick={() => setShowUniversalSearch(false)}>
+            <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl mx-4 max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+              <div className="sticky top-0 bg-white border-b border-gray-200 p-4 flex items-center justify-between z-10">
+                <h2 className="text-lg font-semibold">Search All Drinks</h2>
+                <Button variant="ghost" size="sm" onClick={() => setShowUniversalSearch(false)}>
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+              <div className="p-4">
+                <UniversalSearch onClose={() => setShowUniversalSearch(false)} />
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* RecipeKit Modal */}
         {selectedRecipe && (
           <RecipeKit
@@ -259,7 +301,7 @@ export default function TequilaMezcalPage() {
         {/* Hero Section */}
         <div className="bg-gradient-to-r from-lime-600 via-green-600 to-emerald-600 text-white py-16 px-4">
           <div className="max-w-7xl mx-auto">
-            <div className="flex items-center gap-3 mb-4">
+            <div className="flex items-center justify-between mb-4">
               <Link href="/drinks/potent-potables">
                 <Button
                   variant="ghost"
@@ -270,6 +312,16 @@ export default function TequilaMezcalPage() {
                   Back to Potent Potables
                 </Button>
               </Link>
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" className="text-white border-white/50 hover:bg-white/20" onClick={() => setShowUniversalSearch(true)}>
+                  <Search className="h-4 w-4 mr-2" />
+                  Universal Search
+                </Button>
+                <Button size="sm" className="bg-white/20 hover:bg-white/30 text-white border border-white/50" onClick={handleSharePage}>
+                  <Share2 className="h-4 w-4 mr-2" />
+                  Share Page
+                </Button>
+              </div>
             </div>
             
             <div className="flex items-center gap-4 mb-6">

--- a/client/src/pages/drinks/potent-potables/vodka/index.tsx
+++ b/client/src/pages/drinks/potent-potables/vodka/index.tsx
@@ -10,10 +10,11 @@ import {
   Droplets, Clock, Heart, Target, Sparkles, Wine, 
   Search, Share2, ArrowLeft, GlassWater, Flame,
   TrendingUp, Award, Zap, Crown, Apple, Leaf,
-  Clipboard, RotateCcw, Check, Home, Martini, Coffee
+  Clipboard, RotateCcw, Check, Home, Martini, Coffee, X
 } from 'lucide-react';
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
+import UniversalSearch from '@/components/UniversalSearch';
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 import { vodkaCocktails } from "@/data/drinks/potent-potables/vodka";
 
@@ -136,6 +137,7 @@ export default function VodkaCocktailsPage() {
   // RecipeKit state
   const [selectedRecipe, setSelectedRecipe] = useState<any | null>(null);
   const [showKit, setShowKit] = useState(false);
+  const [showUniversalSearch, setShowUniversalSearch] = useState(false);
   const [servingsById, setServingsById] = useState<Record<string, number>>({});
   const [metricFlags, setMetricFlags] = useState<Record<string, boolean>>({});
 
@@ -177,6 +179,29 @@ export default function VodkaCocktailsPage() {
       try {
         await navigator.clipboard.writeText(`${cocktail.name}\n${text}\n${url}`);
         alert('Recipe copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
+
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Vodka Cocktails',
+      text: 'Discover clean and versatile vodka cocktail recipes for every mood.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
       } catch {
         alert('Unable to share on this device.');
       }
@@ -246,6 +271,23 @@ export default function VodkaCocktailsPage() {
   return (
     <RequireAgeGate>
       <div className="min-h-screen bg-gradient-to-br from-cyan-50 via-blue-50 to-purple-50">
+        {/* Universal Search Modal */}
+        {showUniversalSearch && (
+          <div className="fixed inset-0 bg-black/50 z-50 flex items-start justify-center pt-20" onClick={() => setShowUniversalSearch(false)}>
+            <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl mx-4 max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+              <div className="sticky top-0 bg-white border-b border-gray-200 p-4 flex items-center justify-between z-10">
+                <h2 className="text-lg font-semibold">Search All Drinks</h2>
+                <Button variant="ghost" size="sm" onClick={() => setShowUniversalSearch(false)}>
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+              <div className="p-4">
+                <UniversalSearch onClose={() => setShowUniversalSearch(false)} />
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* RecipeKit Modal */}
         {selectedRecipe && (
           <RecipeKit
@@ -284,11 +326,21 @@ export default function VodkaCocktailsPage() {
                   <Badge className="bg-cyan-100 text-cyan-800">Clean & Versatile</Badge>
                 </div>
               </div>
-              <div className="flex items-center gap-4 text-sm text-gray-600">
-                <GlassWater className="fill-cyan-500 text-cyan-500" />
-                <span>Level {userProgress.level}</span>
-                <div className="w-px h-4 bg-gray-300" />
-                <span>{userProgress.totalPoints} XP</span>
+              <div className="flex items-center gap-4">
+                <Button variant="outline" size="sm" onClick={() => setShowUniversalSearch(true)}>
+                  <Search className="h-4 w-4 mr-2" />
+                  Universal Search
+                </Button>
+                <div className="flex items-center gap-2 text-sm text-gray-600">
+                  <GlassWater className="fill-cyan-500 text-cyan-500" />
+                  <span>Level {userProgress.level}</span>
+                  <div className="w-px h-4 bg-gray-300" />
+                  <span>{userProgress.totalPoints} XP</span>
+                </div>
+                <Button size="sm" className="bg-blue-600 hover:bg-blue-700" onClick={handleSharePage}>
+                  <Share2 className="h-4 w-4 mr-2" />
+                  Share Page
+                </Button>
               </div>
             </div>
           </div>

--- a/client/src/pages/drinks/potent-potables/whiskey-bourbon/index.tsx
+++ b/client/src/pages/drinks/potent-potables/whiskey-bourbon/index.tsx
@@ -5,9 +5,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import RequireAgeGate from "@/components/RequireAgeGate";
-import { Wine, Clock, Heart, Target, Sparkles, Flame, Search, Share2, ArrowLeft, GlassWater, TrendingUp, Award, Zap, Crown, Droplets, Apple, Leaf, Clipboard, RotateCcw, Check, Home, Martini, Coffee } from "lucide-react";
+import { Wine, Clock, Heart, Target, Sparkles, Flame, Search, Share2, ArrowLeft, GlassWater, TrendingUp, Award, Zap, Crown, Droplets, Apple, Leaf, Clipboard, RotateCcw, Check, Home, Martini, Coffee, X } from "lucide-react";
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
+import UniversalSearch from '@/components/UniversalSearch';
 import { whiskeyCocktails } from "@/data/drinks/potent-potables/whiskey-bourbon";
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 import { redirectToCanonicalRecipe } from '@/lib/canonical-routing';
@@ -133,6 +134,7 @@ export default function WhiskeyBourbonPage() {
   // RecipeKit state
   const [selectedRecipe, setSelectedRecipe] = useState<any | null>(null);
   const [showKit, setShowKit] = useState(false);
+  const [showUniversalSearch, setShowUniversalSearch] = useState(false);
   const [servingsById, setServingsById] = useState<Record<string, number>>({});
   const [metricFlags, setMetricFlags] = useState<Record<string, boolean>>({});
 
@@ -174,6 +176,29 @@ export default function WhiskeyBourbonPage() {
       try {
         await navigator.clipboard.writeText(`${cocktail.name}\n${text}\n${url}`);
         alert('Recipe copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
+
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Whiskey & Bourbon',
+      text: 'Explore rich whiskey and bourbon cocktails with complex flavors.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
       } catch {
         alert('Unable to share on this device.');
       }
@@ -243,6 +268,23 @@ export default function WhiskeyBourbonPage() {
   return (
     <RequireAgeGate>
       <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50">
+        {/* Universal Search Modal */}
+        {showUniversalSearch && (
+          <div className="fixed inset-0 bg-black/50 z-50 flex items-start justify-center pt-20" onClick={() => setShowUniversalSearch(false)}>
+            <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl mx-4 max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+              <div className="sticky top-0 bg-white border-b border-gray-200 p-4 flex items-center justify-between z-10">
+                <h2 className="text-lg font-semibold">Search All Drinks</h2>
+                <Button variant="ghost" size="sm" onClick={() => setShowUniversalSearch(false)}>
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+              <div className="p-4">
+                <UniversalSearch onClose={() => setShowUniversalSearch(false)} />
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* RecipeKit Modal */}
         {selectedRecipe && (
           <RecipeKit
@@ -281,11 +323,21 @@ export default function WhiskeyBourbonPage() {
                   <Badge className="bg-amber-100 text-amber-800">Kentucky Classics</Badge>
                 </div>
               </div>
-              <div className="flex items-center gap-4 text-sm text-gray-600">
-                <GlassWater className="fill-amber-500 text-amber-500" />
-                <span>Level {userProgress.level}</span>
-                <div className="w-px h-4 bg-gray-300" />
-                <span>{userProgress.totalPoints} XP</span>
+              <div className="flex items-center gap-4">
+                <Button variant="outline" size="sm" onClick={() => setShowUniversalSearch(true)}>
+                  <Search className="h-4 w-4 mr-2" />
+                  Universal Search
+                </Button>
+                <div className="flex items-center gap-2 text-sm text-gray-600">
+                  <GlassWater className="fill-amber-500 text-amber-500" />
+                  <span>Level {userProgress.level}</span>
+                  <div className="w-px h-4 bg-gray-300" />
+                  <span>{userProgress.totalPoints} XP</span>
+                </div>
+                <Button size="sm" className="bg-amber-600 hover:bg-amber-700" onClick={handleSharePage}>
+                  <Share2 className="h-4 w-4 mr-2" />
+                  Share Page
+                </Button>
               </div>
             </div>
           </div>

--- a/client/src/pages/drinks/protein-shakes/casein/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/casein/index.tsx
@@ -293,7 +293,7 @@ export default function CaseinProteinPage() {
       }
       addToRecentlyViewed(drinkData)
       incrementDrinksMade()
-      addPoints(30)
+      addPoints(25)
     }
     setShowKit(false)
     setSelectedRecipe(null)

--- a/client/src/pages/drinks/protein-shakes/collagen/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/collagen/index.tsx
@@ -325,7 +325,7 @@ export default function CollagenProteinPage() {
       tags: shake.tags
     });
     incrementDrinksMade();
-    addPoints(35);
+    addPoints(25);
   };
 
   return (
@@ -512,9 +512,9 @@ export default function CollagenProteinPage() {
         <div className="flex items-center gap-1 mb-6 bg-gray-100 rounded-lg p-1">
           {[
             { id: 'browse', label: 'Browse All', icon: Search },
-            { id: 'collagen-types', label: 'Collagen Types', icon: Sparkles },
-            { id: 'sources', label: 'Sources', icon: Droplets },
-            { id: 'beauty-goals', label: 'Beauty Goals', icon: Eye },
+            { id: 'types', label: 'Collagen Types', icon: Sparkles },
+            { id: 'benefits', label: 'Sources', icon: Droplets },
+            { id: 'trending', label: 'Beauty Goals', icon: Eye },
             { id: 'featured', label: 'Featured', icon: Star }
           ].map(tab => {
             const Icon = tab.icon;
@@ -766,7 +766,7 @@ export default function CollagenProteinPage() {
         )}
 
         {/* Collagen Types Tab */}
-        {activeTab === 'collagen-types' && (
+        {activeTab === 'types' && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
             {collagenTypes.map(type => {
               const Icon = type.icon;
@@ -837,7 +837,7 @@ export default function CollagenProteinPage() {
         )}
 
         {/* Sources Tab */}
-        {activeTab === 'sources' && (
+        {activeTab === 'benefits' && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
             {collagenSources.map(source => {
               const Icon = source.icon;
@@ -908,7 +908,7 @@ export default function CollagenProteinPage() {
         )}
 
         {/* Beauty Goals Tab */}
-        {activeTab === 'beauty-goals' && (
+        {activeTab === 'trending' && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
             {beautyGoals.map(goal => {
               const Icon = goal.icon;

--- a/client/src/pages/drinks/protein-shakes/egg/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/egg/index.tsx
@@ -207,7 +207,7 @@ export default function EggProteinPage() {
       };
       addToRecentlyViewed(drinkData);
       incrementDrinksMade();
-      addPoints(100);
+      addPoints(25);
     }
     setShowKit(false);
     setSelectedRecipe(null);
@@ -699,7 +699,7 @@ export default function EggProteinPage() {
                         bestTime: 'Post-Workout'
                       });
                       incrementDrinksMade();
-                      addPoints(100);
+                      addPoints(25);
                       kitRefs.current[recipe.id]?.open?.();
                     }}
                   >

--- a/client/src/pages/drinks/protein-shakes/plant-based/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/plant-based/index.tsx
@@ -83,7 +83,7 @@ export default function PlantBasedProteinPage() {
     incrementDrinksMade
   } = useDrinks();
 
-  const [activeTab, setActiveTab] = useState<'browse'|'protein-types'|'goals'|'featured'>('browse');
+  const [activeTab, setActiveTab] = useState<'browse'|'types'|'goals'|'featured'>('browse');
   const [selectedProteinType, setSelectedProteinType] = useState('');
   const [selectedGoal, setSelectedGoal] = useState('');
   const [selectedAllergen, setSelectedAllergen] = useState('');
@@ -375,7 +375,7 @@ export default function PlantBasedProteinPage() {
         <div className="flex items-center gap-1 mb-6 bg-gray-100 rounded-lg p-1">
           {[
             { id: 'browse', label: 'Browse All', icon: Search },
-            { id: 'protein-types', label: 'Protein Types', icon: Leaf },
+            { id: 'types', label: 'Protein Types', icon: Leaf },
             { id: 'goals', label: 'By Goal', icon: Target },
             { id: 'featured', label: 'Featured', icon: Star }
           ].map((tab: any) => {
@@ -660,7 +660,7 @@ export default function PlantBasedProteinPage() {
         )}
 
         {/* Protein Types */}
-        {activeTab === 'protein-types' && (
+        {activeTab === 'types' && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
             {proteinTypes.map(type => {
               const Icon = type.icon;

--- a/client/src/pages/drinks/smoothies/berry/index.tsx
+++ b/client/src/pages/drinks/smoothies/berry/index.tsx
@@ -150,7 +150,7 @@ export default function BerrySmoothiesPage() {
   const [maxCalories, setMaxCalories] = useState<number | 'all'>('all');
   const [onlyNaturalSweetener, setOnlyNaturalSweetener] = useState(false);
   const [sortBy, setSortBy] = useState<'rating' | 'fiber' | 'cost' | 'calories'>('rating');
-  const [activeTab, setActiveTab] = useState<'browse'|'berry-types'|'benefits'|'featured'|'trending'>('browse');
+  const [activeTab, setActiveTab] = useState<'browse'|'types'|'benefits'|'featured'|'trending'>('browse');
   const [showUniversalSearch, setShowUniversalSearch] = useState(false);
 
   // RecipeKit state
@@ -500,7 +500,7 @@ export default function BerrySmoothiesPage() {
         <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-1 bg-gray-100 rounded-lg p-1">
           {[
             { id: 'browse', label: 'Browse All', icon: Search },
-            { id: 'berry-types', label: 'Berry Types', icon: Heart },
+            { id: 'types', label: 'Berry Types', icon: Heart },
             { id: 'benefits', label: 'Health Benefits', icon: Star },
             { id: 'featured', label: 'Featured', icon: Zap },
             { id: 'trending', label: 'Trending', icon: Flame }
@@ -833,7 +833,7 @@ export default function BerrySmoothiesPage() {
         )}
 
         {/* Berry Types Tab */}
-        {activeTab === 'berry-types' && (
+        {activeTab === 'types' && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {berryTypes.map(type => (
               <Card key={type.id} className="hover:shadow-lg transition-shadow">

--- a/client/src/pages/drinks/smoothies/breakfast/index.tsx
+++ b/client/src/pages/drinks/smoothies/breakfast/index.tsx
@@ -197,7 +197,7 @@ export default function BreakfastSmoothiesPage() {
   const [maxCalories, setMaxCalories] = useState<number | 'all'>('all');
   const [onlyNaturalSweetener, setOnlyNaturalSweetener] = useState(false);
   const [sortBy, setSortBy] = useState<'rating' | 'protein' | 'cost' | 'calories'>('rating');
-  const [activeTab, setActiveTab] = useState<'browse'|'breakfast-types'|'benefits'|'featured'|'trending'>('browse');
+  const [activeTab, setActiveTab] = useState<'browse'|'types'|'benefits'|'featured'|'trending'>('browse');
   const [showUniversalSearch, setShowUniversalSearch] = useState(false);
 
   // RecipeKit state
@@ -541,7 +541,7 @@ export default function BreakfastSmoothiesPage() {
         <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-1 bg-gray-100 rounded-lg p-1">
           {[
             { id: 'browse', label: 'Browse All', icon: Search },
-            { id: 'breakfast-types', label: 'Breakfast Types', icon: Apple },
+            { id: 'types', label: 'Breakfast Types', icon: Apple },
             { id: 'benefits', label: 'Benefits', icon: Heart },
             { id: 'featured', label: 'Featured', icon: Star },
             { id: 'trending', label: 'Trending', icon: Zap }
@@ -860,7 +860,7 @@ export default function BreakfastSmoothiesPage() {
         )}
 
         {/* Breakfast Types Tab */}
-        {activeTab === 'breakfast-types' && (
+        {activeTab === 'types' && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {breakfastTypes.map(type => {
               const Icon = type.icon;

--- a/client/src/pages/drinks/smoothies/dessert/index.tsx
+++ b/client/src/pages/drinks/smoothies/dessert/index.tsx
@@ -107,7 +107,7 @@ export default function DessertSmoothiesPage() {
   const [maxCalories, setMaxCalories] = useState<number | 'all'>('all'); // FIXED: Now supports 'all'
   const [onlyNaturalSweetener, setOnlyNaturalSweetener] = useState(false);
   const [sortBy, setSortBy] = useState<'rating' | 'protein' | 'cost' | 'calories'>('rating');
-  const [activeTab, setActiveTab] = useState<'browse'|'dessert-types'|'categories'|'featured'>('browse');
+  const [activeTab, setActiveTab] = useState<'browse'|'types'|'benefits'|'featured'>('browse');
   const [showUniversalSearch, setShowUniversalSearch] = useState(false);
 
   // RecipeKit state
@@ -441,8 +441,8 @@ export default function DessertSmoothiesPage() {
         <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-1 bg-gray-100 rounded-lg p-1">
           {[
             { id: 'browse', label: 'Browse All', icon: Search },
-            { id: 'dessert-types', label: 'Dessert Types', icon: Cookie },
-            { id: 'categories', label: 'Categories', icon: Cookie },
+            { id: 'types', label: 'Dessert Types', icon: Cookie },
+            { id: 'benefits', label: 'Categories', icon: Cookie },
             { id: 'featured', label: 'Featured', icon: Star }
           ].map(tab => {
             const Icon = tab.icon as any;
@@ -758,7 +758,7 @@ export default function DessertSmoothiesPage() {
         )}
 
         {/* Rest of the tabs remain the same structure */}
-        {activeTab === 'dessert-types' && (
+        {activeTab === 'types' && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
             {dessertTypes.map(type => {
               const Icon = type.icon as any;
@@ -800,7 +800,7 @@ export default function DessertSmoothiesPage() {
           </div>
         )}
 
-        {activeTab === 'categories' && (
+        {activeTab === 'benefits' && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
             {dessertCategories.map(category => {
               const Icon = category.icon as any;

--- a/client/src/pages/drinks/smoothies/detox/index.tsx
+++ b/client/src/pages/drinks/smoothies/detox/index.tsx
@@ -137,7 +137,7 @@ export default function DetoxSmoothiesPage() {
   const [maxCalories, setMaxCalories] = useState<number | 'all'>('all');
   const [onlyNaturalSweetener, setOnlyNaturalSweetener] = useState(false);
   const [sortBy, setSortBy] = useState<'rating' | 'fiber' | 'cost' | 'calories'>('rating');
-  const [activeTab, setActiveTab] = useState<'browse'|'detox-types'|'benefits'|'featured'>('browse');
+  const [activeTab, setActiveTab] = useState<'browse'|'types'|'benefits'|'featured'>('browse');
   const [showUniversalSearch, setShowUniversalSearch] = useState(false);
 
   // RecipeKit state
@@ -456,7 +456,7 @@ export default function DetoxSmoothiesPage() {
         <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-1 bg-gray-100 rounded-lg p-1">
           {[
             { id: 'browse', label: 'Browse All', icon: Search },
-            { id: 'detox-types', label: 'Detox Types', icon: Apple },
+            { id: 'types', label: 'Detox Types', icon: Apple },
             { id: 'benefits', label: 'Benefits', icon: Heart },
             { id: 'featured', label: 'Featured', icon: Star }
           ].map(tab => {
@@ -771,7 +771,7 @@ export default function DetoxSmoothiesPage() {
         )}
 
         {/* Detox Types Tab */}
-        {activeTab === 'detox-types' && (
+        {activeTab === 'types' && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {detoxTypes.map(type => (
               <Card key={type.id} className="hover:shadow-lg transition-shadow">

--- a/client/src/pages/drinks/smoothies/green/index.tsx
+++ b/client/src/pages/drinks/smoothies/green/index.tsx
@@ -147,7 +147,7 @@ export default function GreenSmoothiesPage() {
   const [maxCalories, setMaxCalories] = useState<number | 'all'>('all');
   const [onlyNaturalSweetener, setOnlyNaturalSweetener] = useState(false);
   const [sortBy, setSortBy] = useState<'rating' | 'fiber' | 'calories' | 'cost'>('rating');
-  const [activeTab, setActiveTab] = useState<'browse'|'green-types'|'benefits'|'featured'>('browse');
+  const [activeTab, setActiveTab] = useState<'browse'|'types'|'benefits'|'featured'>('browse');
   const [showUniversalSearch, setShowUniversalSearch] = useState(false);
 
   // RecipeKit state
@@ -492,7 +492,7 @@ export default function GreenSmoothiesPage() {
         <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-1 bg-gray-100 rounded-lg p-1">
           {[
             { id: 'browse', label: 'Browse All', icon: Search },
-            { id: 'green-types', label: 'Green Types', icon: Leaf },
+            { id: 'types', label: 'Green Types', icon: Leaf },
             { id: 'benefits', label: 'Health Benefits', icon: Heart },
             { id: 'featured', label: 'Featured', icon: Star }
           ].map(tab => {
@@ -807,7 +807,7 @@ export default function GreenSmoothiesPage() {
         )}
 
         {/* Green Types Tab */}
-        {activeTab === 'green-types' && (
+        {activeTab === 'types' && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {greenTypes.map(type => (
               <Card key={type.id} className="hover:shadow-lg transition-shadow">

--- a/client/src/pages/drinks/smoothies/protein/index.tsx
+++ b/client/src/pages/drinks/smoothies/protein/index.tsx
@@ -143,7 +143,7 @@ export default function ProteinSmoothiesPage() {
   const [minProtein, setMinProtein] = useState<number | 'all'>('all');
   const [maxCalories, setMaxCalories] = useState<number | 'all'>('all');
   const [sortBy, setSortBy] = useState<'rating' | 'protein' | 'calories' | 'fiber'>('rating');
-  const [activeTab, setActiveTab] = useState<'browse'|'protein-types'|'goals'|'featured'>('browse');
+  const [activeTab, setActiveTab] = useState<'browse'|'types'|'goals'|'featured'>('browse');
   const [showUniversalSearch, setShowUniversalSearch] = useState(false);
 
   // RecipeKit state
@@ -242,7 +242,7 @@ export default function ProteinSmoothiesPage() {
       };
       addToRecentlyViewed(drinkData);
       incrementDrinksMade();
-      addPoints(35); // XP for protein smoothies
+      addPoints(25); // XP for protein smoothies
     }
     setShowKit(false);
     setSelectedRecipe(null);
@@ -488,7 +488,7 @@ export default function ProteinSmoothiesPage() {
         <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-1 bg-gray-100 rounded-lg p-1">
           {[
             { id: 'browse', label: 'Browse All', icon: Search },
-            { id: 'protein-types', label: 'Protein Types', icon: Zap },
+            { id: 'types', label: 'Protein Types', icon: Zap },
             { id: 'goals', label: 'Fitness Goals', icon: Dumbbell },
             { id: 'featured', label: 'Featured', icon: Star }
           ].map(tab => {
@@ -809,7 +809,7 @@ export default function ProteinSmoothiesPage() {
         )}
 
         {/* Protein Types Tab */}
-        {activeTab === 'protein-types' && (
+        {activeTab === 'types' && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {proteinTypes.map(type => (
               <Card key={type.id} className="hover:shadow-lg transition-shadow">

--- a/client/src/pages/drinks/smoothies/tropical/index.tsx
+++ b/client/src/pages/drinks/smoothies/tropical/index.tsx
@@ -146,7 +146,7 @@ export default function TropicalSmoothiesPage() {
   const [maxCalories, setMaxCalories] = useState<number | 'all'>('all');
   const [onlyNaturalSweetener, setOnlyNaturalSweetener] = useState(false);
   const [sortBy, setSortBy] = useState<'rating' | 'fiber' | 'cost' | 'calories'>('rating');
-  const [activeTab, setActiveTab] = useState<'browse'|'flavors'|'benefits'|'featured'|'trending'>('browse');
+  const [activeTab, setActiveTab] = useState<'browse'|'types'|'benefits'|'featured'|'trending'>('browse');
   const [showUniversalSearch, setShowUniversalSearch] = useState(false);
 
   // RecipeKit state
@@ -490,7 +490,7 @@ export default function TropicalSmoothiesPage() {
         <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-1 bg-gray-100 rounded-lg p-1">
           {[
             { id: 'browse', label: 'Browse All', icon: Search },
-            { id: 'flavors', label: 'Tropical Flavors', icon: Palmtree },
+            { id: 'types', label: 'Tropical Flavors', icon: Palmtree },
             { id: 'benefits', label: 'Health Benefits', icon: Heart },
             { id: 'featured', label: 'Featured', icon: Star },
             { id: 'trending', label: 'Trending', icon: Zap }
@@ -806,7 +806,7 @@ export default function TropicalSmoothiesPage() {
         )}
 
         {/* Tropical Flavors Tab */}
-        {activeTab === 'flavors' && (
+        {activeTab === 'types' && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {tropicalFlavors.map(flavor => (
               <Card key={flavor.id} className="hover:shadow-lg transition-shadow">

--- a/client/src/pages/drinks/smoothies/workout/index.tsx
+++ b/client/src/pages/drinks/smoothies/workout/index.tsx
@@ -197,7 +197,7 @@ export default function WorkoutSmoothiesPage() {
   const [maxCalories, setMaxCalories] = useState<number | 'all'>('all');
   const [onlyNaturalSweetener, setOnlyNaturalSweetener] = useState(false);
   const [sortBy, setSortBy] = useState<'rating' | 'protein' | 'cost' | 'calories'>('rating');
-  const [activeTab, setActiveTab] = useState<'browse'|'workout-types'|'benefits'|'featured'|'trending'>('browse');
+  const [activeTab, setActiveTab] = useState<'browse'|'types'|'benefits'|'featured'|'trending'>('browse');
   const [showUniversalSearch, setShowUniversalSearch] = useState(false);
 
   // RecipeKit state
@@ -295,7 +295,7 @@ export default function WorkoutSmoothiesPage() {
       };
       addToRecentlyViewed(drinkData);
       incrementDrinksMade();
-      addPoints(30); // XP for workout smoothies
+      addPoints(25); // XP for workout smoothies
     }
     setShowKit(false);
     setSelectedRecipe(null);
@@ -541,7 +541,7 @@ export default function WorkoutSmoothiesPage() {
         <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-1 bg-gray-100 rounded-lg p-1">
           {[
             { id: 'browse', label: 'Browse All', icon: Search },
-            { id: 'workout-types', label: 'Workout Types', icon: Activity },
+            { id: 'types', label: 'Workout Types', icon: Activity },
             { id: 'benefits', label: 'Benefits', icon: Trophy },
             { id: 'featured', label: 'Featured', icon: Star },
             { id: 'trending', label: 'Trending', icon: Zap }
@@ -858,7 +858,7 @@ export default function WorkoutSmoothiesPage() {
         )}
 
         {/* Workout Types Tab */}
-        {activeTab === 'workout-types' && (
+        {activeTab === 'types' && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {workoutTypes.map(type => {
               const Icon = type.icon;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Type union fix**: Added `'caffeinated'` to `DrinkItem.category` union in `DrinksContext.tsx` — every caffeinated page was writing this value but the type didn't include it
- **Tab ID normalization**: Standardized tab IDs across 12 subcategory pages to the canonical set (`browse` / `types` / `benefits` / `featured` / `trending`), replacing page-specific variants like `'flavors'`, `'berry-types'`, `'collagen-types'`, etc.
- **XP reward normalization**: Standardized `addPoints()` calls to 25 (non-alcoholic / general) and 35 (alcoholic PP) across ~10 files that had stray values (20, 30, 40, 45, 100)
- **PP Universal Search + Share Page**: Added `UniversalSearch` modal and `handleSharePage` to all 15 Potent Potables subcategory pages — they were the only hub family missing cross-hub search and page-level share

## Test plan

- [ ] Verify TypeScript compiles without errors on `DrinkItem.category` usage in caffeinated pages
- [ ] Click through tabs on a normalized page (e.g. tropical smoothies, berry smoothies, collagen protein shakes) — confirm tabs render and switch correctly
- [ ] Open a PP subcategory page (e.g. /drinks/potent-potables/cocktails) — confirm "Universal Search" button opens the search modal and "Share Page" button triggers share/clipboard
- [ ] Confirm XP reward toasts show the correct value when completing a recipe on a normalized page

https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
