### PR TITLE
Fix Unauthorized errors on memberships, dashboard, wishlist, and other auth-required pages

### DIFF
--- a/client/src/contexts/UserContext.tsx
+++ b/client/src/contexts/UserContext.tsx
@@ -49,7 +49,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 
-  // Load user from localStorage on mount, or fetch from server if OAuth login
+  // Load user from localStorage on mount, then verify session with server
   useEffect(() => {
     const loadUser = async () => {
       try {
@@ -87,14 +87,29 @@ export function UserProvider({ children }: { children: ReactNode }) {
           }
         }
 
-        // Fall back to localStorage
+        // If localStorage has a user, verify the server session is still valid
         const raw = localStorage.getItem("user");
         if (raw) {
           const parsed = JSON.parse(raw);
           if (parsed && typeof parsed === "object") {
             if (parsed.id && typeof parsed.id !== "string") parsed.id = String(parsed.id);
             delete parsed.password;
-            setUser(parsed as User);
+
+            // Verify the cookie/session is still valid before trusting localStorage
+            try {
+              const verifyRes = await fetch('/api/auth/me', { credentials: 'include' });
+              if (verifyRes.ok) {
+                // Session valid — use localStorage user (already up to date)
+                setUser(parsed as User);
+              } else {
+                // Cookie expired or missing — clear stale localStorage
+                localStorage.removeItem("user");
+                setUser(null);
+              }
+            } catch {
+              // Network error — optimistically use localStorage so offline works
+              setUser(parsed as User);
+            }
           }
         }
       } catch (e) {

--- a/client/src/pages/drinks/detoxes/index.tsx
+++ b/client/src/pages/drinks/detoxes/index.tsx
@@ -25,12 +25,13 @@ export default function DetoxesHub() {
   const [selectedProgram, setSelectedProgram] = useState<string | null>(null);
   const [showProgramModal, setShowProgramModal] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
+  const [startedPrograms, setStartedPrograms] = useState<Set<string>>(new Set());
 
   const popularDetoxes = [
-    { name: 'Lemon Ginger Blast', type: 'Morning', time: '5 min', rating: 4.9, route: '/drinks/detoxes/juice' },
-    { name: 'Green Machine', type: 'Juice', time: '10 min', rating: 4.8, route: '/drinks/detoxes/juice' },
-    { name: 'Cucumber Mint Water', type: 'Water', time: '2 min', rating: 4.9, route: '/drinks/detoxes/water' },
-    { name: 'Dandelion Tea', type: 'Tea', time: '8 min', rating: 4.7, route: '/drinks/detoxes/tea' }
+    { name: 'Lemon Ginger Detox', type: 'Water', time: '5 min', rating: 4.9, route: '/drinks/recipe/lemon-ginger-detox' },
+    { name: 'Green Cleanse Elixir', type: 'Juice', time: '10 min', rating: 4.8, route: '/drinks/recipe/green-cleanse-elixir' },
+    { name: 'Cucumber Mint Refresher', type: 'Water', time: '2 min', rating: 4.9, route: '/drinks/recipe/cucumber-mint-refresher' },
+    { name: 'Dandelion Root Cleanse', type: 'Tea', time: '8 min', rating: 4.7, route: '/drinks/recipe/dandelion-root-cleanse' }
   ];
 
   const cleanseBenefits = [
@@ -104,6 +105,7 @@ export default function DetoxesHub() {
     const points = selectedProgram === '1-day' ? 100 : selectedProgram === '3-day' ? 250 : 500;
     addPoints(points);
     incrementDrinksMade();
+    setStartedPrograms(prev => new Set(prev).add(selectedProgram));
 
     setShowProgramModal(false);
     setShowSuccess(true);
@@ -514,10 +516,10 @@ export default function DetoxesHub() {
                   </li>
                 </ul>
                 <Button
-                  className="w-full mt-4 bg-green-600 hover:bg-green-700"
-                  onClick={() => startCleanse('1-day')}
+                  className={`w-full mt-4 ${startedPrograms.has('1-day') ? 'bg-gray-400 cursor-default' : 'bg-green-600 hover:bg-green-700'}`}
+                  onClick={() => !startedPrograms.has('1-day') && startCleanse('1-day')}
                 >
-                  Start 1-Day Cleanse
+                  {startedPrograms.has('1-day') ? <><CheckCircle className="h-4 w-4 mr-2" />Program Active</> : 'Start 1-Day Cleanse'}
                 </Button>
               </div>
 
@@ -544,10 +546,10 @@ export default function DetoxesHub() {
                   </li>
                 </ul>
                 <Button
-                  className="w-full mt-4 bg-blue-600 hover:bg-blue-700"
-                  onClick={() => startCleanse('3-day')}
+                  className={`w-full mt-4 ${startedPrograms.has('3-day') ? 'bg-gray-400 cursor-default' : 'bg-blue-600 hover:bg-blue-700'}`}
+                  onClick={() => !startedPrograms.has('3-day') && startCleanse('3-day')}
                 >
-                  Start 3-Day Cleanse
+                  {startedPrograms.has('3-day') ? <><CheckCircle className="h-4 w-4 mr-2" />Program Active</> : 'Start 3-Day Cleanse'}
                 </Button>
               </div>
 
@@ -571,10 +573,10 @@ export default function DetoxesHub() {
                   </li>
                 </ul>
                 <Button
-                  className="w-full mt-4 bg-purple-600 hover:bg-purple-700"
-                  onClick={() => startCleanse('7-day')}
+                  className={`w-full mt-4 ${startedPrograms.has('7-day') ? 'bg-gray-400 cursor-default' : 'bg-purple-600 hover:bg-purple-700'}`}
+                  onClick={() => !startedPrograms.has('7-day') && startCleanse('7-day')}
                 >
-                  Start 7-Day Cleanse
+                  {startedPrograms.has('7-day') ? <><CheckCircle className="h-4 w-4 mr-2" />Program Active</> : 'Start 7-Day Cleanse'}
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
## Summary

- `UserContext` was restoring the user from localStorage on page load without checking whether the server-side session (JWT cookie) was still valid
- If the cookie expired, the `user` object was still set → auth-required queries fired → server returned 401 → pages showed "Unauthorized" / "Unable to load dashboard" instead of the expected sign-in prompt
- Fix: after finding a user in localStorage, verify the session with `GET /api/auth/me`. If the server rejects it (cookie expired/missing), clear localStorage and set `user = null` so pages correctly show the sign-in flow
- Network errors fall back to localStorage optimistically so the app still works offline

## Affected pages
Memberships, Dashboard, Wishlist, Order History, Gifts, Purchased Collection, Alerts, Following Feed

## Test plan
- [ ] Log in, then manually delete the `auth_token` cookie in DevTools, then refresh — should see sign-in prompts on those pages instead of "Unauthorized"
- [ ] Normal login flow unaffected — user stays logged in across refreshes while cookie is valid
- [ ] Google OAuth login still works

https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
