### PR TITLE
Sort PP subcategory nav alphabetically + Neon cleanse state persistence

### DIFF
--- a/client/src/pages/drinks/detoxes/index.tsx
+++ b/client/src/pages/drinks/detoxes/index.tsx
@@ -1,5 +1,5 @@
 // client/src/pages/drinks/detoxes/index.tsx
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -13,6 +13,7 @@ import {
   X, CheckCircle
 } from 'lucide-react';
 import { useDrinks } from '@/contexts/DrinksContext';
+import { useUser } from '@/contexts/UserContext';
 import { otherDrinkHubs, detoxSubcategories } from '../data/detoxes';
 import UniversalSearch from '@/components/UniversalSearch';
 import { sortByName } from '@/lib/sort-by-name';
@@ -21,18 +22,30 @@ const sortedDetoxSubcategories = sortByName(detoxSubcategories);
 
 export default function DetoxesHub() {
   const { userProgress, incrementDrinksMade, addPoints, addToRecentlyViewed } = useDrinks();
+  const { user } = useUser();
   const [hoveredCard, setHoveredCard] = useState<string | null>(null);
   const [selectedProgram, setSelectedProgram] = useState<string | null>(null);
   const [showProgramModal, setShowProgramModal] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
-  const [startedPrograms, setStartedPrograms] = useState<Set<string>>(() => {
-    try {
-      const saved = localStorage.getItem('detox-started-programs');
-      return saved ? new Set<string>(JSON.parse(saved)) : new Set<string>();
-    } catch {
-      return new Set<string>();
+  const [startedPrograms, setStartedPrograms] = useState<Set<string>>(new Set());
+
+  // Load started programs from Neon (logged-in) or localStorage (guest)
+  useEffect(() => {
+    if (user?.id) {
+      fetch(`/api/drinks/user-drink-stats/${encodeURIComponent(user.id)}`, { credentials: 'include' })
+        .then(r => r.ok ? r.json() : null)
+        .then(data => {
+          const ids: string[] = data?.stats?.activeCleanseProgramIds ?? [];
+          if (ids.length) setStartedPrograms(new Set(ids));
+        })
+        .catch(() => {});
+    } else {
+      try {
+        const saved = localStorage.getItem('detox-started-programs');
+        if (saved) setStartedPrograms(new Set<string>(JSON.parse(saved)));
+      } catch {}
     }
-  });
+  }, [user?.id]);
 
   const popularDetoxes = [
     { name: 'Lemon Ginger Detox', type: 'Water', time: '5 min', rating: 4.9, route: '/drinks/recipe/lemon-ginger-detox' },
@@ -112,9 +125,19 @@ export default function DetoxesHub() {
     const points = selectedProgram === '1-day' ? 100 : selectedProgram === '3-day' ? 250 : 500;
     addPoints(points);
     incrementDrinksMade();
+
     setStartedPrograms(prev => {
-      const next = new Set(prev).add(selectedProgram);
-      localStorage.setItem('detox-started-programs', JSON.stringify([...next]));
+      const next = new Set(prev).add(selectedProgram!);
+      if (user?.id) {
+        fetch(`/api/drinks/user-drink-stats/${encodeURIComponent(user.id)}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ activeCleanseProgramIds: [...next] }),
+        }).catch(() => {});
+      } else {
+        localStorage.setItem('detox-started-programs', JSON.stringify([...next]));
+      }
       return next;
     });
 

--- a/client/src/pages/drinks/detoxes/index.tsx
+++ b/client/src/pages/drinks/detoxes/index.tsx
@@ -25,7 +25,14 @@ export default function DetoxesHub() {
   const [selectedProgram, setSelectedProgram] = useState<string | null>(null);
   const [showProgramModal, setShowProgramModal] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
-  const [startedPrograms, setStartedPrograms] = useState<Set<string>>(new Set());
+  const [startedPrograms, setStartedPrograms] = useState<Set<string>>(() => {
+    try {
+      const saved = localStorage.getItem('detox-started-programs');
+      return saved ? new Set<string>(JSON.parse(saved)) : new Set<string>();
+    } catch {
+      return new Set<string>();
+    }
+  });
 
   const popularDetoxes = [
     { name: 'Lemon Ginger Detox', type: 'Water', time: '5 min', rating: 4.9, route: '/drinks/recipe/lemon-ginger-detox' },
@@ -105,7 +112,11 @@ export default function DetoxesHub() {
     const points = selectedProgram === '1-day' ? 100 : selectedProgram === '3-day' ? 250 : 500;
     addPoints(points);
     incrementDrinksMade();
-    setStartedPrograms(prev => new Set(prev).add(selectedProgram));
+    setStartedPrograms(prev => {
+      const next = new Set(prev).add(selectedProgram);
+      localStorage.setItem('detox-started-programs', JSON.stringify([...next]));
+      return next;
+    });
 
     setShowProgramModal(false);
     setShowSuccess(true);

--- a/client/src/pages/drinks/potent-potables/cocktails/index.tsx
+++ b/client/src/pages/drinks/potent-potables/cocktails/index.tsx
@@ -457,7 +457,7 @@ export default function ClassicCocktailsPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/cognac-brandy/index.tsx
+++ b/client/src/pages/drinks/potent-potables/cognac-brandy/index.tsx
@@ -408,7 +408,7 @@ export default function CognacBrandyPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/daiquiri/index.tsx
+++ b/client/src/pages/drinks/potent-potables/daiquiri/index.tsx
@@ -324,7 +324,7 @@ export default function DaiquiriPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/gin/index.tsx
+++ b/client/src/pages/drinks/potent-potables/gin/index.tsx
@@ -366,7 +366,7 @@ export default function GinCocktailsPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/hot-drinks/index.tsx
+++ b/client/src/pages/drinks/potent-potables/hot-drinks/index.tsx
@@ -369,7 +369,7 @@ export default function HotDrinksPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/liqueurs/index.tsx
+++ b/client/src/pages/drinks/potent-potables/liqueurs/index.tsx
@@ -367,7 +367,7 @@ export default function LiqueursPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/martinis/index.tsx
+++ b/client/src/pages/drinks/potent-potables/martinis/index.tsx
@@ -384,7 +384,7 @@ export default function MartinisPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/mocktails/index.tsx
+++ b/client/src/pages/drinks/potent-potables/mocktails/index.tsx
@@ -397,7 +397,7 @@ export default function MocktailsPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {sisterPotentPotablesPages.map((page) => {
+              {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                 const Icon = page.icon;
                 return (
                   <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/rum/index.tsx
+++ b/client/src/pages/drinks/potent-potables/rum/index.tsx
@@ -401,7 +401,7 @@ export default function RumCocktailsPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/scotch-irish-whiskey/index.tsx
+++ b/client/src/pages/drinks/potent-potables/scotch-irish-whiskey/index.tsx
@@ -394,7 +394,7 @@ export default function ScotchIrishWhiskeyPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/seasonal/index.tsx
+++ b/client/src/pages/drinks/potent-potables/seasonal/index.tsx
@@ -422,7 +422,7 @@ export default function SeasonalCocktailsPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/spritz/index.tsx
+++ b/client/src/pages/drinks/potent-potables/spritz/index.tsx
@@ -367,7 +367,7 @@ export default function SpritzMimosasPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/tequila-mezcal/index.tsx
+++ b/client/src/pages/drinks/potent-potables/tequila-mezcal/index.tsx
@@ -401,7 +401,7 @@ export default function TequilaMezcalPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/vodka/index.tsx
+++ b/client/src/pages/drinks/potent-potables/vodka/index.tsx
@@ -379,7 +379,7 @@ export default function VodkaCocktailsPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/whiskey-bourbon/index.tsx
+++ b/client/src/pages/drinks/potent-potables/whiskey-bourbon/index.tsx
@@ -376,7 +376,7 @@ export default function WhiskeyBourbonPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/migrations/007_add_active_cleanse_programs.sql
+++ b/migrations/007_add_active_cleanse_programs.sql
@@ -1,0 +1,3 @@
+-- Add active cleanse programs tracking to user_drink_stats
+ALTER TABLE user_drink_stats
+  ADD COLUMN IF NOT EXISTS active_cleanse_programs jsonb NOT NULL DEFAULT '[]'::jsonb;

--- a/shared/schema/domains/drinks-creator.ts
+++ b/shared/schema/domains/drinks-creator.ts
@@ -495,5 +495,6 @@ export const userDrinkStats = pgTable("user_drink_stats", {
       earnedAt: string;
     }>
   >().default(sql`'[]'::jsonb`),
+  activeCleanseProgramIds: jsonb("active_cleanse_programs").$type<string[]>().default(sql`'[]'::jsonb`),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });


### PR DESCRIPTION
## Summary

- Sort "Other Potent Potables" navigation grid alphabetically on all 15 PP subcategory pages
- Persist cleanse program started state to Neon (`user_drink_stats.active_cleanse_programs`) for logged-in users; localStorage fallback for guests
- Add `migrations/007_add_active_cleanse_programs.sql` — run this on your Neon database

## Test plan

- [ ] Visit any PP subcategory page (e.g. `/drinks/potent-potables/vodka`) — "Other Potent Potables" grid should be A→Z
- [ ] Start a cleanse program on `/drinks/detoxes` while logged in — button shows "Program Active"
- [ ] Refresh — button still shows "Program Active" (loaded from Neon)
- [ ] Run `migrations/007_add_active_cleanse_programs.sql` on Neon to apply schema change

https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
