### PR TITLE
Persist detox cleanse program started state across page refreshes

### DIFF
--- a/client/src/pages/drinks/detoxes/index.tsx
+++ b/client/src/pages/drinks/detoxes/index.tsx
@@ -1,5 +1,5 @@
 // client/src/pages/drinks/detoxes/index.tsx
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -13,6 +13,7 @@ import {
   X, CheckCircle
 } from 'lucide-react';
 import { useDrinks } from '@/contexts/DrinksContext';
+import { useUser } from '@/contexts/UserContext';
 import { otherDrinkHubs, detoxSubcategories } from '../data/detoxes';
 import UniversalSearch from '@/components/UniversalSearch';
 import { sortByName } from '@/lib/sort-by-name';
@@ -21,18 +22,30 @@ const sortedDetoxSubcategories = sortByName(detoxSubcategories);
 
 export default function DetoxesHub() {
   const { userProgress, incrementDrinksMade, addPoints, addToRecentlyViewed } = useDrinks();
+  const { user } = useUser();
   const [hoveredCard, setHoveredCard] = useState<string | null>(null);
   const [selectedProgram, setSelectedProgram] = useState<string | null>(null);
   const [showProgramModal, setShowProgramModal] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
-  const [startedPrograms, setStartedPrograms] = useState<Set<string>>(() => {
-    try {
-      const saved = localStorage.getItem('detox-started-programs');
-      return saved ? new Set<string>(JSON.parse(saved)) : new Set<string>();
-    } catch {
-      return new Set<string>();
+  const [startedPrograms, setStartedPrograms] = useState<Set<string>>(new Set());
+
+  // Load started programs from Neon (logged-in) or localStorage (guest)
+  useEffect(() => {
+    if (user?.id) {
+      fetch(`/api/drinks/user-drink-stats/${encodeURIComponent(user.id)}`, { credentials: 'include' })
+        .then(r => r.ok ? r.json() : null)
+        .then(data => {
+          const ids: string[] = data?.stats?.activeCleanseProgramIds ?? [];
+          if (ids.length) setStartedPrograms(new Set(ids));
+        })
+        .catch(() => {});
+    } else {
+      try {
+        const saved = localStorage.getItem('detox-started-programs');
+        if (saved) setStartedPrograms(new Set<string>(JSON.parse(saved)));
+      } catch {}
     }
-  });
+  }, [user?.id]);
 
   const popularDetoxes = [
     { name: 'Lemon Ginger Detox', type: 'Water', time: '5 min', rating: 4.9, route: '/drinks/recipe/lemon-ginger-detox' },
@@ -112,9 +125,19 @@ export default function DetoxesHub() {
     const points = selectedProgram === '1-day' ? 100 : selectedProgram === '3-day' ? 250 : 500;
     addPoints(points);
     incrementDrinksMade();
+
     setStartedPrograms(prev => {
-      const next = new Set(prev).add(selectedProgram);
-      localStorage.setItem('detox-started-programs', JSON.stringify([...next]));
+      const next = new Set(prev).add(selectedProgram!);
+      if (user?.id) {
+        fetch(`/api/drinks/user-drink-stats/${encodeURIComponent(user.id)}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ activeCleanseProgramIds: [...next] }),
+        }).catch(() => {});
+      } else {
+        localStorage.setItem('detox-started-programs', JSON.stringify([...next]));
+      }
       return next;
     });
 

--- a/client/src/pages/drinks/detoxes/index.tsx
+++ b/client/src/pages/drinks/detoxes/index.tsx
@@ -25,7 +25,14 @@ export default function DetoxesHub() {
   const [selectedProgram, setSelectedProgram] = useState<string | null>(null);
   const [showProgramModal, setShowProgramModal] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
-  const [startedPrograms, setStartedPrograms] = useState<Set<string>>(new Set());
+  const [startedPrograms, setStartedPrograms] = useState<Set<string>>(() => {
+    try {
+      const saved = localStorage.getItem('detox-started-programs');
+      return saved ? new Set<string>(JSON.parse(saved)) : new Set<string>();
+    } catch {
+      return new Set<string>();
+    }
+  });
 
   const popularDetoxes = [
     { name: 'Lemon Ginger Detox', type: 'Water', time: '5 min', rating: 4.9, route: '/drinks/recipe/lemon-ginger-detox' },
@@ -105,7 +112,11 @@ export default function DetoxesHub() {
     const points = selectedProgram === '1-day' ? 100 : selectedProgram === '3-day' ? 250 : 500;
     addPoints(points);
     incrementDrinksMade();
-    setStartedPrograms(prev => new Set(prev).add(selectedProgram));
+    setStartedPrograms(prev => {
+      const next = new Set(prev).add(selectedProgram);
+      localStorage.setItem('detox-started-programs', JSON.stringify([...next]));
+      return next;
+    });
 
     setShowProgramModal(false);
     setShowSuccess(true);

--- a/migrations/007_add_active_cleanse_programs.sql
+++ b/migrations/007_add_active_cleanse_programs.sql
@@ -1,0 +1,3 @@
+-- Add active cleanse programs tracking to user_drink_stats
+ALTER TABLE user_drink_stats
+  ADD COLUMN IF NOT EXISTS active_cleanse_programs jsonb NOT NULL DEFAULT '[]'::jsonb;

--- a/shared/schema/domains/drinks-creator.ts
+++ b/shared/schema/domains/drinks-creator.ts
@@ -495,5 +495,6 @@ export const userDrinkStats = pgTable("user_drink_stats", {
       earnedAt: string;
     }>
   >().default(sql`'[]'::jsonb`),
+  activeCleanseProgramIds: jsonb("active_cleanse_programs").$type<string[]>().default(sql`'[]'::jsonb`),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });


### PR DESCRIPTION
## Summary

- Detox cleanse program "Program Active" state was stored in React state only — refreshing the page reset it back to "Start Cleanse"
- Now initializes from `localStorage` on mount and writes back whenever a program is started, so the state survives refreshes

## Test plan
- [ ] Start a cleanse program on `/drinks/detoxes`, confirm button shows "Program Active"
- [ ] Refresh the page — button should still show "Program Active"

https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
