### PR TITLE
Fix stale Fix It details queue state across week/day target transitions

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -2878,7 +2878,7 @@ const NutritionMealPlanner = () => {
     setFixItDetailsQueuePendingSkipReason(DEFAULT_FIX_IT_DETAILS_QUEUE_SKIP_REASON);
     setFixItDetailsQueueDone(false);
     setFixItDetailsQueueSnoozedByKey({});
-  }, [activeFixItTarget?.issueType, activeFixItTarget?.targetDay]);
+  }, [activeFixItTarget?.issueType, activeFixItTarget?.targetDay, activeFixItTarget?.targetDate]);
 
   const activeFixItDetailsQueue = useMemo<FixItDetailsQueueState | null>(() => {
     if (!activeFixItTarget?.targetDay) return null;


### PR DESCRIPTION
### Motivation
- Switching the Fix It target to the same weekday in a different week could retain skipped/snoozed/done state because the queue reset only keyed on `issueType` and `targetDay`, causing stale UI state and incorrect counts.

### Description
- Reset the Fix It details queue when the actual target date changes by adding `activeFixItTarget?.targetDate` to the `useEffect` dependency list in `client/src/components/NutritionMealPlanner.tsx`, ensuring skipped/snoozed/done state is cleared when moving between weeks.

### Testing
- Built the app with `npm run build`, `npm run build:client`, and `npm run build:server`, and all builds completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2836b6184832584e378d907142cbd)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
