### PR TITLE
Uniform pet pages to drinks: share page button + alphabetical nav sorting

### DIFF
--- a/client/src/pages/drinks/caffeinated/cold-brew/index.tsx
+++ b/client/src/pages/drinks/caffeinated/cold-brew/index.tsx
@@ -408,7 +408,7 @@ export default function ColdBrewDrinksPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/caffeinated/cold-brew/index.tsx
+++ b/client/src/pages/drinks/caffeinated/cold-brew/index.tsx
@@ -432,7 +432,7 @@ export default function ColdBrewDrinksPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Caffeinated Drink Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allCaffeinatedSubcategories.map((subcategory) => {
+              {[...allCaffeinatedSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/caffeinated/energy/index.tsx
+++ b/client/src/pages/drinks/caffeinated/energy/index.tsx
@@ -444,7 +444,7 @@ export default function EnergyPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Caffeinated Drinks</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allCaffeinatedSubcategories.map((subcategory) => {
+              {[...allCaffeinatedSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/caffeinated/energy/index.tsx
+++ b/client/src/pages/drinks/caffeinated/energy/index.tsx
@@ -420,7 +420,7 @@ export default function EnergyPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/caffeinated/espresso/index.tsx
+++ b/client/src/pages/drinks/caffeinated/espresso/index.tsx
@@ -409,7 +409,7 @@ export default function EspressoDrinksPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/caffeinated/espresso/index.tsx
+++ b/client/src/pages/drinks/caffeinated/espresso/index.tsx
@@ -433,7 +433,7 @@ export default function EspressoDrinksPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Caffeinated Drink Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allCaffeinatedSubcategories.map((subcategory) => {
+              {[...allCaffeinatedSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/caffeinated/iced/index.tsx
+++ b/client/src/pages/drinks/caffeinated/iced/index.tsx
@@ -419,7 +419,7 @@ export default function IcedCoffeePage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/caffeinated/iced/index.tsx
+++ b/client/src/pages/drinks/caffeinated/iced/index.tsx
@@ -443,7 +443,7 @@ export default function IcedCoffeePage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Caffeinated Drinks</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allCaffeinatedSubcategories.map((subcategory) => {
+              {[...allCaffeinatedSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/caffeinated/index.tsx
+++ b/client/src/pages/drinks/caffeinated/index.tsx
@@ -569,7 +569,7 @@ export default function CaffeinatedDrinksPage() {
               Explore Other Drink Categories
             </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-              {otherDrinkHubs.filter(hub => hub.id !== 'caffeinated').map((hub) => {
+              {[...otherDrinkHubs].filter((hub) => hub.id !== 'caffeinated').sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/caffeinated/lattes/index.tsx
+++ b/client/src/pages/drinks/caffeinated/lattes/index.tsx
@@ -420,7 +420,7 @@ export default function LattesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/caffeinated/lattes/index.tsx
+++ b/client/src/pages/drinks/caffeinated/lattes/index.tsx
@@ -444,7 +444,7 @@ export default function LattesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Caffeinated Drinks</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allCaffeinatedSubcategories.map((subcategory) => {
+              {[...allCaffeinatedSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/caffeinated/matcha/index.tsx
+++ b/client/src/pages/drinks/caffeinated/matcha/index.tsx
@@ -377,7 +377,7 @@ export default function MatchaDrinksPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon as any;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/caffeinated/specialty/index.tsx
+++ b/client/src/pages/drinks/caffeinated/specialty/index.tsx
@@ -420,7 +420,7 @@ export default function SpecialtyPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/caffeinated/specialty/index.tsx
+++ b/client/src/pages/drinks/caffeinated/specialty/index.tsx
@@ -444,7 +444,7 @@ export default function SpecialtyPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Caffeinated Drinks</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allCaffeinatedSubcategories.map((subcategory) => {
+              {[...allCaffeinatedSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/caffeinated/tea/index.tsx
+++ b/client/src/pages/drinks/caffeinated/tea/index.tsx
@@ -452,7 +452,7 @@ export default function TeaPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Caffeinated Drinks</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allCaffeinatedSubcategories.map((subcategory) => {
+              {[...allCaffeinatedSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/caffeinated/tea/index.tsx
+++ b/client/src/pages/drinks/caffeinated/tea/index.tsx
@@ -428,7 +428,7 @@ export default function TeaPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/detoxes/index.tsx
+++ b/client/src/pages/drinks/detoxes/index.tsx
@@ -335,7 +335,7 @@ export default function DetoxesHub() {
               Explore Other Drink Categories
             </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-              {otherDrinkHubs.filter(hub => hub.id !== 'detoxes').map((hub) => {
+              {[...otherDrinkHubs].filter((hub) => hub.id !== 'detoxes').sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/detoxes/index.tsx
+++ b/client/src/pages/drinks/detoxes/index.tsx
@@ -1,5 +1,5 @@
 // client/src/pages/drinks/detoxes/index.tsx
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -13,6 +13,7 @@ import {
   X, CheckCircle
 } from 'lucide-react';
 import { useDrinks } from '@/contexts/DrinksContext';
+import { useUser } from '@/contexts/UserContext';
 import { otherDrinkHubs, detoxSubcategories } from '../data/detoxes';
 import UniversalSearch from '@/components/UniversalSearch';
 import { sortByName } from '@/lib/sort-by-name';
@@ -21,18 +22,30 @@ const sortedDetoxSubcategories = sortByName(detoxSubcategories);
 
 export default function DetoxesHub() {
   const { userProgress, incrementDrinksMade, addPoints, addToRecentlyViewed } = useDrinks();
+  const { user } = useUser();
   const [hoveredCard, setHoveredCard] = useState<string | null>(null);
   const [selectedProgram, setSelectedProgram] = useState<string | null>(null);
   const [showProgramModal, setShowProgramModal] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
-  const [startedPrograms, setStartedPrograms] = useState<Set<string>>(() => {
-    try {
-      const saved = localStorage.getItem('detox-started-programs');
-      return saved ? new Set<string>(JSON.parse(saved)) : new Set<string>();
-    } catch {
-      return new Set<string>();
+  const [startedPrograms, setStartedPrograms] = useState<Set<string>>(new Set());
+
+  // Load started programs from Neon (logged-in) or localStorage (guest)
+  useEffect(() => {
+    if (user?.id) {
+      fetch(`/api/drinks/user-drink-stats/${encodeURIComponent(user.id)}`, { credentials: 'include' })
+        .then(r => r.ok ? r.json() : null)
+        .then(data => {
+          const ids: string[] = data?.stats?.activeCleanseProgramIds ?? [];
+          if (ids.length) setStartedPrograms(new Set(ids));
+        })
+        .catch(() => {});
+    } else {
+      try {
+        const saved = localStorage.getItem('detox-started-programs');
+        if (saved) setStartedPrograms(new Set<string>(JSON.parse(saved)));
+      } catch {}
     }
-  });
+  }, [user?.id]);
 
   const popularDetoxes = [
     { name: 'Lemon Ginger Detox', type: 'Water', time: '5 min', rating: 4.9, route: '/drinks/recipe/lemon-ginger-detox' },
@@ -112,9 +125,19 @@ export default function DetoxesHub() {
     const points = selectedProgram === '1-day' ? 100 : selectedProgram === '3-day' ? 250 : 500;
     addPoints(points);
     incrementDrinksMade();
+
     setStartedPrograms(prev => {
-      const next = new Set(prev).add(selectedProgram);
-      localStorage.setItem('detox-started-programs', JSON.stringify([...next]));
+      const next = new Set(prev).add(selectedProgram!);
+      if (user?.id) {
+        fetch(`/api/drinks/user-drink-stats/${encodeURIComponent(user.id)}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ activeCleanseProgramIds: [...next] }),
+        }).catch(() => {});
+      } else {
+        localStorage.setItem('detox-started-programs', JSON.stringify([...next]));
+      }
       return next;
     });
 

--- a/client/src/pages/drinks/detoxes/index.tsx
+++ b/client/src/pages/drinks/detoxes/index.tsx
@@ -25,7 +25,14 @@ export default function DetoxesHub() {
   const [selectedProgram, setSelectedProgram] = useState<string | null>(null);
   const [showProgramModal, setShowProgramModal] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
-  const [startedPrograms, setStartedPrograms] = useState<Set<string>>(new Set());
+  const [startedPrograms, setStartedPrograms] = useState<Set<string>>(() => {
+    try {
+      const saved = localStorage.getItem('detox-started-programs');
+      return saved ? new Set<string>(JSON.parse(saved)) : new Set<string>();
+    } catch {
+      return new Set<string>();
+    }
+  });
 
   const popularDetoxes = [
     { name: 'Lemon Ginger Detox', type: 'Water', time: '5 min', rating: 4.9, route: '/drinks/recipe/lemon-ginger-detox' },
@@ -105,7 +112,11 @@ export default function DetoxesHub() {
     const points = selectedProgram === '1-day' ? 100 : selectedProgram === '3-day' ? 250 : 500;
     addPoints(points);
     incrementDrinksMade();
-    setStartedPrograms(prev => new Set(prev).add(selectedProgram));
+    setStartedPrograms(prev => {
+      const next = new Set(prev).add(selectedProgram);
+      localStorage.setItem('detox-started-programs', JSON.stringify([...next]));
+      return next;
+    });
 
     setShowProgramModal(false);
     setShowSuccess(true);

--- a/client/src/pages/drinks/detoxes/juice/index.tsx
+++ b/client/src/pages/drinks/detoxes/juice/index.tsx
@@ -342,7 +342,7 @@ export default function DetoxJuicesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/detoxes/tea/index.tsx
+++ b/client/src/pages/drinks/detoxes/tea/index.tsx
@@ -289,7 +289,7 @@ export default function DetoxTeasPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/detoxes/water/index.tsx
+++ b/client/src/pages/drinks/detoxes/water/index.tsx
@@ -284,7 +284,7 @@ export default function DetoxWatersPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/cocktails/index.tsx
+++ b/client/src/pages/drinks/potent-potables/cocktails/index.tsx
@@ -457,7 +457,7 @@ export default function ClassicCocktailsPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/cocktails/index.tsx
+++ b/client/src/pages/drinks/potent-potables/cocktails/index.tsx
@@ -433,7 +433,7 @@ export default function ClassicCocktailsPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/cognac-brandy/index.tsx
+++ b/client/src/pages/drinks/potent-potables/cognac-brandy/index.tsx
@@ -408,7 +408,7 @@ export default function CognacBrandyPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/cognac-brandy/index.tsx
+++ b/client/src/pages/drinks/potent-potables/cognac-brandy/index.tsx
@@ -384,7 +384,7 @@ export default function CognacBrandyPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/daiquiri/index.tsx
+++ b/client/src/pages/drinks/potent-potables/daiquiri/index.tsx
@@ -324,7 +324,7 @@ export default function DaiquiriPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/daiquiri/index.tsx
+++ b/client/src/pages/drinks/potent-potables/daiquiri/index.tsx
@@ -300,7 +300,7 @@ export default function DaiquiriPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/gin/index.tsx
+++ b/client/src/pages/drinks/potent-potables/gin/index.tsx
@@ -366,7 +366,7 @@ export default function GinCocktailsPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/gin/index.tsx
+++ b/client/src/pages/drinks/potent-potables/gin/index.tsx
@@ -342,7 +342,7 @@ export default function GinCocktailsPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/hot-drinks/index.tsx
+++ b/client/src/pages/drinks/potent-potables/hot-drinks/index.tsx
@@ -345,7 +345,7 @@ export default function HotDrinksPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/hot-drinks/index.tsx
+++ b/client/src/pages/drinks/potent-potables/hot-drinks/index.tsx
@@ -369,7 +369,7 @@ export default function HotDrinksPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/liqueurs/index.tsx
+++ b/client/src/pages/drinks/potent-potables/liqueurs/index.tsx
@@ -343,7 +343,7 @@ export default function LiqueursPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/liqueurs/index.tsx
+++ b/client/src/pages/drinks/potent-potables/liqueurs/index.tsx
@@ -367,7 +367,7 @@ export default function LiqueursPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/martinis/index.tsx
+++ b/client/src/pages/drinks/potent-potables/martinis/index.tsx
@@ -384,7 +384,7 @@ export default function MartinisPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/martinis/index.tsx
+++ b/client/src/pages/drinks/potent-potables/martinis/index.tsx
@@ -360,7 +360,7 @@ export default function MartinisPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/mocktails/index.tsx
+++ b/client/src/pages/drinks/potent-potables/mocktails/index.tsx
@@ -373,7 +373,7 @@ export default function MocktailsPage() {
               <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/mocktails/index.tsx
+++ b/client/src/pages/drinks/potent-potables/mocktails/index.tsx
@@ -397,7 +397,7 @@ export default function MocktailsPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {sisterPotentPotablesPages.map((page) => {
+              {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                 const Icon = page.icon;
                 return (
                   <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/rum/index.tsx
+++ b/client/src/pages/drinks/potent-potables/rum/index.tsx
@@ -377,7 +377,7 @@ export default function RumCocktailsPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/rum/index.tsx
+++ b/client/src/pages/drinks/potent-potables/rum/index.tsx
@@ -401,7 +401,7 @@ export default function RumCocktailsPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/scotch-irish-whiskey/index.tsx
+++ b/client/src/pages/drinks/potent-potables/scotch-irish-whiskey/index.tsx
@@ -370,7 +370,7 @@ export default function ScotchIrishWhiskeyPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/scotch-irish-whiskey/index.tsx
+++ b/client/src/pages/drinks/potent-potables/scotch-irish-whiskey/index.tsx
@@ -394,7 +394,7 @@ export default function ScotchIrishWhiskeyPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/seasonal/index.tsx
+++ b/client/src/pages/drinks/potent-potables/seasonal/index.tsx
@@ -422,7 +422,7 @@ export default function SeasonalCocktailsPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/seasonal/index.tsx
+++ b/client/src/pages/drinks/potent-potables/seasonal/index.tsx
@@ -398,7 +398,7 @@ export default function SeasonalCocktailsPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/spritz/index.tsx
+++ b/client/src/pages/drinks/potent-potables/spritz/index.tsx
@@ -343,7 +343,7 @@ export default function SpritzMimosasPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/spritz/index.tsx
+++ b/client/src/pages/drinks/potent-potables/spritz/index.tsx
@@ -367,7 +367,7 @@ export default function SpritzMimosasPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/tequila-mezcal/index.tsx
+++ b/client/src/pages/drinks/potent-potables/tequila-mezcal/index.tsx
@@ -377,7 +377,7 @@ export default function TequilaMezcalPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/tequila-mezcal/index.tsx
+++ b/client/src/pages/drinks/potent-potables/tequila-mezcal/index.tsx
@@ -401,7 +401,7 @@ export default function TequilaMezcalPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/vodka/index.tsx
+++ b/client/src/pages/drinks/potent-potables/vodka/index.tsx
@@ -355,7 +355,7 @@ export default function VodkaCocktailsPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/vodka/index.tsx
+++ b/client/src/pages/drinks/potent-potables/vodka/index.tsx
@@ -379,7 +379,7 @@ export default function VodkaCocktailsPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/whiskey-bourbon/index.tsx
+++ b/client/src/pages/drinks/potent-potables/whiskey-bourbon/index.tsx
@@ -376,7 +376,7 @@ export default function WhiskeyBourbonPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/whiskey-bourbon/index.tsx
+++ b/client/src/pages/drinks/potent-potables/whiskey-bourbon/index.tsx
@@ -352,7 +352,7 @@ export default function WhiskeyBourbonPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/protein-shakes/beef/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/beef/index.tsx
@@ -325,7 +325,7 @@ export default function BeefProteinPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon as any;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/protein-shakes/beef/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/beef/index.tsx
@@ -352,7 +352,7 @@ export default function BeefProteinPage() {
               Other Protein Types
             </h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {proteinSubcategories.map((subcategory) => {
+              {[...proteinSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon as any;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/protein-shakes/casein/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/casein/index.tsx
@@ -452,7 +452,7 @@ export default function CaseinProteinPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Protein Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {proteinSubcategories.map((subcategory) => {
+              {[...proteinSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/protein-shakes/casein/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/casein/index.tsx
@@ -425,7 +425,7 @@ export default function CaseinProteinPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/protein-shakes/collagen/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/collagen/index.tsx
@@ -407,7 +407,7 @@ export default function CollagenProteinPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/protein-shakes/collagen/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/collagen/index.tsx
@@ -431,7 +431,7 @@ export default function CollagenProteinPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Protein Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {proteinSubcategories.map((subcategory) => {
+              {[...proteinSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/protein-shakes/egg/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/egg/index.tsx
@@ -305,7 +305,7 @@ export default function EggProteinPage() {
               Other Protein Types
             </h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {proteinSubcategories.map((subcategory) => {
+              {[...proteinSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon as any;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/protein-shakes/egg/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/egg/index.tsx
@@ -278,7 +278,7 @@ export default function EggProteinPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon as any;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/protein-shakes/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/index.tsx
@@ -377,7 +377,7 @@ export default function ProteinShakesPage({ params }: Params) {
             Explore Other Drink Categories
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-            {otherDrinkHubs.filter(hub => hub.id !== 'protein-shakes').map((hub) => {
+            {[...otherDrinkHubs].filter((hub) => hub.id !== 'protein-shakes').sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
               const Icon = hub.icon;
               return (
                 <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/protein-shakes/plant-based/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/plant-based/index.tsx
@@ -320,7 +320,7 @@ export default function PlantBasedProteinPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/protein-shakes/plant-based/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/plant-based/index.tsx
@@ -344,7 +344,7 @@ export default function PlantBasedProteinPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Protein Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {proteinSubcategories.map((subcategory) => {
+              {[...proteinSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/protein-shakes/whey/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/whey/index.tsx
@@ -424,7 +424,7 @@ export default function WheyProteinShakesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Protein Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {proteinSubcategories.map((subcategory) => {
+              {[...proteinSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.route}>

--- a/client/src/pages/drinks/protein-shakes/whey/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/whey/index.tsx
@@ -400,7 +400,7 @@ export default function WheyProteinShakesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/berry/index.tsx
+++ b/client/src/pages/drinks/smoothies/berry/index.tsx
@@ -395,7 +395,7 @@ export default function BerrySmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/berry/index.tsx
+++ b/client/src/pages/drinks/smoothies/berry/index.tsx
@@ -419,7 +419,7 @@ export default function BerrySmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Smoothie Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allSmoothieSubcategories.map((subcategory) => {
+              {[...allSmoothieSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/smoothies/breakfast/index.tsx
+++ b/client/src/pages/drinks/smoothies/breakfast/index.tsx
@@ -442,7 +442,7 @@ export default function BreakfastSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/breakfast/index.tsx
+++ b/client/src/pages/drinks/smoothies/breakfast/index.tsx
@@ -466,7 +466,7 @@ export default function BreakfastSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Smoothie Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allSmoothieSubcategories.map((subcategory) => {
+              {[...allSmoothieSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/smoothies/dessert/index.tsx
+++ b/client/src/pages/drinks/smoothies/dessert/index.tsx
@@ -366,7 +366,7 @@ export default function DessertSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-text font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/dessert/index.tsx
+++ b/client/src/pages/drinks/smoothies/dessert/index.tsx
@@ -390,7 +390,7 @@ export default function DessertSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Smoothie Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allSmoothieSubcategories.map((subcategory) => {
+              {[...allSmoothieSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/smoothies/detox/index.tsx
+++ b/client/src/pages/drinks/smoothies/detox/index.tsx
@@ -381,7 +381,7 @@ export default function DetoxSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/detox/index.tsx
+++ b/client/src/pages/drinks/smoothies/detox/index.tsx
@@ -405,7 +405,7 @@ export default function DetoxSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Smoothie Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allSmoothieSubcategories.map((subcategory) => {
+              {[...allSmoothieSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/smoothies/green/index.tsx
+++ b/client/src/pages/drinks/smoothies/green/index.tsx
@@ -393,7 +393,7 @@ export default function GreenSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/green/index.tsx
+++ b/client/src/pages/drinks/smoothies/green/index.tsx
@@ -417,7 +417,7 @@ export default function GreenSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Smoothie Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allSmoothieSubcategories.map((subcategory) => {
+              {[...allSmoothieSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/smoothies/index.tsx
+++ b/client/src/pages/drinks/smoothies/index.tsx
@@ -604,7 +604,7 @@ export default function SmoothiesPage() {
               Explore Other Drink Categories
             </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-              {otherDrinkHubs.filter(hub => hub.id !== 'smoothies').map((hub) => {
+              {[...otherDrinkHubs].filter((hub) => hub.id !== 'smoothies').sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/protein/index.tsx
+++ b/client/src/pages/drinks/smoothies/protein/index.tsx
@@ -413,7 +413,7 @@ export default function ProteinSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Smoothie Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allSmoothieSubcategories.map((subcategory) => {
+              {[...allSmoothieSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/smoothies/protein/index.tsx
+++ b/client/src/pages/drinks/smoothies/protein/index.tsx
@@ -389,7 +389,7 @@ export default function ProteinSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/tropical/index.tsx
+++ b/client/src/pages/drinks/smoothies/tropical/index.tsx
@@ -415,7 +415,7 @@ export default function TropicalSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Smoothie Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allSmoothieSubcategories.map((subcategory) => {
+              {[...allSmoothieSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/smoothies/tropical/index.tsx
+++ b/client/src/pages/drinks/smoothies/tropical/index.tsx
@@ -391,7 +391,7 @@ export default function TropicalSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/workout/index.tsx
+++ b/client/src/pages/drinks/smoothies/workout/index.tsx
@@ -442,7 +442,7 @@ export default function WorkoutSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/workout/index.tsx
+++ b/client/src/pages/drinks/smoothies/workout/index.tsx
@@ -466,7 +466,7 @@ export default function WorkoutSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Smoothie Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allSmoothieSubcategories.map((subcategory) => {
+              {[...allSmoothieSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/pet-food/birds/index.tsx
+++ b/client/src/pages/pet-food/birds/index.tsx
@@ -432,6 +432,29 @@ export default function BirdsPage() {
     }
   };
 
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Bird Food Recipes',
+      text: 'Seed mixes, fruits, and treats for your feathered friends — browse bird food recipes on ChefSire.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-cyan-50 via-blue-50 to-sky-50">
       {/* RecipeKit Modal */}
@@ -465,7 +488,7 @@ export default function BirdsPage() {
               </Button>
             </Link>
             <div className="flex gap-2">
-              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
+              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20" onClick={handleSharePage}>
                 <Share2 className="h-4 w-4" />
               </Button>
               <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
@@ -521,7 +544,7 @@ export default function BirdsPage() {
           <CardContent className="p-6">
             <h3 className="text-lg font-bold text-gray-800 mb-4">Other Pet Food Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {sisterPetFoodPages.map((page) => {
+              {[...sisterPetFoodPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                 const Icon = page.icon;
                 return (
                   <Link key={page.id} href={page.path}>

--- a/client/src/pages/pet-food/cats/index.tsx
+++ b/client/src/pages/pet-food/cats/index.tsx
@@ -443,6 +443,29 @@ export default function CatsPage() {
     }
   };
 
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Cat Food Recipes',
+      text: 'High-protein, taurine-rich homemade meals for cats — browse cat food recipes on ChefSire.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 via-pink-50 to-fuchsia-50">
       {/* RecipeKit Modal */}
@@ -476,7 +499,7 @@ export default function CatsPage() {
               </Button>
             </Link>
             <div className="flex gap-2">
-              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
+              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20" onClick={handleSharePage}>
                 <Share2 className="h-4 w-4" />
               </Button>
               <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
@@ -532,7 +555,7 @@ export default function CatsPage() {
           <CardContent className="p-6">
             <h3 className="text-lg font-bold text-gray-800 mb-4">Other Pet Food Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {sisterPetFoodPages.map((page) => {
+              {[...sisterPetFoodPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                 const Icon = page.icon;
                 return (
                   <Link key={page.id} href={page.path}>

--- a/client/src/pages/pet-food/dogs/index.tsx
+++ b/client/src/pages/pet-food/dogs/index.tsx
@@ -434,6 +434,29 @@ export default function DogsPage() {
     }
   };
 
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Dog Food Recipes',
+      text: 'Nutritious homemade meals for your best friend — browse dog food recipes on ChefSire.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50">
       {/* RecipeKit Modal */}
@@ -467,7 +490,7 @@ export default function DogsPage() {
               </Button>
             </Link>
             <div className="flex gap-2">
-              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
+              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20" onClick={handleSharePage}>
                 <Share2 className="h-4 w-4" />
               </Button>
               <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
@@ -523,7 +546,7 @@ export default function DogsPage() {
           <CardContent className="p-6">
             <h3 className="text-lg font-bold text-gray-800 mb-4">Other Pet Food Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {sisterPetFoodPages.map((page) => {
+              {[...sisterPetFoodPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                 const Icon = page.icon;
                 return (
                   <Link key={page.id} href={page.path}>

--- a/client/src/pages/pet-food/index.tsx
+++ b/client/src/pages/pet-food/index.tsx
@@ -142,6 +142,29 @@ export default function PetFoodHub() {
   const [searchQuery, setSearchQuery] = useState('');
   const [hoveredCard, setHoveredCard] = useState<string | null>(null);
 
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Pet Food Recipes',
+      text: 'Homemade pet food recipes for dogs, cats, birds & small pets — browse on ChefSire.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-orange-50 via-purple-50 to-emerald-50">
       {/* HEADER */}
@@ -155,7 +178,7 @@ export default function PetFoodHub() {
               </Button>
             </Link>
             <div className="flex gap-2">
-              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
+              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20" onClick={handleSharePage}>
                 <Share2 className="h-4 w-4" />
               </Button>
               <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
@@ -249,7 +272,7 @@ export default function PetFoodHub() {
             Browse Pet Food Categories
           </h2>
           <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
-            {petCategories.map((category) => {
+            {[...petCategories].sort((a,b) => a.name.localeCompare(b.name)).map((category) => {
               const Icon = category.icon;
               return (
                 <Card

--- a/client/src/pages/pet-food/small-pets/index.tsx
+++ b/client/src/pages/pet-food/small-pets/index.tsx
@@ -432,6 +432,29 @@ export default function SmallPetsPage() {
     }
   };
 
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Small Pet Food Recipes',
+      text: 'Hay-based diets and veggie mixes for rabbits, guinea pigs & more — browse small pet food recipes on ChefSire.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-emerald-50 via-green-50 to-teal-50">
       {/* RecipeKit Modal */}
@@ -465,7 +488,7 @@ export default function SmallPetsPage() {
               </Button>
             </Link>
             <div className="flex gap-2">
-              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
+              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20" onClick={handleSharePage}>
                 <Share2 className="h-4 w-4" />
               </Button>
               <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
@@ -521,7 +544,7 @@ export default function SmallPetsPage() {
           <CardContent className="p-6">
             <h3 className="text-lg font-bold text-gray-800 mb-4">Other Pet Food Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {sisterPetFoodPages.map((page) => {
+              {[...sisterPetFoodPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                 const Icon = page.icon;
                 return (
                   <Link key={page.id} href={page.path}>

--- a/migrations/007_add_active_cleanse_programs.sql
+++ b/migrations/007_add_active_cleanse_programs.sql
@@ -1,0 +1,3 @@
+-- Add active cleanse programs tracking to user_drink_stats
+ALTER TABLE user_drink_stats
+  ADD COLUMN IF NOT EXISTS active_cleanse_programs jsonb NOT NULL DEFAULT '[]'::jsonb;

--- a/shared/schema/domains/drinks-creator.ts
+++ b/shared/schema/domains/drinks-creator.ts
@@ -495,5 +495,6 @@ export const userDrinkStats = pgTable("user_drink_stats", {
       earnedAt: string;
     }>
   >().default(sql`'[]'::jsonb`),
+  activeCleanseProgramIds: jsonb("active_cleanse_programs").$type<string[]>().default(sql`'[]'::jsonb`),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });


### PR DESCRIPTION
## Summary

- Added `handleSharePage` function to all 5 pet pages (hub + dogs, cats, birds, small-pets)
- Wired the existing Share2 header button to `handleSharePage` on all pages — it was a dead button before
- Sorted "Other Pet Types" nav A→Z on all 4 subcategory pages (Birds → Cats → Dogs → Small Pets)
- Sorted pet category cards A→Z on the hub page

## Test plan

- [ ] Visit `/pet-food` — category cards should be alphabetical (Birds, Cats, Dogs, Small Pets)
- [ ] Visit `/pet-food/dogs` — "Other Pet Food Types" nav should be A→Z (Birds, Cats, Small Pets)
- [ ] Click the Share button in the header on any pet page — should trigger native share or copy link to clipboard

https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/myron302/chefsire/pull/1119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
