### PR TITLE
Meal planner Phase 1 & 2: fix broken CRUD + diary → forward planner

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -1293,7 +1293,17 @@ const NutritionMealPlanner = () => {
           }
         };
       });
-      toast({ description: "✅ Meal item added!" });
+
+      const savedDate = getDateForWeekday(selectedMealSlot.day);
+      const isFutureMeal = savedDate > formatLocalDate(new Date());
+      if (isFutureMeal) {
+        toast({
+          title: `📅 Planned for ${selectedMealSlot.day}`,
+          description: `"${mealData.name}" is scheduled. Head to the Grocery tab to add what you'll need.`,
+        });
+      } else {
+        toast({ description: "✅ Meal item added!" });
+      }
     } catch (error) {
       console.error('Error saving meal item:', error);
       toast({ variant: 'destructive', description: 'Failed to save meal item' });
@@ -2152,6 +2162,7 @@ const NutritionMealPlanner = () => {
 
   const calorieGoal = nutritionGoals?.dailyCalorieGoal || 2000;
   const macroGoals = nutritionGoals?.macroGoals || { protein: 150, carbs: 200, fat: 65 };
+  const today = formatLocalDate(new Date());
   const caloriesCurrent = dailyNutrition?.calories || 0;
   const proteinCurrent = dailyNutrition?.protein || 0;
   const carbsCurrent = dailyNutrition?.carbs || 0;
@@ -4094,6 +4105,10 @@ const NutritionMealPlanner = () => {
                 proteinCurrent={proteinCurrent}
                 carbsCurrent={carbsCurrent}
                 fatCurrent={fatCurrent}
+                proteinGoal={macroGoals.protein}
+                carbsGoal={macroGoals.carbs}
+                fatGoal={macroGoals.fat}
+                today={today}
                 viewMode={viewMode}
                 setViewMode={setViewMode}
                 generateWeekPlan={generateWeekPlan}

--- a/client/src/components/meal-planner/sections/PlannerTabSection.tsx
+++ b/client/src/components/meal-planner/sections/PlannerTabSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BarChart3, ChefHat, Clock, Package, Plus, Save, ShoppingCart, Sparkles, Target, Zap } from 'lucide-react';
+import { BarChart3, ChefHat, Clock, Package, Plus, Save, ShoppingCart, Sparkles, Target, TrendingUp, Zap } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -15,6 +15,10 @@ type PlannerTabSectionProps = {
   proteinCurrent: number;
   carbsCurrent: number;
   fatCurrent: number;
+  proteinGoal: number;
+  carbsGoal: number;
+  fatGoal: number;
+  today: string;
   viewMode: ViewMode;
   setViewMode: React.Dispatch<React.SetStateAction<ViewMode>>;
   generateWeekPlan: () => void;
@@ -58,6 +62,10 @@ const PlannerTabSection = ({
   proteinCurrent,
   carbsCurrent,
   fatCurrent,
+  proteinGoal,
+  carbsGoal,
+  fatGoal,
+  today,
   viewMode,
   setViewMode,
   generateWeekPlan,
@@ -99,6 +107,77 @@ const PlannerTabSection = ({
       ? 'Week fully planned'
       : `${plannedSlots}/${totalSlots} slots filled`;
 
+  // Compute weekly totals (all 7 days, planned + logged)
+  const weeklyTotals = weekDays.reduce(
+    (acc, day) => {
+      const dayDate = getDateForWeekday(day);
+      const isPast = dayDate < today;
+      const isToday = dayDate === today;
+      const isFuture = dayDate > today;
+      let dayCal = 0, dayProt = 0, dayCarbs = 0, dayFat = 0;
+      mealTypes.forEach((mt) => {
+        const t = getMealSlotTotals(weeklyMeals, day, mt);
+        dayCal += t.calories; dayProt += t.protein; dayCarbs += t.carbs; dayFat += t.fat;
+      });
+      return {
+        calories: acc.calories + dayCal,
+        protein: acc.protein + dayProt,
+        carbs: acc.carbs + dayCarbs,
+        fat: acc.fat + dayFat,
+        loggedCalories: acc.loggedCalories + (isPast || isToday ? dayCal : 0),
+        plannedCalories: acc.plannedCalories + (isFuture ? dayCal : 0),
+        daysWithMeals: acc.daysWithMeals + (dayCal > 0 ? 1 : 0),
+        futureDaysWithMeals: acc.futureDaysWithMeals + (isFuture && dayCal > 0 ? 1 : 0),
+      };
+    },
+    { calories: 0, protein: 0, carbs: 0, fat: 0, loggedCalories: 0, plannedCalories: 0, daysWithMeals: 0, futureDaysWithMeals: 0 }
+  );
+
+  const weeklyCalorieGoal = calorieGoal * 7;
+  const weeklyCaloriePct = weeklyCalorieGoal > 0 ? Math.min(100, Math.round((weeklyTotals.calories / weeklyCalorieGoal) * 100)) : 0;
+  const weeklyProteinPct = proteinGoal * 7 > 0 ? Math.min(100, Math.round((weeklyTotals.protein / (proteinGoal * 7)) * 100)) : 0;
+
+  // Slot type helpers
+  const getDayStatus = (day: string): 'past' | 'today' | 'future' => {
+    const d = getDateForWeekday(day);
+    if (d > today) return 'future';
+    if (d === today) return 'today';
+    return 'past';
+  };
+
+  const slotAction = (day: string, hasItems: boolean) => {
+    const status = getDayStatus(day);
+    if (status === 'future') return hasItems ? 'Add more' : 'Plan';
+    if (status === 'today') return hasItems ? 'Add more' : 'Log';
+    return hasItems ? 'Add more' : 'Log';
+  };
+
+  const emptySlotLabel = (day: string) => {
+    const status = getDayStatus(day);
+    return status === 'future' ? 'Nothing planned — click to plan' : 'Nothing logged yet — tap to add';
+  };
+
+  const dayHeaderClass = (day: string) => {
+    const status = getDayStatus(day);
+    if (status === 'future') return 'bg-blue-50';
+    if (status === 'today') return 'bg-orange-50';
+    return 'bg-gray-50';
+  };
+
+  const slotCellClass = (day: string) => {
+    const status = getDayStatus(day);
+    if (status === 'future') return 'bg-blue-50/30';
+    return '';
+  };
+
+  const addButtonClass = (day: string) => {
+    const status = getDayStatus(day);
+    if (status === 'future') return 'text-blue-500 hover:text-blue-700';
+    return 'text-gray-400 hover:text-orange-500';
+  };
+
+  const futureDayCount = weekDays.filter((d) => getDayStatus(d) === 'future').length;
+
   return (
     <div className="space-y-6">
       <Card className="bg-gradient-to-r from-orange-500 to-pink-500 text-white shadow-lg">
@@ -127,6 +206,54 @@ const PlannerTabSection = ({
           </div>
         </CardContent>
       </Card>
+
+      {/* Weekly projection card */}
+      {weeklyTotals.calories > 0 && (
+        <Card className="border-blue-200 bg-gradient-to-r from-blue-50 via-white to-indigo-50">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base flex items-center gap-2">
+              <TrendingUp className="w-4 h-4 text-blue-600" />
+              This Week's Projection
+            </CardTitle>
+            <CardDescription>
+              {weeklyTotals.loggedCalories > 0 && weeklyTotals.plannedCalories > 0
+                ? `${weeklyTotals.loggedCalories.toLocaleString()} kcal logged · ${weeklyTotals.plannedCalories.toLocaleString()} kcal planned ahead`
+                : weeklyTotals.plannedCalories > 0
+                  ? `${weeklyTotals.plannedCalories.toLocaleString()} kcal planned for ${weeklyTotals.futureDaysWithMeals} future day${weeklyTotals.futureDaysWithMeals !== 1 ? 's' : ''}`
+                  : `${weeklyTotals.loggedCalories.toLocaleString()} kcal logged so far`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div>
+              <div className="flex items-center justify-between text-xs mb-1">
+                <span className="text-gray-600">Weekly calories ({weeklyTotals.calories.toLocaleString()} / {weeklyCalorieGoal.toLocaleString()} kcal)</span>
+                <span className="font-semibold text-blue-700">{weeklyCaloriePct}%</span>
+              </div>
+              <Progress value={weeklyCaloriePct} className="h-1.5 bg-blue-100 [&>div]:bg-blue-500" />
+            </div>
+            <div className="grid grid-cols-3 gap-2 text-xs">
+              <div className="rounded-md border bg-white p-2 text-center">
+                <div className="font-semibold text-blue-700">{weeklyTotals.protein}g</div>
+                <div className="text-gray-500">/ {proteinGoal * 7}g protein</div>
+                <div className="text-[10px] text-gray-400">{weeklyProteinPct}% of goal</div>
+              </div>
+              <div className="rounded-md border bg-white p-2 text-center">
+                <div className="font-semibold text-orange-600">{weeklyTotals.carbs}g</div>
+                <div className="text-gray-500">/ {carbsGoal * 7}g carbs</div>
+              </div>
+              <div className="rounded-md border bg-white p-2 text-center">
+                <div className="font-semibold text-purple-600">{weeklyTotals.fat}g</div>
+                <div className="text-gray-500">/ {fatGoal * 7}g fat</div>
+              </div>
+            </div>
+            {futureDayCount > 0 && weeklyTotals.futureDaysWithMeals < futureDayCount && (
+              <p className="text-xs text-blue-700 bg-blue-100 rounded px-2 py-1">
+                {futureDayCount - weeklyTotals.futureDaysWithMeals} future day{futureDayCount - weeklyTotals.futureDaysWithMeals !== 1 ? 's' : ''} still need meals planned — blue slots below are waiting.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
       <Card className="border-orange-200 bg-gradient-to-r from-orange-50 via-white to-amber-50">
         <CardHeader className="pb-4">
@@ -226,9 +353,9 @@ const PlannerTabSection = ({
             <Card className="border-dashed border-orange-200 bg-orange-50/40">
               <CardContent className="p-6 text-center">
                 <Target className="w-8 h-8 text-orange-500 mx-auto mb-2" />
-                <h3 className="font-semibold text-gray-900">Start your week plan</h3>
+                <h3 className="font-semibold text-gray-900">Start planning your week</h3>
                 <p className="text-sm text-gray-600 mt-1 mb-4">
-                  Plan your first meals, auto-generate a week, or load a template to skip blank days.
+                  Plan meals ahead in the blue future slots, auto-generate a week, or load a template. Blue = planned ahead. Orange = today. Gray = already logged.
                 </p>
                 <div className="flex flex-wrap justify-center gap-2">
                   <Button size="sm" onClick={generateWeekPlan} disabled={isGeneratingWeek}>
@@ -248,15 +375,33 @@ const PlannerTabSection = ({
             </Card>
           )}
 
+          {/* Legend */}
+          <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500 px-1">
+            <span className="flex items-center gap-1.5"><span className="w-3 h-3 rounded bg-blue-100 border border-blue-300 inline-block" />Planned (future)</span>
+            <span className="flex items-center gap-1.5"><span className="w-3 h-3 rounded bg-orange-100 border border-orange-300 inline-block" />Today</span>
+            <span className="flex items-center gap-1.5"><span className="w-3 h-3 rounded bg-gray-100 border border-gray-200 inline-block" />Logged (past)</span>
+          </div>
+
           <div className="hidden md:block bg-white rounded-lg shadow-sm overflow-hidden overflow-x-auto">
             <div className="grid grid-cols-8 border-b min-w-[800px]">
               <div className="p-4 bg-gray-50 border-r"><span className="text-sm font-medium text-gray-500">Meal</span></div>
-              {weekDays.map((day) => (
-                <div key={day} className="p-4 bg-gray-50 border-r last:border-r-0">
-                  <div className="text-sm font-medium text-gray-900">{day}</div>
-                  <div className={`text-xs ${getDateForWeekday(day) === formatLocalDate(new Date()) ? 'text-orange-600 font-semibold' : 'text-gray-500'}`}>{new Date(getDateForWeekday(day) + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</div>
-                </div>
-              ))}
+              {weekDays.map((day) => {
+                const dayDate = getDateForWeekday(day);
+                const isToday = dayDate === today;
+                const isFuture = dayDate > today;
+                return (
+                  <div key={day} className={`p-4 border-r last:border-r-0 ${isFuture ? 'bg-blue-50' : isToday ? 'bg-orange-50' : 'bg-gray-50'}`}>
+                    <div className="flex items-center gap-1.5">
+                      <div className="text-sm font-medium text-gray-900">{day}</div>
+                      {isFuture && <Badge variant="outline" className="text-[9px] py-0 px-1 border-blue-300 text-blue-600 leading-4">Plan</Badge>}
+                      {isToday && <Badge variant="outline" className="text-[9px] py-0 px-1 border-orange-300 text-orange-600 leading-4">Today</Badge>}
+                    </div>
+                    <div className={`text-xs ${isToday ? 'text-orange-600 font-semibold' : isFuture ? 'text-blue-500' : 'text-gray-500'}`}>
+                      {new Date(dayDate + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                    </div>
+                  </div>
+                );
+              })}
             </div>
             {mealTypes.map((mealType) => (
               <div key={mealType} className="grid grid-cols-8 border-b last:border-b-0 min-w-[800px]">
@@ -264,14 +409,19 @@ const PlannerTabSection = ({
                 {weekDays.map((day) => {
                   const items = getMealSlotItems(weeklyMeals, day, mealType);
                   const totals = getMealSlotTotals(weeklyMeals, day, mealType);
+                  const isFuture = getDateForWeekday(day) > today;
                   return (
-                    <div key={`${day}-${mealType}`} className="p-2 border-r last:border-r-0 min-h-[72px]">
+                    <div key={`${day}-${mealType}`} className={`p-2 border-r last:border-r-0 min-h-[72px] ${isFuture ? 'bg-blue-50/30' : ''}`}>
                       {items.length > 0 && (
                         <div className="space-y-1 mb-1">
                           {items.map((item: any, idx: number) => (
                             <div key={idx} className="flex items-start justify-between gap-1 group">
                               <div className="flex-1 min-w-0">
-                                <div className="text-xs font-medium text-gray-900 truncate flex items-center gap-1">{item.name} {item.source === 'recipe' && <ChefHat className="w-3 h-3 text-orange-500" />} <span className={`px-1.5 py-0.5 rounded text-[10px] ${gradeClass(getNutritionGrade(item, calorieGoal))}`}>{getNutritionGrade(item, calorieGoal)}</span></div>
+                                <div className="text-xs font-medium text-gray-900 truncate flex items-center gap-1">
+                                  {item.name}
+                                  {item.source === 'recipe' && <ChefHat className="w-3 h-3 text-orange-500" />}
+                                  <span className={`px-1.5 py-0.5 rounded text-[10px] ${gradeClass(getNutritionGrade(item, calorieGoal))}`}>{getNutritionGrade(item, calorieGoal)}</span>
+                                </div>
                                 <div className="text-xs text-gray-400">{item.calories} cal · P:{item.protein}g</div>
                               </div>
                               <button className="opacity-0 group-hover:opacity-100 text-red-400 hover:text-red-600 text-xs leading-none mt-0.5 shrink-0" onClick={(e) => { e.stopPropagation(); removeMealItem(day, mealType, idx); }} title="Remove">✕</button>
@@ -280,7 +430,13 @@ const PlannerTabSection = ({
                           {items.length > 1 && <div className="text-xs text-orange-600 font-medium border-t border-gray-100 pt-1">Total: {totals.calories} cal</div>}
                         </div>
                       )}
-                      <button className="flex items-center gap-1 text-xs text-gray-400 hover:text-orange-500 w-full mt-1" onClick={() => handleAddMeal(day, mealType)}><Plus className="w-3.5 h-3.5" /><span>{items.length > 0 ? 'Add more' : 'Add'}</span></button>
+                      <button
+                        className={`flex items-center gap-1 text-xs w-full mt-1 ${addButtonClass(day)}`}
+                        onClick={() => handleAddMeal(day, mealType)}
+                      >
+                        <Plus className="w-3.5 h-3.5" />
+                        <span>{slotAction(day, items.length > 0)}</span>
+                      </button>
                     </div>
                   );
                 })}
@@ -289,85 +445,130 @@ const PlannerTabSection = ({
           </div>
 
           <div className="md:hidden space-y-4">
-            {weekDays.map((day) => (
-              <Card key={day}>
-                <CardHeader className="pb-3">
-                  <CardTitle className="text-lg">{day}</CardTitle>
-                  <CardDescription className={getDateForWeekday(day) === formatLocalDate(new Date()) ? 'text-orange-600 font-semibold' : ''}>{new Date(getDateForWeekday(day) + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}</CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-3">
-                  {mealTypes.map((mealType) => (
-                    <div key={`${day}-${mealType}`} className="p-3 bg-gray-50 rounded-lg">
-                      <div className="flex items-center justify-between mb-2">
-                        <span className="text-sm font-medium text-gray-700 capitalize">{mealType}</span>
-                        <button className="flex items-center gap-1 text-xs text-orange-500 hover:text-orange-700" onClick={() => handleAddMeal(day, mealType)}><Plus className="w-3.5 h-3.5" />{getMealSlotItems(weeklyMeals, day, mealType).length > 0 ? 'Add more' : 'Add'}</button>
-                      </div>
-                      {getMealSlotItems(weeklyMeals, day, mealType).length > 0 ? (
-                        <div className="space-y-2">
-                          {getMealSlotItems(weeklyMeals, day, mealType).map((item: any, idx: number) => (
-                            <div key={idx} className="flex items-start justify-between gap-2 bg-white rounded p-2">
-                              <div className="flex-1 min-w-0">
-                                <div className="text-sm font-medium text-gray-900 truncate">{item.name}</div>
-                                <div className="flex gap-1 mt-1 flex-wrap"><Badge variant="secondary" className="text-xs">{item.calories} cal</Badge><Badge variant="secondary" className="text-xs">P: {item.protein}g</Badge></div>
-                              </div>
-                              <button className="text-red-400 hover:text-red-600 text-xs mt-0.5 shrink-0" onClick={() => removeMealItem(day, mealType, idx)}>✕</button>
-                            </div>
-                          ))}
-                          {getMealSlotItems(weeklyMeals, day, mealType).length > 1 && <div className="text-xs text-orange-600 font-semibold text-right">Total: {getMealSlotTotals(weeklyMeals, day, mealType).calories} cal · P: {getMealSlotTotals(weeklyMeals, day, mealType).protein}g</div>}
-                        </div>
-                      ) : <p className="text-xs text-gray-500">Tap Add to log meals</p>}
+            {weekDays.map((day) => {
+              const dayDate = getDateForWeekday(day);
+              const isToday = dayDate === today;
+              const isFuture = dayDate > today;
+              return (
+                <Card key={day} className={isFuture ? 'border-blue-200' : isToday ? 'border-orange-200' : ''}>
+                  <CardHeader className="pb-3">
+                    <div className="flex items-center gap-2">
+                      <CardTitle className="text-lg">{day}</CardTitle>
+                      {isFuture && <Badge variant="outline" className="border-blue-300 text-blue-600">Plan ahead</Badge>}
+                      {isToday && <Badge variant="outline" className="border-orange-300 text-orange-600">Today</Badge>}
                     </div>
-                  ))}
-                </CardContent>
-              </Card>
-            ))}
+                    <CardDescription className={isToday ? 'text-orange-600 font-semibold' : isFuture ? 'text-blue-500' : ''}>
+                      {new Date(dayDate + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    {mealTypes.map((mealType) => (
+                      <div key={`${day}-${mealType}`} className={`p-3 rounded-lg ${isFuture ? 'bg-blue-50' : 'bg-gray-50'}`}>
+                        <div className="flex items-center justify-between mb-2">
+                          <span className="text-sm font-medium text-gray-700 capitalize">{mealType}</span>
+                          <button
+                            className={`flex items-center gap-1 text-xs ${isFuture ? 'text-blue-500 hover:text-blue-700' : 'text-orange-500 hover:text-orange-700'}`}
+                            onClick={() => handleAddMeal(day, mealType)}
+                          >
+                            <Plus className="w-3.5 h-3.5" />
+                            {slotAction(day, getMealSlotItems(weeklyMeals, day, mealType).length > 0)}
+                          </button>
+                        </div>
+                        {getMealSlotItems(weeklyMeals, day, mealType).length > 0 ? (
+                          <div className="space-y-2">
+                            {getMealSlotItems(weeklyMeals, day, mealType).map((item: any, idx: number) => (
+                              <div key={idx} className="flex items-start justify-between gap-2 bg-white rounded p-2">
+                                <div className="flex-1 min-w-0">
+                                  <div className="text-sm font-medium text-gray-900 truncate">{item.name}</div>
+                                  <div className="flex gap-1 mt-1 flex-wrap"><Badge variant="secondary" className="text-xs">{item.calories} cal</Badge><Badge variant="secondary" className="text-xs">P: {item.protein}g</Badge></div>
+                                </div>
+                                <button className="text-red-400 hover:text-red-600 text-xs mt-0.5 shrink-0" onClick={() => removeMealItem(day, mealType, idx)}>✕</button>
+                              </div>
+                            ))}
+                            {getMealSlotItems(weeklyMeals, day, mealType).length > 1 && <div className="text-xs text-orange-600 font-semibold text-right">Total: {getMealSlotTotals(weeklyMeals, day, mealType).calories} cal · P: {getMealSlotTotals(weeklyMeals, day, mealType).protein}g</div>}
+                          </div>
+                        ) : (
+                          <p className="text-xs text-gray-500">
+                            {isFuture ? 'Tap Plan to schedule this meal' : 'Tap Log to record this meal'}
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                  </CardContent>
+                </Card>
+              );
+            })}
           </div>
         </>
       )}
 
       {viewMode === 'day' && (
         <div className="space-y-4">
-          <div className="bg-white rounded-lg shadow-sm overflow-hidden">
-            {selectedDate === formatLocalDate(new Date()) && <div className="bg-orange-50 border-b border-orange-100 px-4 py-2 flex items-center gap-2"><span className="w-2 h-2 bg-orange-500 rounded-full inline-block"></span><span className="text-xs font-medium text-orange-700">Today</span></div>}
-            <div className="divide-y">
-              {mealTypes.map((mealType) => {
-                const dayName = dayNames[parseDateOnly(selectedDate).getDay()];
-                const items = getMealSlotItems(weeklyMeals, dayName, mealType);
-                const totals = getMealSlotTotals(weeklyMeals, dayName, mealType);
-                return (
-                  <div key={mealType} className="p-4">
-                    <div className="flex items-center justify-between mb-3">
-                      <div className="flex items-center gap-2"><span className="text-sm font-semibold text-gray-800 capitalize">{mealType}</span>{items.length > 0 && <span className="text-xs text-gray-400">{totals.calories} cal total</span>}</div>
-                      <button className="flex items-center gap-1 text-xs text-orange-500 hover:text-orange-700 font-medium" onClick={() => handleAddMeal(dayName, mealType)}><Plus className="w-3.5 h-3.5" />{items.length > 0 ? 'Add more' : 'Add meal'}</button>
-                    </div>
-                    {items.length > 0 ? (
-                      <div className="space-y-2">
-                        {items.map((item: any, idx: number) => (
-                          <div key={idx} className="flex items-center justify-between bg-gray-50 rounded-lg px-3 py-2">
-                            <div className="flex-1 min-w-0">
-                              <div className="text-sm font-medium text-gray-900 flex items-center gap-1">{item.name} {item.source === 'recipe' && <ChefHat className="w-3.5 h-3.5 text-orange-500" />} <span className={`px-1.5 py-0.5 rounded text-[10px] ${gradeClass(getNutritionGrade(item, calorieGoal))}`}>{getNutritionGrade(item, calorieGoal)}</span></div>
-                              <div className="flex gap-3 mt-0.5"><span className="text-xs text-gray-500">{item.calories} cal</span><span className="text-xs text-blue-500">P: {item.protein}g</span><span className="text-xs text-orange-500">C: {item.carbs}g</span><span className="text-xs text-purple-500">F: {item.fat}g</span></div>
-                            </div>
-                            <button className="text-red-400 hover:text-red-600 text-xs ml-2 shrink-0" onClick={() => removeMealItem(dayName, mealType, idx)}>✕</button>
+          {(() => {
+            const isFutureDay = selectedDate > today;
+            const isTodayDay = selectedDate === today;
+            return (
+              <div className="bg-white rounded-lg shadow-sm overflow-hidden">
+                {isTodayDay && <div className="bg-orange-50 border-b border-orange-100 px-4 py-2 flex items-center gap-2"><span className="w-2 h-2 bg-orange-500 rounded-full inline-block"></span><span className="text-xs font-medium text-orange-700">Today — log what you eat</span></div>}
+                {isFutureDay && <div className="bg-blue-50 border-b border-blue-100 px-4 py-2 flex items-center gap-2"><span className="w-2 h-2 bg-blue-500 rounded-full inline-block"></span><span className="text-xs font-medium text-blue-700">Future day — plan your meals ahead. Items added here will be saved to your grocery list.</span></div>}
+                {!isTodayDay && !isFutureDay && <div className="bg-gray-50 border-b border-gray-100 px-4 py-2 flex items-center gap-2"><span className="w-2 h-2 bg-gray-400 rounded-full inline-block"></span><span className="text-xs font-medium text-gray-500">Past day</span></div>}
+                <div className="divide-y">
+                  {mealTypes.map((mealType) => {
+                    const dayName = dayNames[parseDateOnly(selectedDate).getDay()];
+                    const items = getMealSlotItems(weeklyMeals, dayName, mealType);
+                    const totals = getMealSlotTotals(weeklyMeals, dayName, mealType);
+                    return (
+                      <div key={mealType} className="p-4">
+                        <div className="flex items-center justify-between mb-3">
+                          <div className="flex items-center gap-2">
+                            <span className="text-sm font-semibold text-gray-800 capitalize">{mealType}</span>
+                            {items.length > 0 && <span className="text-xs text-gray-400">{totals.calories} cal total</span>}
                           </div>
-                        ))}
-                        {items.length > 1 && <div className="flex gap-4 text-xs font-semibold text-gray-600 px-1 pt-1 border-t"><span>{totals.calories} cal</span><span className="text-blue-500">P: {totals.protein}g</span><span className="text-orange-500">C: {totals.carbs}g</span><span className="text-purple-500">F: {totals.fat}g</span></div>}
+                          <button
+                            className={`flex items-center gap-1 text-xs font-medium ${isFutureDay ? 'text-blue-500 hover:text-blue-700' : 'text-orange-500 hover:text-orange-700'}`}
+                            onClick={() => handleAddMeal(dayName, mealType)}
+                          >
+                            <Plus className="w-3.5 h-3.5" />
+                            {items.length > 0 ? 'Add more' : isFutureDay ? 'Plan meal' : 'Log meal'}
+                          </button>
+                        </div>
+                        {items.length > 0 ? (
+                          <div className="space-y-2">
+                            {items.map((item: any, idx: number) => (
+                              <div key={idx} className="flex items-center justify-between bg-gray-50 rounded-lg px-3 py-2">
+                                <div className="flex-1 min-w-0">
+                                  <div className="text-sm font-medium text-gray-900 flex items-center gap-1">{item.name} {item.source === 'recipe' && <ChefHat className="w-3.5 h-3.5 text-orange-500" />} <span className={`px-1.5 py-0.5 rounded text-[10px] ${gradeClass(getNutritionGrade(item, calorieGoal))}`}>{getNutritionGrade(item, calorieGoal)}</span></div>
+                                  <div className="flex gap-3 mt-0.5"><span className="text-xs text-gray-500">{item.calories} cal</span><span className="text-xs text-blue-500">P: {item.protein}g</span><span className="text-xs text-orange-500">C: {item.carbs}g</span><span className="text-xs text-purple-500">F: {item.fat}g</span></div>
+                                </div>
+                                <button className="text-red-400 hover:text-red-600 text-xs ml-2 shrink-0" onClick={() => removeMealItem(dayName, mealType, idx)}>✕</button>
+                              </div>
+                            ))}
+                            {items.length > 1 && <div className="flex gap-4 text-xs font-semibold text-gray-600 px-1 pt-1 border-t"><span>{totals.calories} cal</span><span className="text-blue-500">P: {totals.protein}g</span><span className="text-orange-500">C: {totals.carbs}g</span><span className="text-purple-500">F: {totals.fat}g</span></div>}
+                          </div>
+                        ) : (
+                          <div
+                            className={`border-2 border-dashed rounded-lg p-4 text-center cursor-pointer transition-colors ${isFutureDay ? 'border-blue-200 hover:border-blue-400 hover:bg-blue-50' : 'border-gray-200 hover:border-orange-300 hover:bg-orange-50'}`}
+                            onClick={() => handleAddMeal(dayName, mealType)}
+                          >
+                            <p className="text-xs text-gray-400">{isFutureDay ? 'Nothing planned yet — click to plan' : 'Nothing logged yet — tap to add'}</p>
+                          </div>
+                        )}
                       </div>
-                    ) : <div className="border-2 border-dashed border-gray-200 rounded-lg p-4 text-center cursor-pointer hover:border-orange-300 hover:bg-orange-50 transition-colors" onClick={() => handleAddMeal(dayName, mealType)}><p className="text-xs text-gray-400">Nothing logged yet — tap to add</p></div>}
-                  </div>
-                );
-              })}
-            </div>
-            {(() => {
-              const dayName = dayNames[parseDateOnly(selectedDate).getDay()];
-              const dayTotal = mealTypes.reduce((acc, mt) => {
-                const t = getMealSlotTotals(weeklyMeals, dayName, mt);
-                return { calories: acc.calories + t.calories, protein: acc.protein + t.protein, carbs: acc.carbs + t.carbs, fat: acc.fat + t.fat };
-              }, { calories: 0, protein: 0, carbs: 0, fat: 0 });
-              if (dayTotal.calories === 0) return null;
-              return <div className="bg-gray-50 border-t px-4 py-3 grid grid-cols-4 gap-2 text-center"><div><div className="text-lg font-bold text-gray-900">{dayTotal.calories}</div><div className="text-xs text-gray-500">Calories</div></div><div><div className="text-lg font-bold text-blue-600">{dayTotal.protein}g</div><div className="text-xs text-gray-500">Protein</div></div><div><div className="text-lg font-bold text-orange-500">{dayTotal.carbs}g</div><div className="text-xs text-gray-500">Carbs</div></div><div><div className="text-lg font-bold text-purple-600">{dayTotal.fat}g</div><div className="text-xs text-gray-500">Fat</div></div></div>;
-            })()}
-          </div>
+                    );
+                  })}
+                </div>
+                {(() => {
+                  const dayName = dayNames[parseDateOnly(selectedDate).getDay()];
+                  const dayTotal = mealTypes.reduce((acc, mt) => {
+                    const t = getMealSlotTotals(weeklyMeals, dayName, mt);
+                    return { calories: acc.calories + t.calories, protein: acc.protein + t.protein, carbs: acc.carbs + t.carbs, fat: acc.fat + t.fat };
+                  }, { calories: 0, protein: 0, carbs: 0, fat: 0 });
+                  if (dayTotal.calories === 0) return null;
+                  return <div className="bg-gray-50 border-t px-4 py-3 grid grid-cols-4 gap-2 text-center"><div><div className="text-lg font-bold text-gray-900">{dayTotal.calories}</div><div className="text-xs text-gray-500">Calories</div></div><div><div className="text-lg font-bold text-blue-600">{dayTotal.protein}g</div><div className="text-xs text-gray-500">Protein</div></div><div><div className="text-lg font-bold text-orange-500">{dayTotal.carbs}g</div><div className="text-xs text-gray-500">Carbs</div></div><div><div className="text-lg font-bold text-purple-600">{dayTotal.fat}g</div><div className="text-xs text-gray-500">Fat</div></div></div>;
+                })()}
+              </div>
+            );
+          })()}
         </div>
       )}
 
@@ -378,7 +579,6 @@ const PlannerTabSection = ({
             const anchor = parseDateOnly(selectedDate);
             const year = anchor.getFullYear();
             const month = anchor.getMonth();
-            const today = formatLocalDate(new Date());
             const firstDay = new Date(year, month, 1);
             const startOffset = (firstDay.getDay() + 6) % 7;
             const daysInMonth = new Date(year, month + 1, 0).getDate();
@@ -389,14 +589,24 @@ const PlannerTabSection = ({
               const cellStr = formatLocalDate(cellDate);
               const inMonth = cellDate.getMonth() === month;
               const isToday = cellStr === today;
+              const isFuture = cellStr > today;
               const isSelected = cellStr === selectedDate;
               const dayName = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'][cellDate.getDay()];
               const hasAnyMeal = inMonth && mealTypes.some((mt) => getMealSlotItems(weeklyMeals, dayName, mt).length > 0);
               const dayTotalCal = inMonth ? mealTypes.reduce((acc, mt) => acc + getMealSlotTotals(weeklyMeals, dayName, mt).calories, 0) : 0;
               cells.push(
-                <div key={cellStr} className={`min-h-[80px] p-1.5 border-r border-b last:border-r-0 cursor-pointer transition-colors ${!inMonth ? 'bg-gray-50' : isSelected ? 'bg-orange-50' : 'bg-white hover:bg-gray-50'}`} onClick={() => { if (inMonth) { setSelectedDate(cellStr); setViewMode('day'); } }}>
-                  <div className={`text-xs font-semibold w-6 h-6 flex items-center justify-center rounded-full mb-1 ${isToday ? 'bg-orange-500 text-white' : inMonth ? 'text-gray-900' : 'text-gray-300'}`}>{cellDate.getDate()}</div>
-                  {inMonth && hasAnyMeal && <div className="space-y-0.5"><div className="text-xs text-orange-600 font-medium">{dayTotalCal} cal</div><div className="flex gap-0.5 flex-wrap">{mealTypes.filter((mt) => getMealSlotItems(weeklyMeals, dayName, mt).length > 0).map((mt) => <span key={mt} className="text-xs bg-orange-100 text-orange-700 rounded px-1 leading-4">{mt[0].toUpperCase()}</span>)}</div></div>}
+                <div key={cellStr} className={`min-h-[80px] p-1.5 border-r border-b last:border-r-0 cursor-pointer transition-colors ${!inMonth ? 'bg-gray-50' : isSelected ? 'bg-orange-50' : isFuture ? 'bg-blue-50/40 hover:bg-blue-50' : 'bg-white hover:bg-gray-50'}`} onClick={() => { if (inMonth) { setSelectedDate(cellStr); setViewMode('day'); } }}>
+                  <div className={`text-xs font-semibold w-6 h-6 flex items-center justify-center rounded-full mb-1 ${isToday ? 'bg-orange-500 text-white' : inMonth ? isFuture ? 'text-blue-700' : 'text-gray-900' : 'text-gray-300'}`}>{cellDate.getDate()}</div>
+                  {inMonth && hasAnyMeal && (
+                    <div className="space-y-0.5">
+                      <div className={`text-xs font-medium ${isFuture ? 'text-blue-600' : 'text-orange-600'}`}>{dayTotalCal} cal</div>
+                      <div className="flex gap-0.5 flex-wrap">
+                        {mealTypes.filter((mt) => getMealSlotItems(weeklyMeals, dayName, mt).length > 0).map((mt) => (
+                          <span key={mt} className={`text-xs rounded px-1 leading-4 ${isFuture ? 'bg-blue-100 text-blue-700' : 'bg-orange-100 text-orange-700'}`}>{mt[0].toUpperCase()}</span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
                   {inMonth && !hasAnyMeal && <div className="flex items-center justify-center h-8 opacity-0 hover:opacity-100 transition-opacity"><Plus className="w-3.5 h-3.5 text-gray-300" /></div>}
                 </div>
               );
@@ -405,7 +615,12 @@ const PlannerTabSection = ({
             for (let r = 0; r < totalCells / 7; r++) rows.push(<div key={r} className="grid grid-cols-7">{cells.slice(r * 7, r * 7 + 7)}</div>);
             return rows;
           })()}
-          <div className="px-4 py-2 border-t bg-gray-50 text-xs text-gray-500 flex gap-4"><span><span className="inline-block w-4 h-4 bg-orange-500 rounded-full text-white text-center leading-4 mr-1">·</span> Today</span><span><span className="inline-block bg-orange-100 text-orange-700 rounded px-1 mr-1">B</span> Breakfast logged</span><span>Click any day to view/add meals</span></div>
+          <div className="px-4 py-2 border-t bg-gray-50 text-xs text-gray-500 flex gap-4 flex-wrap">
+            <span><span className="inline-block w-4 h-4 bg-orange-500 rounded-full text-white text-center leading-4 mr-1">·</span> Today</span>
+            <span><span className="inline-block bg-orange-100 text-orange-700 rounded px-1 mr-1">B</span> Logged</span>
+            <span><span className="inline-block bg-blue-100 text-blue-700 rounded px-1 mr-1">B</span> Planned ahead</span>
+            <span>Click any day to view/add meals</span>
+          </div>
         </div>
       )}
 

--- a/client/src/pages/drinks/caffeinated/cold-brew/index.tsx
+++ b/client/src/pages/drinks/caffeinated/cold-brew/index.tsx
@@ -408,7 +408,7 @@ export default function ColdBrewDrinksPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/caffeinated/cold-brew/index.tsx
+++ b/client/src/pages/drinks/caffeinated/cold-brew/index.tsx
@@ -432,7 +432,7 @@ export default function ColdBrewDrinksPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Caffeinated Drink Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allCaffeinatedSubcategories.map((subcategory) => {
+              {[...allCaffeinatedSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/caffeinated/energy/index.tsx
+++ b/client/src/pages/drinks/caffeinated/energy/index.tsx
@@ -444,7 +444,7 @@ export default function EnergyPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Caffeinated Drinks</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allCaffeinatedSubcategories.map((subcategory) => {
+              {[...allCaffeinatedSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/caffeinated/energy/index.tsx
+++ b/client/src/pages/drinks/caffeinated/energy/index.tsx
@@ -420,7 +420,7 @@ export default function EnergyPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/caffeinated/espresso/index.tsx
+++ b/client/src/pages/drinks/caffeinated/espresso/index.tsx
@@ -409,7 +409,7 @@ export default function EspressoDrinksPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/caffeinated/espresso/index.tsx
+++ b/client/src/pages/drinks/caffeinated/espresso/index.tsx
@@ -433,7 +433,7 @@ export default function EspressoDrinksPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Caffeinated Drink Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allCaffeinatedSubcategories.map((subcategory) => {
+              {[...allCaffeinatedSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/caffeinated/iced/index.tsx
+++ b/client/src/pages/drinks/caffeinated/iced/index.tsx
@@ -419,7 +419,7 @@ export default function IcedCoffeePage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/caffeinated/iced/index.tsx
+++ b/client/src/pages/drinks/caffeinated/iced/index.tsx
@@ -443,7 +443,7 @@ export default function IcedCoffeePage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Caffeinated Drinks</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allCaffeinatedSubcategories.map((subcategory) => {
+              {[...allCaffeinatedSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/caffeinated/index.tsx
+++ b/client/src/pages/drinks/caffeinated/index.tsx
@@ -569,7 +569,7 @@ export default function CaffeinatedDrinksPage() {
               Explore Other Drink Categories
             </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-              {otherDrinkHubs.filter(hub => hub.id !== 'caffeinated').map((hub) => {
+              {[...otherDrinkHubs].filter((hub) => hub.id !== 'caffeinated').sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/caffeinated/lattes/index.tsx
+++ b/client/src/pages/drinks/caffeinated/lattes/index.tsx
@@ -420,7 +420,7 @@ export default function LattesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/caffeinated/lattes/index.tsx
+++ b/client/src/pages/drinks/caffeinated/lattes/index.tsx
@@ -444,7 +444,7 @@ export default function LattesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Caffeinated Drinks</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allCaffeinatedSubcategories.map((subcategory) => {
+              {[...allCaffeinatedSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/caffeinated/matcha/index.tsx
+++ b/client/src/pages/drinks/caffeinated/matcha/index.tsx
@@ -377,7 +377,7 @@ export default function MatchaDrinksPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon as any;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/caffeinated/specialty/index.tsx
+++ b/client/src/pages/drinks/caffeinated/specialty/index.tsx
@@ -420,7 +420,7 @@ export default function SpecialtyPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/caffeinated/specialty/index.tsx
+++ b/client/src/pages/drinks/caffeinated/specialty/index.tsx
@@ -444,7 +444,7 @@ export default function SpecialtyPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Caffeinated Drinks</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allCaffeinatedSubcategories.map((subcategory) => {
+              {[...allCaffeinatedSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/caffeinated/tea/index.tsx
+++ b/client/src/pages/drinks/caffeinated/tea/index.tsx
@@ -452,7 +452,7 @@ export default function TeaPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Caffeinated Drinks</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allCaffeinatedSubcategories.map((subcategory) => {
+              {[...allCaffeinatedSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/caffeinated/tea/index.tsx
+++ b/client/src/pages/drinks/caffeinated/tea/index.tsx
@@ -428,7 +428,7 @@ export default function TeaPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/detoxes/index.tsx
+++ b/client/src/pages/drinks/detoxes/index.tsx
@@ -335,7 +335,7 @@ export default function DetoxesHub() {
               Explore Other Drink Categories
             </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-              {otherDrinkHubs.filter(hub => hub.id !== 'detoxes').map((hub) => {
+              {[...otherDrinkHubs].filter((hub) => hub.id !== 'detoxes').sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/detoxes/index.tsx
+++ b/client/src/pages/drinks/detoxes/index.tsx
@@ -1,5 +1,5 @@
 // client/src/pages/drinks/detoxes/index.tsx
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -13,6 +13,7 @@ import {
   X, CheckCircle
 } from 'lucide-react';
 import { useDrinks } from '@/contexts/DrinksContext';
+import { useUser } from '@/contexts/UserContext';
 import { otherDrinkHubs, detoxSubcategories } from '../data/detoxes';
 import UniversalSearch from '@/components/UniversalSearch';
 import { sortByName } from '@/lib/sort-by-name';
@@ -21,18 +22,30 @@ const sortedDetoxSubcategories = sortByName(detoxSubcategories);
 
 export default function DetoxesHub() {
   const { userProgress, incrementDrinksMade, addPoints, addToRecentlyViewed } = useDrinks();
+  const { user } = useUser();
   const [hoveredCard, setHoveredCard] = useState<string | null>(null);
   const [selectedProgram, setSelectedProgram] = useState<string | null>(null);
   const [showProgramModal, setShowProgramModal] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
-  const [startedPrograms, setStartedPrograms] = useState<Set<string>>(() => {
-    try {
-      const saved = localStorage.getItem('detox-started-programs');
-      return saved ? new Set<string>(JSON.parse(saved)) : new Set<string>();
-    } catch {
-      return new Set<string>();
+  const [startedPrograms, setStartedPrograms] = useState<Set<string>>(new Set());
+
+  // Load started programs from Neon (logged-in) or localStorage (guest)
+  useEffect(() => {
+    if (user?.id) {
+      fetch(`/api/drinks/user-drink-stats/${encodeURIComponent(user.id)}`, { credentials: 'include' })
+        .then(r => r.ok ? r.json() : null)
+        .then(data => {
+          const ids: string[] = data?.stats?.activeCleanseProgramIds ?? [];
+          if (ids.length) setStartedPrograms(new Set(ids));
+        })
+        .catch(() => {});
+    } else {
+      try {
+        const saved = localStorage.getItem('detox-started-programs');
+        if (saved) setStartedPrograms(new Set<string>(JSON.parse(saved)));
+      } catch {}
     }
-  });
+  }, [user?.id]);
 
   const popularDetoxes = [
     { name: 'Lemon Ginger Detox', type: 'Water', time: '5 min', rating: 4.9, route: '/drinks/recipe/lemon-ginger-detox' },
@@ -112,9 +125,19 @@ export default function DetoxesHub() {
     const points = selectedProgram === '1-day' ? 100 : selectedProgram === '3-day' ? 250 : 500;
     addPoints(points);
     incrementDrinksMade();
+
     setStartedPrograms(prev => {
-      const next = new Set(prev).add(selectedProgram);
-      localStorage.setItem('detox-started-programs', JSON.stringify([...next]));
+      const next = new Set(prev).add(selectedProgram!);
+      if (user?.id) {
+        fetch(`/api/drinks/user-drink-stats/${encodeURIComponent(user.id)}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ activeCleanseProgramIds: [...next] }),
+        }).catch(() => {});
+      } else {
+        localStorage.setItem('detox-started-programs', JSON.stringify([...next]));
+      }
       return next;
     });
 

--- a/client/src/pages/drinks/detoxes/index.tsx
+++ b/client/src/pages/drinks/detoxes/index.tsx
@@ -25,7 +25,14 @@ export default function DetoxesHub() {
   const [selectedProgram, setSelectedProgram] = useState<string | null>(null);
   const [showProgramModal, setShowProgramModal] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
-  const [startedPrograms, setStartedPrograms] = useState<Set<string>>(new Set());
+  const [startedPrograms, setStartedPrograms] = useState<Set<string>>(() => {
+    try {
+      const saved = localStorage.getItem('detox-started-programs');
+      return saved ? new Set<string>(JSON.parse(saved)) : new Set<string>();
+    } catch {
+      return new Set<string>();
+    }
+  });
 
   const popularDetoxes = [
     { name: 'Lemon Ginger Detox', type: 'Water', time: '5 min', rating: 4.9, route: '/drinks/recipe/lemon-ginger-detox' },
@@ -105,7 +112,11 @@ export default function DetoxesHub() {
     const points = selectedProgram === '1-day' ? 100 : selectedProgram === '3-day' ? 250 : 500;
     addPoints(points);
     incrementDrinksMade();
-    setStartedPrograms(prev => new Set(prev).add(selectedProgram));
+    setStartedPrograms(prev => {
+      const next = new Set(prev).add(selectedProgram);
+      localStorage.setItem('detox-started-programs', JSON.stringify([...next]));
+      return next;
+    });
 
     setShowProgramModal(false);
     setShowSuccess(true);

--- a/client/src/pages/drinks/detoxes/juice/index.tsx
+++ b/client/src/pages/drinks/detoxes/juice/index.tsx
@@ -342,7 +342,7 @@ export default function DetoxJuicesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/detoxes/tea/index.tsx
+++ b/client/src/pages/drinks/detoxes/tea/index.tsx
@@ -289,7 +289,7 @@ export default function DetoxTeasPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/detoxes/water/index.tsx
+++ b/client/src/pages/drinks/detoxes/water/index.tsx
@@ -284,7 +284,7 @@ export default function DetoxWatersPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/cocktails/index.tsx
+++ b/client/src/pages/drinks/potent-potables/cocktails/index.tsx
@@ -457,7 +457,7 @@ export default function ClassicCocktailsPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/cocktails/index.tsx
+++ b/client/src/pages/drinks/potent-potables/cocktails/index.tsx
@@ -433,7 +433,7 @@ export default function ClassicCocktailsPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/cognac-brandy/index.tsx
+++ b/client/src/pages/drinks/potent-potables/cognac-brandy/index.tsx
@@ -408,7 +408,7 @@ export default function CognacBrandyPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/cognac-brandy/index.tsx
+++ b/client/src/pages/drinks/potent-potables/cognac-brandy/index.tsx
@@ -384,7 +384,7 @@ export default function CognacBrandyPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/daiquiri/index.tsx
+++ b/client/src/pages/drinks/potent-potables/daiquiri/index.tsx
@@ -324,7 +324,7 @@ export default function DaiquiriPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/daiquiri/index.tsx
+++ b/client/src/pages/drinks/potent-potables/daiquiri/index.tsx
@@ -300,7 +300,7 @@ export default function DaiquiriPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/gin/index.tsx
+++ b/client/src/pages/drinks/potent-potables/gin/index.tsx
@@ -366,7 +366,7 @@ export default function GinCocktailsPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/gin/index.tsx
+++ b/client/src/pages/drinks/potent-potables/gin/index.tsx
@@ -342,7 +342,7 @@ export default function GinCocktailsPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/hot-drinks/index.tsx
+++ b/client/src/pages/drinks/potent-potables/hot-drinks/index.tsx
@@ -345,7 +345,7 @@ export default function HotDrinksPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/hot-drinks/index.tsx
+++ b/client/src/pages/drinks/potent-potables/hot-drinks/index.tsx
@@ -369,7 +369,7 @@ export default function HotDrinksPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/liqueurs/index.tsx
+++ b/client/src/pages/drinks/potent-potables/liqueurs/index.tsx
@@ -343,7 +343,7 @@ export default function LiqueursPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/liqueurs/index.tsx
+++ b/client/src/pages/drinks/potent-potables/liqueurs/index.tsx
@@ -367,7 +367,7 @@ export default function LiqueursPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/martinis/index.tsx
+++ b/client/src/pages/drinks/potent-potables/martinis/index.tsx
@@ -384,7 +384,7 @@ export default function MartinisPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/martinis/index.tsx
+++ b/client/src/pages/drinks/potent-potables/martinis/index.tsx
@@ -360,7 +360,7 @@ export default function MartinisPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/mocktails/index.tsx
+++ b/client/src/pages/drinks/potent-potables/mocktails/index.tsx
@@ -373,7 +373,7 @@ export default function MocktailsPage() {
               <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/mocktails/index.tsx
+++ b/client/src/pages/drinks/potent-potables/mocktails/index.tsx
@@ -397,7 +397,7 @@ export default function MocktailsPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {sisterPotentPotablesPages.map((page) => {
+              {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                 const Icon = page.icon;
                 return (
                   <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/rum/index.tsx
+++ b/client/src/pages/drinks/potent-potables/rum/index.tsx
@@ -377,7 +377,7 @@ export default function RumCocktailsPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/rum/index.tsx
+++ b/client/src/pages/drinks/potent-potables/rum/index.tsx
@@ -401,7 +401,7 @@ export default function RumCocktailsPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/scotch-irish-whiskey/index.tsx
+++ b/client/src/pages/drinks/potent-potables/scotch-irish-whiskey/index.tsx
@@ -370,7 +370,7 @@ export default function ScotchIrishWhiskeyPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/scotch-irish-whiskey/index.tsx
+++ b/client/src/pages/drinks/potent-potables/scotch-irish-whiskey/index.tsx
@@ -394,7 +394,7 @@ export default function ScotchIrishWhiskeyPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/seasonal/index.tsx
+++ b/client/src/pages/drinks/potent-potables/seasonal/index.tsx
@@ -422,7 +422,7 @@ export default function SeasonalCocktailsPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/seasonal/index.tsx
+++ b/client/src/pages/drinks/potent-potables/seasonal/index.tsx
@@ -398,7 +398,7 @@ export default function SeasonalCocktailsPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/spritz/index.tsx
+++ b/client/src/pages/drinks/potent-potables/spritz/index.tsx
@@ -343,7 +343,7 @@ export default function SpritzMimosasPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/spritz/index.tsx
+++ b/client/src/pages/drinks/potent-potables/spritz/index.tsx
@@ -367,7 +367,7 @@ export default function SpritzMimosasPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/tequila-mezcal/index.tsx
+++ b/client/src/pages/drinks/potent-potables/tequila-mezcal/index.tsx
@@ -377,7 +377,7 @@ export default function TequilaMezcalPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/tequila-mezcal/index.tsx
+++ b/client/src/pages/drinks/potent-potables/tequila-mezcal/index.tsx
@@ -401,7 +401,7 @@ export default function TequilaMezcalPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/vodka/index.tsx
+++ b/client/src/pages/drinks/potent-potables/vodka/index.tsx
@@ -355,7 +355,7 @@ export default function VodkaCocktailsPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/potent-potables/vodka/index.tsx
+++ b/client/src/pages/drinks/potent-potables/vodka/index.tsx
@@ -379,7 +379,7 @@ export default function VodkaCocktailsPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/whiskey-bourbon/index.tsx
+++ b/client/src/pages/drinks/potent-potables/whiskey-bourbon/index.tsx
@@ -376,7 +376,7 @@ export default function WhiskeyBourbonPage() {
             <CardContent className="p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Potent Potables</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                {sisterPotentPotablesPages.map((page) => {
+                {[...sisterPotentPotablesPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                   const Icon = page.icon;
                   return (
                     <Link key={page.id} href={page.path}>

--- a/client/src/pages/drinks/potent-potables/whiskey-bourbon/index.tsx
+++ b/client/src/pages/drinks/potent-potables/whiskey-bourbon/index.tsx
@@ -352,7 +352,7 @@ export default function WhiskeyBourbonPage() {
                 <span className="text-sm text-gray-600">Explore Other Drink Categories</span>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-                {otherDrinkHubs.map((hub) => {
+                {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                   const Icon = hub.icon;
                   return (
                     <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/protein-shakes/beef/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/beef/index.tsx
@@ -325,7 +325,7 @@ export default function BeefProteinPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon as any;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/protein-shakes/beef/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/beef/index.tsx
@@ -352,7 +352,7 @@ export default function BeefProteinPage() {
               Other Protein Types
             </h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {proteinSubcategories.map((subcategory) => {
+              {[...proteinSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon as any;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/protein-shakes/casein/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/casein/index.tsx
@@ -452,7 +452,7 @@ export default function CaseinProteinPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Protein Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {proteinSubcategories.map((subcategory) => {
+              {[...proteinSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/protein-shakes/casein/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/casein/index.tsx
@@ -425,7 +425,7 @@ export default function CaseinProteinPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/protein-shakes/collagen/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/collagen/index.tsx
@@ -407,7 +407,7 @@ export default function CollagenProteinPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/protein-shakes/collagen/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/collagen/index.tsx
@@ -431,7 +431,7 @@ export default function CollagenProteinPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Protein Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {proteinSubcategories.map((subcategory) => {
+              {[...proteinSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/protein-shakes/egg/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/egg/index.tsx
@@ -305,7 +305,7 @@ export default function EggProteinPage() {
               Other Protein Types
             </h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {proteinSubcategories.map((subcategory) => {
+              {[...proteinSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon as any;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/protein-shakes/egg/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/egg/index.tsx
@@ -278,7 +278,7 @@ export default function EggProteinPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon as any;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/protein-shakes/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/index.tsx
@@ -377,7 +377,7 @@ export default function ProteinShakesPage({ params }: Params) {
             Explore Other Drink Categories
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-            {otherDrinkHubs.filter(hub => hub.id !== 'protein-shakes').map((hub) => {
+            {[...otherDrinkHubs].filter((hub) => hub.id !== 'protein-shakes').sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
               const Icon = hub.icon;
               return (
                 <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/protein-shakes/plant-based/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/plant-based/index.tsx
@@ -320,7 +320,7 @@ export default function PlantBasedProteinPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/protein-shakes/plant-based/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/plant-based/index.tsx
@@ -344,7 +344,7 @@ export default function PlantBasedProteinPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Protein Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {proteinSubcategories.map((subcategory) => {
+              {[...proteinSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/protein-shakes/whey/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/whey/index.tsx
@@ -424,7 +424,7 @@ export default function WheyProteinShakesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Protein Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {proteinSubcategories.map((subcategory) => {
+              {[...proteinSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.route}>

--- a/client/src/pages/drinks/protein-shakes/whey/index.tsx
+++ b/client/src/pages/drinks/protein-shakes/whey/index.tsx
@@ -400,7 +400,7 @@ export default function WheyProteinShakesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/berry/index.tsx
+++ b/client/src/pages/drinks/smoothies/berry/index.tsx
@@ -395,7 +395,7 @@ export default function BerrySmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/berry/index.tsx
+++ b/client/src/pages/drinks/smoothies/berry/index.tsx
@@ -419,7 +419,7 @@ export default function BerrySmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Smoothie Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allSmoothieSubcategories.map((subcategory) => {
+              {[...allSmoothieSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/smoothies/breakfast/index.tsx
+++ b/client/src/pages/drinks/smoothies/breakfast/index.tsx
@@ -442,7 +442,7 @@ export default function BreakfastSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/breakfast/index.tsx
+++ b/client/src/pages/drinks/smoothies/breakfast/index.tsx
@@ -466,7 +466,7 @@ export default function BreakfastSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Smoothie Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allSmoothieSubcategories.map((subcategory) => {
+              {[...allSmoothieSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/smoothies/dessert/index.tsx
+++ b/client/src/pages/drinks/smoothies/dessert/index.tsx
@@ -366,7 +366,7 @@ export default function DessertSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-text font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/dessert/index.tsx
+++ b/client/src/pages/drinks/smoothies/dessert/index.tsx
@@ -390,7 +390,7 @@ export default function DessertSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Smoothie Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allSmoothieSubcategories.map((subcategory) => {
+              {[...allSmoothieSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/smoothies/detox/index.tsx
+++ b/client/src/pages/drinks/smoothies/detox/index.tsx
@@ -381,7 +381,7 @@ export default function DetoxSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/detox/index.tsx
+++ b/client/src/pages/drinks/smoothies/detox/index.tsx
@@ -405,7 +405,7 @@ export default function DetoxSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Smoothie Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allSmoothieSubcategories.map((subcategory) => {
+              {[...allSmoothieSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/smoothies/green/index.tsx
+++ b/client/src/pages/drinks/smoothies/green/index.tsx
@@ -393,7 +393,7 @@ export default function GreenSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/green/index.tsx
+++ b/client/src/pages/drinks/smoothies/green/index.tsx
@@ -417,7 +417,7 @@ export default function GreenSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Smoothie Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allSmoothieSubcategories.map((subcategory) => {
+              {[...allSmoothieSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/smoothies/index.tsx
+++ b/client/src/pages/drinks/smoothies/index.tsx
@@ -604,7 +604,7 @@ export default function SmoothiesPage() {
               Explore Other Drink Categories
             </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-              {otherDrinkHubs.filter(hub => hub.id !== 'smoothies').map((hub) => {
+              {[...otherDrinkHubs].filter((hub) => hub.id !== 'smoothies').sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/protein/index.tsx
+++ b/client/src/pages/drinks/smoothies/protein/index.tsx
@@ -413,7 +413,7 @@ export default function ProteinSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Smoothie Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allSmoothieSubcategories.map((subcategory) => {
+              {[...allSmoothieSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/smoothies/protein/index.tsx
+++ b/client/src/pages/drinks/smoothies/protein/index.tsx
@@ -389,7 +389,7 @@ export default function ProteinSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/tropical/index.tsx
+++ b/client/src/pages/drinks/smoothies/tropical/index.tsx
@@ -415,7 +415,7 @@ export default function TropicalSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Smoothie Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allSmoothieSubcategories.map((subcategory) => {
+              {[...allSmoothieSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/drinks/smoothies/tropical/index.tsx
+++ b/client/src/pages/drinks/smoothies/tropical/index.tsx
@@ -391,7 +391,7 @@ export default function TropicalSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/workout/index.tsx
+++ b/client/src/pages/drinks/smoothies/workout/index.tsx
@@ -442,7 +442,7 @@ export default function WorkoutSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Explore Other Drink Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              {otherDrinkHubs.map((hub) => {
+              {[...otherDrinkHubs].sort((a,b) => a.name.localeCompare(b.name)).map((hub) => {
                 const Icon = hub.icon;
                 return (
                   <Link key={hub.id} href={hub.route}>

--- a/client/src/pages/drinks/smoothies/workout/index.tsx
+++ b/client/src/pages/drinks/smoothies/workout/index.tsx
@@ -466,7 +466,7 @@ export default function WorkoutSmoothiesPage() {
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">Other Smoothie Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-              {allSmoothieSubcategories.map((subcategory) => {
+              {[...allSmoothieSubcategories].sort((a,b) => a.name.localeCompare(b.name)).map((subcategory) => {
                 const Icon = subcategory.icon;
                 return (
                   <Link key={subcategory.id} href={subcategory.path}>

--- a/client/src/pages/nutrition/MealPlanCreator.tsx
+++ b/client/src/pages/nutrition/MealPlanCreator.tsx
@@ -6,57 +6,100 @@ import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
-import { ChefHat, Plus, DollarSign, Calendar, Target, TrendingUp, Edit, Trash2, Eye, Crown } from "lucide-react";
+import {
+  ChefHat, Plus, DollarSign, Calendar, TrendingUp,
+  Edit, Trash2, Eye, Crown, X, AlertTriangle,
+} from "lucide-react";
 
 type MealPlanBlueprint = {
   id: string;
   title: string;
   description: string | null;
-  price: string;
+  priceInCents: number;
   duration: number;
+  durationUnit: string;
   difficulty: string | null;
-  dietType: string | null;
+  category: string | null;
+  dietaryLabels: string[];
+  tags: string[];
+  servings: number;
   salesCount: number;
-  averageRating: string;
-  reviewCount: number;
-  isPublished: boolean;
+  status: string;
   createdAt: string;
+  avgRating?: number;
+  reviewCount?: number;
 };
+
+type FormState = {
+  title: string;
+  description: string;
+  price: string;
+  duration: string;
+  difficulty: string;
+  category: string;
+  dietaryLabels: string;
+  tags: string;
+  servings: string;
+  isPremiumContent: boolean;
+};
+
+const emptyForm = (): FormState => ({
+  title: "",
+  description: "",
+  price: "",
+  duration: "7",
+  difficulty: "intermediate",
+  category: "general",
+  dietaryLabels: "",
+  tags: "",
+  servings: "4",
+  isPremiumContent: false,
+});
+
+function blueprintToForm(p: MealPlanBlueprint): FormState {
+  return {
+    title: p.title,
+    description: p.description || "",
+    price: ((p.priceInCents || 0) / 100).toFixed(2),
+    duration: String(p.duration || 7),
+    difficulty: p.difficulty || "intermediate",
+    category: p.category || "general",
+    dietaryLabels: (p.dietaryLabels || []).join(", "),
+    tags: (p.tags || []).join(", "),
+    servings: String(p.servings || 4),
+    isPremiumContent: false,
+  };
+}
+
+function getCompletenessScore(title: string, description: string) {
+  let score = 0;
+  if (title.trim()) score += 40;
+  if (description.trim()) score += 35;
+  if (parseFloat(title) !== 0) score += 25;
+  return Math.min(score, 100);
+}
 
 export default function MealPlanCreator() {
   const [, setLocation] = useLocation();
   const { toast } = useToast();
+
   const [plans, setPlans] = useState<MealPlanBlueprint[]>([]);
   const [loading, setLoading] = useState(true);
-  const [showCreateForm, setShowCreateForm] = useState(false);
-
-  // Form state
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
-  const [price, setPrice] = useState("");
-  const [duration, setDuration] = useState("7");
-  const [difficulty, setDifficulty] = useState("intermediate");
-  const [dietType, setDietType] = useState("");
-  const [targetCalories, setTargetCalories] = useState("");
-  const [meals, setMeals] = useState<any[]>([]);
-  const [isPremiumContent, setIsPremiumContent] = useState(false);
   const [userHasPremium, setUserHasPremium] = useState(false);
 
-  const getCompletenessScore = (plan: {
-    title?: string;
-    description?: string | null;
-    targetCalories?: string | number | null;
-    meals?: any[];
-  }) => {
-    let score = 0;
-    if (plan.title?.trim()) score += 25;
-    if (plan.description?.trim()) score += 25;
-    if (plan.targetCalories) score += 20;
-    if ((plan.meals?.length || 0) >= 7) score += 30;
-    return score;
-  };
+  // Create form
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [createForm, setCreateForm] = useState<FormState>(emptyForm());
+  const [creating, setCreating] = useState(false);
 
-  const draftCompleteness = getCompletenessScore({ title, description, targetCalories, meals });
+  // Edit modal
+  const [editingPlan, setEditingPlan] = useState<MealPlanBlueprint | null>(null);
+  const [editForm, setEditForm] = useState<FormState>(emptyForm());
+  const [saving, setSaving] = useState(false);
+
+  // Delete confirm
+  const [deletingPlan, setDeletingPlan] = useState<MealPlanBlueprint | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
     fetchMyPlans();
@@ -65,146 +108,269 @@ export default function MealPlanCreator() {
 
   const checkPremiumStatus = async () => {
     try {
-      const response = await fetch("/api/user", {
-        credentials: "include",
-      });
-      if (response.ok) {
-        const data = await response.json();
+      const res = await fetch("/api/user", { credentials: "include" });
+      if (res.ok) {
+        const data = await res.json();
         setUserHasPremium(data.nutritionPremium || false);
       }
-    } catch (error) {
-      console.error("Failed to check premium status:", error);
-    }
+    } catch {}
   };
 
   const fetchMyPlans = async () => {
     try {
       setLoading(true);
-      const response = await fetch("/api/my-plans", {
-        credentials: "include",
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        setPlans(data.plans.map((p: any) => p.blueprint));
+      const res = await fetch("/api/my-plans", { credentials: "include" });
+      if (res.ok) {
+        const data = await res.json();
+        setPlans(data.plans.map((p: any) => ({
+          ...p.blueprint,
+          avgRating: p.avgRating,
+          reviewCount: Number(p.reviewCount || 0),
+        })));
       }
-    } catch (error) {
-      console.error("Failed to fetch plans:", error);
-    } finally {
-      setLoading(false);
-    }
+    } catch {}
+    finally { setLoading(false); }
   };
 
-  const handleCreatePlan = async (e: React.FormEvent) => {
+  // ── Create ──────────────────────────────────────────────────
+  const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
-
-    if (!title || !price) {
-      toast({
-        title: "Missing fields",
-        description: "Title and price are required",
-        variant: "destructive",
-      });
+    if (!createForm.title || !createForm.price) {
+      toast({ title: "Missing fields", description: "Title and price are required.", variant: "destructive" });
       return;
     }
-
-    // Check if user is trying to create premium content without access
-    if (isPremiumContent && !userHasPremium) {
-      toast({
-        title: "Premium Feature",
-        description: "You need Nutrition Premium to create premium content",
-        variant: "destructive",
-      });
-      return;
-    }
-
+    setCreating(true);
     try {
-      const response = await fetch("/api/meal-plans", {
+      const res = await fetch("/api/meal-plans", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
         body: JSON.stringify({
-          title,
-          description,
-          price: parseFloat(price),
-          duration: parseInt(duration),
-          difficulty,
-          dietType: dietType || null,
-          targetCalories: targetCalories ? parseInt(targetCalories) : null,
-          meals: meals.length > 0 ? meals : [{ day: 1, mealType: "breakfast", recipeName: "Example meal" }],
-          isPremiumContent,
+          title: createForm.title,
+          description: createForm.description || null,
+          priceInCents: Math.round(parseFloat(createForm.price) * 100),
+          duration: parseInt(createForm.duration),
+          durationUnit: "days",
+          difficulty: createForm.difficulty,
+          category: createForm.category,
+          dietaryLabels: createForm.dietaryLabels.split(",").map(s => s.trim()).filter(Boolean),
+          tags: createForm.tags.split(",").map(s => s.trim()).filter(Boolean),
+          servings: parseInt(createForm.servings),
+          mealStructure: JSON.stringify([]),
         }),
       });
-
-      if (response.ok) {
-        toast({
-          title: "Success!",
-          description: "Meal plan created successfully",
-        });
+      if (res.ok) {
+        toast({ title: "Created!", description: "Meal plan created as draft." });
         setShowCreateForm(false);
-        resetForm();
+        setCreateForm(emptyForm());
         fetchMyPlans();
       } else {
-        const data = await response.json();
-        toast({
-          title: "Error",
-          description: data.message || "Failed to create meal plan",
-          variant: "destructive",
-        });
+        const data = await res.json();
+        toast({ title: "Error", description: data.message || "Failed to create.", variant: "destructive" });
       }
-    } catch (error) {
-      console.error("Create error:", error);
-      toast({
-        title: "Error",
-        description: "Failed to create meal plan",
-        variant: "destructive",
-      });
-    }
+    } catch {
+      toast({ title: "Error", description: "Network error.", variant: "destructive" });
+    } finally { setCreating(false); }
   };
 
+  // ── Edit ─────────────────────────────────────────────────────
+  const openEdit = (plan: MealPlanBlueprint) => {
+    setEditingPlan(plan);
+    setEditForm(blueprintToForm(plan));
+  };
+
+  const handleSaveEdit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!editingPlan) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/meal-plans/${editingPlan.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          title: editForm.title,
+          description: editForm.description || null,
+          priceInCents: Math.round(parseFloat(editForm.price) * 100),
+          duration: parseInt(editForm.duration),
+          difficulty: editForm.difficulty,
+          category: editForm.category,
+          dietaryLabels: editForm.dietaryLabels.split(",").map(s => s.trim()).filter(Boolean),
+          tags: editForm.tags.split(",").map(s => s.trim()).filter(Boolean),
+          servings: parseInt(editForm.servings),
+        }),
+      });
+      if (res.ok) {
+        toast({ title: "Saved!", description: "Meal plan updated." });
+        setEditingPlan(null);
+        fetchMyPlans();
+      } else {
+        const data = await res.json();
+        toast({ title: "Error", description: data.message || "Failed to save.", variant: "destructive" });
+      }
+    } catch {
+      toast({ title: "Error", description: "Network error.", variant: "destructive" });
+    } finally { setSaving(false); }
+  };
+
+  // ── Delete ───────────────────────────────────────────────────
+  const handleDelete = async () => {
+    if (!deletingPlan) return;
+    setDeleting(true);
+    try {
+      const res = await fetch(`/api/meal-plans/${deletingPlan.id}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+      if (res.ok) {
+        toast({ title: "Deleted", description: `"${deletingPlan.title}" removed.` });
+        setDeletingPlan(null);
+        fetchMyPlans();
+      } else {
+        const data = await res.json();
+        toast({ title: "Error", description: data.message || "Failed to delete.", variant: "destructive" });
+      }
+    } catch {
+      toast({ title: "Error", description: "Network error.", variant: "destructive" });
+    } finally { setDeleting(false); }
+  };
+
+  // ── Publish ──────────────────────────────────────────────────
   const handlePublish = async (planId: string) => {
     try {
-      const response = await fetch(`/api/meal-plans/${planId}/publish`, {
+      const res = await fetch(`/api/meal-plans/${planId}/publish`, {
         method: "POST",
         credentials: "include",
       });
-
-      if (response.ok) {
-        toast({
-          title: "Published!",
-          description: "Your meal plan is now live in the marketplace",
-        });
+      if (res.ok) {
+        toast({ title: "Published!", description: "Your meal plan is now live in the marketplace." });
         fetchMyPlans();
       } else {
-        const data = await response.json();
-        toast({
-          title: "Error",
-          description: data.message || "Failed to publish",
-          variant: "destructive",
-        });
+        const data = await res.json();
+        toast({ title: "Error", description: data.message || "Failed to publish.", variant: "destructive" });
       }
-    } catch (error) {
-      toast({
-        title: "Error",
-        description: "Failed to publish meal plan",
-        variant: "destructive",
-      });
+    } catch {
+      toast({ title: "Error", description: "Failed to publish.", variant: "destructive" });
     }
   };
 
-  const resetForm = () => {
-    setTitle("");
-    setDescription("");
-    setPrice("");
-    setDuration("7");
-    setDifficulty("intermediate");
-    setDietType("");
-    setTargetCalories("");
-    setMeals([]);
-  };
+  // ── Plan form fields (shared between create + edit) ──────────
+  const PlanFormFields = ({ form, setForm }: { form: FormState; setForm: (f: FormState) => void }) => (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium mb-1">Plan Title *</label>
+          <Input value={form.title} onChange={e => setForm({ ...form, title: e.target.value })} placeholder="7-Day Keto Meal Plan" required />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Price (USD) *</label>
+          <Input type="number" step="0.01" min="0" value={form.price} onChange={e => setForm({ ...form, price: e.target.value })} placeholder="29.99" required />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Duration (days)</label>
+          <Input type="number" min="1" value={form.duration} onChange={e => setForm({ ...form, duration: e.target.value })} />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Servings per meal</label>
+          <Input type="number" min="1" value={form.servings} onChange={e => setForm({ ...form, servings: e.target.value })} />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Difficulty</label>
+          <select value={form.difficulty} onChange={e => setForm({ ...form, difficulty: e.target.value })} className="w-full p-2 border rounded text-sm">
+            <option value="beginner">Beginner</option>
+            <option value="intermediate">Intermediate</option>
+            <option value="advanced">Advanced</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Category</label>
+          <select value={form.category} onChange={e => setForm({ ...form, category: e.target.value })} className="w-full p-2 border rounded text-sm">
+            <option value="general">General</option>
+            <option value="weight-loss">Weight Loss</option>
+            <option value="muscle-gain">Muscle Gain</option>
+            <option value="keto">Keto</option>
+            <option value="vegan">Vegan</option>
+            <option value="paleo">Paleo</option>
+            <option value="mediterranean">Mediterranean</option>
+          </select>
+        </div>
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">Description</label>
+        <Textarea value={form.description} onChange={e => setForm({ ...form, description: e.target.value })} placeholder="Describe your meal plan..." rows={3} />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium mb-1">Dietary Labels <span className="text-muted-foreground">(comma-separated)</span></label>
+          <Input value={form.dietaryLabels} onChange={e => setForm({ ...form, dietaryLabels: e.target.value })} placeholder="Gluten-Free, Dairy-Free" />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Tags <span className="text-muted-foreground">(comma-separated)</span></label>
+          <Input value={form.tags} onChange={e => setForm({ ...form, tags: e.target.value })} placeholder="quick, budget, family" />
+        </div>
+      </div>
+    </div>
+  );
 
   return (
     <div className="max-w-7xl mx-auto p-6">
-      {/* Header */}
+
+      {/* ── Edit Modal ── */}
+      {editingPlan && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4 overflow-y-auto">
+          <Card className="w-full max-w-2xl">
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <CardTitle>Edit Meal Plan</CardTitle>
+                <Button variant="ghost" size="sm" onClick={() => setEditingPlan(null)}>
+                  <X className="w-4 h-4" />
+                </Button>
+              </div>
+              {editingPlan.status === "published" && (
+                <p className="text-sm text-amber-600 bg-amber-50 border border-amber-200 rounded p-2 mt-2">
+                  This plan is published. Unpublish it first to make edits.
+                </p>
+              )}
+            </CardHeader>
+            <CardContent>
+              <form onSubmit={handleSaveEdit} className="space-y-4">
+                <PlanFormFields form={editForm} setForm={setEditForm} />
+                <div className="flex gap-2 pt-2">
+                  <Button type="submit" disabled={saving || editingPlan.status === "published"}>
+                    {saving ? "Saving…" : "Save Changes"}
+                  </Button>
+                  <Button type="button" variant="outline" onClick={() => setEditingPlan(null)}>Cancel</Button>
+                </div>
+              </form>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* ── Delete Confirm Modal ── */}
+      {deletingPlan && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <Card className="w-full max-w-sm">
+            <CardContent className="p-6">
+              <div className="flex items-start gap-3 mb-4">
+                <AlertTriangle className="w-6 h-6 text-red-500 mt-0.5 shrink-0" />
+                <div>
+                  <h3 className="font-semibold mb-1">Delete "{deletingPlan.title}"?</h3>
+                  <p className="text-sm text-muted-foreground">This cannot be undone. Only draft plans with no purchases can be deleted.</p>
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <Button variant="destructive" onClick={handleDelete} disabled={deleting} className="flex-1">
+                  {deleting ? "Deleting…" : "Yes, delete"}
+                </Button>
+                <Button variant="outline" onClick={() => setDeletingPlan(null)} className="flex-1">Cancel</Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* ── Header ── */}
       <div className="flex items-center justify-between mb-8">
         <div>
           <h1 className="text-3xl font-bold flex items-center gap-2">
@@ -225,140 +391,49 @@ export default function MealPlanCreator() {
         </div>
       </div>
 
-      {/* Create Form */}
+      {/* ── Create Form ── */}
       {showCreateForm && (
         <Card className="mb-8">
           <CardHeader>
-            <CardTitle>Create New Meal Plan</CardTitle>
+            <div className="flex items-center justify-between">
+              <CardTitle>Create New Meal Plan</CardTitle>
+              <Button variant="ghost" size="sm" onClick={() => setShowCreateForm(false)}>
+                <X className="w-4 h-4" />
+              </Button>
+            </div>
           </CardHeader>
           <CardContent>
-            <form onSubmit={handleCreatePlan} className="space-y-4">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm font-medium mb-2">Plan Title *</label>
-                  <Input
-                    value={title}
-                    onChange={(e) => setTitle(e.target.value)}
-                    placeholder="7-Day Keto Meal Plan"
-                    required
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium mb-2">Price (USD) *</label>
-                  <Input
-                    type="number"
-                    step="0.01"
-                    value={price}
-                    onChange={(e) => setPrice(e.target.value)}
-                    placeholder="29.99"
-                    required
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium mb-2">Duration (days)</label>
-                  <Input
-                    type="number"
-                    value={duration}
-                    onChange={(e) => setDuration(e.target.value)}
-                    placeholder="7"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium mb-2">Difficulty</label>
-                  <select
-                    value={difficulty}
-                    onChange={(e) => setDifficulty(e.target.value)}
-                    className="w-full p-2 border rounded"
-                  >
-                    <option value="beginner">Beginner</option>
-                    <option value="intermediate">Intermediate</option>
-                    <option value="advanced">Advanced</option>
-                  </select>
-                </div>
-                <div>
-                  <label className="block text-sm font-medium mb-2">Diet Type</label>
-                  <Input
-                    value={dietType}
-                    onChange={(e) => setDietType(e.target.value)}
-                    placeholder="Keto, Vegan, Paleo, etc."
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium mb-2">Target Calories/Day</label>
-                  <Input
-                    type="number"
-                    value={targetCalories}
-                    onChange={(e) => setTargetCalories(e.target.value)}
-                    placeholder="2000"
-                  />
-                </div>
-              </div>
-
-              <div className="p-3 rounded-md border bg-muted/30">
-                <div className="flex items-center justify-between text-sm">
-                  <span className="font-medium">Plan completeness</span>
-                  <span>{draftCompleteness}%</span>
-                </div>
-                <div className="mt-2 h-2 w-full bg-muted rounded-full overflow-hidden">
-                  <div className="h-full bg-green-500" style={{ width: `${draftCompleteness}%` }} />
-                </div>
-              </div>
-              <div>
-                <label className="block text-sm font-medium mb-2">Description</label>
-                <Textarea
-                  value={description}
-                  onChange={(e) => setDescription(e.target.value)}
-                  placeholder="Describe your meal plan..."
-                  rows={4}
-                />
-              </div>
-              <div className="flex items-center gap-3 p-4 bg-orange-50 border border-orange-200 rounded-lg">
+            <form onSubmit={handleCreate} className="space-y-4">
+              <PlanFormFields form={createForm} setForm={setCreateForm} />
+              <div className="flex items-center gap-3 p-3 bg-orange-50 border border-orange-200 rounded-lg">
                 <input
                   type="checkbox"
                   id="isPremiumContent"
-                  checked={isPremiumContent}
-                  onChange={(e) => setIsPremiumContent(e.target.checked)}
+                  checked={createForm.isPremiumContent}
+                  onChange={e => setCreateForm({ ...createForm, isPremiumContent: e.target.checked })}
                   disabled={!userHasPremium}
-                  className="w-5 h-5 rounded border-orange-300 cursor-pointer disabled:cursor-not-allowed"
+                  className="w-4 h-4"
                 />
-                <label htmlFor="isPremiumContent" className="flex items-center gap-2 cursor-pointer">
-                  {isPremiumContent ? (
-                    <Badge variant="default" className="bg-orange-600">
-                      <Crown className="w-3 h-3 mr-1" />
-                      Premium Content
-                    </Badge>
-                  ) : (
-                    <Badge variant="outline">Standard Content</Badge>
-                  )}
-                  <span className="text-sm text-gray-600">
-                    {userHasPremium ? "Mark as premium content" : "Upgrade to create premium content"}
-                  </span>
+                <label htmlFor="isPremiumContent" className="flex items-center gap-2 text-sm cursor-pointer">
+                  <Crown className="w-4 h-4 text-orange-500" />
+                  {userHasPremium ? "Mark as premium content" : "Upgrade to create premium content"}
                 </label>
                 {!userHasPremium && (
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    className="ml-auto"
-                    onClick={() => setLocation("/nutrition/meal-planner")}
-                  >
-                    <Crown className="w-4 h-4 mr-1" />
+                  <Button type="button" size="sm" variant="outline" className="ml-auto" onClick={() => setLocation("/nutrition/meal-planner")}>
                     Upgrade
                   </Button>
                 )}
               </div>
               <div className="flex gap-2">
-                <Button type="submit">Create Plan</Button>
-                <Button type="button" variant="outline" onClick={() => setShowCreateForm(false)}>
-                  Cancel
-                </Button>
+                <Button type="submit" disabled={creating}>{creating ? "Creating…" : "Create Plan"}</Button>
+                <Button type="button" variant="outline" onClick={() => setShowCreateForm(false)}>Cancel</Button>
               </div>
             </form>
           </CardContent>
         </Card>
       )}
 
-      {/* Plans List */}
+      {/* ── Plans List ── */}
       <div className="space-y-4">
         <h2 className="text-xl font-semibold">Your Meal Plans</h2>
         {loading ? (
@@ -380,62 +455,65 @@ export default function MealPlanCreator() {
             {plans.map((plan) => (
               <Card key={plan.id}>
                 <CardContent className="p-6">
-                  <div className="flex items-start justify-between">
-                    <div className="flex-1">
-                      <div className="flex items-center gap-3 mb-2">
-                        <h3 className="text-xl font-semibold">{plan.title}</h3>
-                        {plan.isPublished ? (
-                          <Badge variant="default">Published</Badge>
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-3 mb-2 flex-wrap">
+                        <h3 className="text-xl font-semibold truncate">{plan.title}</h3>
+                        {plan.status === "published" ? (
+                          <Badge className="bg-green-600 text-white">Published</Badge>
                         ) : (
                           <Badge variant="secondary">Draft</Badge>
                         )}
-                        <Badge variant="outline">Quality: {getCompletenessScore({ title: plan.title, description: plan.description, meals: [] })}%</Badge>
                       </div>
                       {plan.description && (
-                        <p className="text-muted-foreground mb-3">{plan.description}</p>
+                        <p className="text-muted-foreground text-sm mb-3 line-clamp-2">{plan.description}</p>
                       )}
-                      <div className="flex flex-wrap gap-4 text-sm">
+                      <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
                         <span className="flex items-center gap-1">
                           <DollarSign className="w-4 h-4" />
-                          ${plan.price}
+                          ${((plan.priceInCents || 0) / 100).toFixed(2)}
                         </span>
                         <span className="flex items-center gap-1">
                           <Calendar className="w-4 h-4" />
                           {plan.duration} days
                         </span>
-                        {plan.difficulty && (
-                          <Badge variant="outline" className="capitalize">
-                            {plan.difficulty}
-                          </Badge>
-                        )}
-                        {plan.dietType && <Badge variant="outline">{plan.dietType}</Badge>}
-                      </div>
-                      <div className="flex gap-4 mt-3 text-sm text-muted-foreground">
+                        {plan.difficulty && <Badge variant="outline" className="capitalize">{plan.difficulty}</Badge>}
+                        {plan.category && plan.category !== "general" && <Badge variant="outline">{plan.category}</Badge>}
                         <span>{plan.salesCount} sales</span>
-                        <span>
-                          {plan.reviewCount} reviews ({plan.averageRating} ⭐)
-                        </span>
+                        {plan.reviewCount ? <span>{plan.reviewCount} reviews ({Number(plan.avgRating || 0).toFixed(1)} ⭐)</span> : null}
                       </div>
                     </div>
-                    <div className="flex gap-2">
-                      {!plan.isPublished && (
-                        <Button
-                          size="sm"
-                          onClick={() => handlePublish(plan.id)}
-                        >
-                          Publish
-                        </Button>
+                    <div className="flex gap-2 shrink-0">
+                      {plan.status === "draft" && (
+                        <Button size="sm" onClick={() => handlePublish(plan.id)}>Publish</Button>
                       )}
-                      <Button size="sm" variant="outline">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        title={plan.status === "published" ? "Unpublish to edit" : "Edit"}
+                        onClick={() => openEdit(plan)}
+                      >
                         <Edit className="w-4 h-4" />
                       </Button>
                       <Button
                         size="sm"
                         variant="outline"
                         onClick={() => setLocation(`/nutrition/meal-plans/${plan.id}`)}
+                        title="View"
                       >
                         <Eye className="w-4 h-4" />
                       </Button>
+                      {plan.status === "draft" && plan.salesCount === 0 && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="text-red-500 hover:bg-red-50 hover:border-red-300"
+                          title="Delete"
+                          onClick={() => setDeletingPlan(plan)}
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </Button>
+                      )}
                     </div>
                   </div>
                 </CardContent>

--- a/client/src/pages/nutrition/MealPlanDetailsPage.tsx
+++ b/client/src/pages/nutrition/MealPlanDetailsPage.tsx
@@ -1,12 +1,15 @@
 // client/src/pages/nutrition/MealPlanDetailsPage.tsx
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Link, useLocation, useParams } from "wouter";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
-import { ArrowLeft, Calendar, DollarSign, Star, User } from "lucide-react";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/hooks/use-toast";
+import { useUser } from "@/contexts/UserContext";
+import { ArrowLeft, Calendar, DollarSign, Star, User, Send } from "lucide-react";
 
 type MealPlanDetailsResponse = {
   plan: {
@@ -44,53 +47,72 @@ type MealPlanDetailsResponse = {
     createdAt: string;
   } | null;
   reviews: Array<{
-    review: {
-      id: string;
-      rating: number;
-      comment: string | null;
-      createdAt: string;
-    };
-    user: {
-      id: string;
-      username: string;
-      displayName: string;
-    };
+    review: { id: string; rating: number; comment: string | null; createdAt: string };
+    user: { id: string; username: string; displayName: string };
   }>;
-  ratingStats: {
-    avgRating: number;
-    totalReviews: number;
-  };
+  ratingStats: { avgRating: number; totalReviews: number };
 };
 
 function formatMoney(cents: number) {
-  const dollars = cents / 100;
-  return dollars.toLocaleString(undefined, { style: "currency", currency: "USD" });
+  return (cents / 100).toLocaleString(undefined, { style: "currency", currency: "USD" });
 }
 
 function safeParseJson(text: string) {
-  try {
-    return { ok: true as const, value: JSON.parse(text) };
-  } catch {
-    return { ok: false as const, value: null };
-  }
+  try { return { ok: true as const, value: JSON.parse(text) }; }
+  catch { return { ok: false as const, value: null }; }
+}
+
+function StarPicker({ value, onChange }: { value: number; onChange: (n: number) => void }) {
+  const [hovered, setHovered] = useState(0);
+  return (
+    <div className="flex gap-1">
+      {[1, 2, 3, 4, 5].map(n => (
+        <button
+          key={n}
+          type="button"
+          onMouseEnter={() => setHovered(n)}
+          onMouseLeave={() => setHovered(0)}
+          onClick={() => onChange(n)}
+          className="focus:outline-none"
+          aria-label={`${n} star${n !== 1 ? "s" : ""}`}
+        >
+          <Star
+            className={`w-7 h-7 transition-colors ${
+              n <= (hovered || value) ? "fill-yellow-400 text-yellow-400" : "text-gray-300"
+            }`}
+          />
+        </button>
+      ))}
+    </div>
+  );
 }
 
 export default function MealPlanDetailsPage() {
   const params = useParams();
   const [, setLocation] = useLocation();
+  const { toast } = useToast();
+  const { user } = useUser();
+  const queryClient = useQueryClient();
   const planId = (params as any)?.id as string | undefined;
 
-  const {
-    data,
-    isLoading,
-    error,
-  } = useQuery<MealPlanDetailsResponse>({
+  const { data, isLoading, error } = useQuery<MealPlanDetailsResponse>({
     queryKey: planId ? ["/api/meal-plans", planId] : ["/api/meal-plans", "__missing__"],
     enabled: !!planId,
   });
 
+  // Review form state
+  const [reviewRating, setReviewRating] = useState(0);
+  const [reviewComment, setReviewComment] = useState("");
+  const [submittingReview, setSubmittingReview] = useState(false);
+
   const blueprint = data?.plan?.blueprint;
   const creator = data?.plan?.creator;
+
+  // Check if the current user already has a review
+  const myExistingReview = useMemo(
+    () => data?.reviews?.find(r => user?.id && r.user.id === user.id),
+    [data?.reviews, user?.id]
+  );
 
   const mealStructurePretty = useMemo(() => {
     const raw = data?.version?.mealStructure;
@@ -99,6 +121,38 @@ export default function MealPlanDetailsPage() {
     if (!parsed.ok) return raw;
     return JSON.stringify(parsed.value, null, 2);
   }, [data?.version?.mealStructure]);
+
+  const handleSubmitReview = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!planId || !user) {
+      toast({ title: "Sign in required", description: "You must be logged in to leave a review.", variant: "destructive" });
+      return;
+    }
+    if (reviewRating < 1) {
+      toast({ title: "Select a rating", description: "Please pick 1–5 stars.", variant: "destructive" });
+      return;
+    }
+    setSubmittingReview(true);
+    try {
+      const res = await fetch(`/api/meal-plans/${planId}/review`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ rating: reviewRating, comment: reviewComment.trim() || null }),
+      });
+      if (res.ok) {
+        toast({ title: "Review submitted!", description: "Thanks for your feedback." });
+        setReviewRating(0);
+        setReviewComment("");
+        queryClient.invalidateQueries({ queryKey: ["/api/meal-plans", planId] });
+      } else {
+        const d = await res.json();
+        toast({ title: "Error", description: d.message || "Failed to submit review.", variant: "destructive" });
+      }
+    } catch {
+      toast({ title: "Error", description: "Network error.", variant: "destructive" });
+    } finally { setSubmittingReview(false); }
+  };
 
   return (
     <div className="max-w-5xl mx-auto p-6">
@@ -113,7 +167,6 @@ export default function MealPlanDetailsPage() {
               Meal Planner
             </Button>
           </div>
-
           <h1 className="text-3xl font-bold truncate">
             {isLoading ? "Loading…" : blueprint?.title || "Meal Plan"}
           </h1>
@@ -123,7 +176,7 @@ export default function MealPlanDetailsPage() {
         </div>
 
         {blueprint ? (
-          <div className="flex flex-col items-end gap-2">
+          <div className="flex flex-col items-end gap-2 shrink-0">
             <div className="text-2xl font-bold">{formatMoney(blueprint.priceInCents)}</div>
             <div className="flex items-center gap-2">
               <Badge variant="secondary">{blueprint.category}</Badge>
@@ -145,6 +198,7 @@ export default function MealPlanDetailsPage() {
       ) : null}
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Left column */}
         <div className="lg:col-span-2 space-y-6">
           <Card>
             <CardHeader>
@@ -159,9 +213,7 @@ export default function MealPlanDetailsPage() {
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
-              {isLoading ? (
-                <div className="text-sm text-muted-foreground">Loading details…</div>
-              ) : null}
+              {isLoading ? <div className="text-sm text-muted-foreground">Loading details…</div> : null}
 
               {blueprint ? (
                 <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
@@ -182,10 +234,10 @@ export default function MealPlanDetailsPage() {
                 <>
                   <Separator />
                   <div className="flex flex-wrap gap-2">
-                    {(blueprint?.dietaryLabels || []).map((l) => (
+                    {(blueprint?.dietaryLabels || []).map(l => (
                       <Badge key={`dl-${l}`} variant="secondary">{l}</Badge>
                     ))}
-                    {(blueprint?.tags || []).map((t) => (
+                    {(blueprint?.tags || []).map(t => (
                       <Badge key={`tag-${t}`} variant="outline">#{t}</Badge>
                     ))}
                   </div>
@@ -217,7 +269,9 @@ export default function MealPlanDetailsPage() {
           </Card>
         </div>
 
+        {/* Right column */}
         <div className="space-y-6">
+          {/* Rating summary */}
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
@@ -232,26 +286,72 @@ export default function MealPlanDetailsPage() {
             </CardHeader>
             <CardContent className="space-y-3">
               {data?.reviews?.length ? (
-                data.reviews.map((r) => (
+                data.reviews.map(r => (
                   <div key={r.review.id} className="rounded-lg border p-3">
                     <div className="flex items-center justify-between gap-2">
-                      <div className="font-semibold text-sm truncate">{r.user.displayName || r.user.username}</div>
-                      <Badge variant="secondary">{r.review.rating} / 5</Badge>
+                      <div className="font-semibold text-sm truncate">
+                        {r.user.displayName || r.user.username}
+                        {user?.id === r.user.id && <span className="text-xs text-muted-foreground ml-1">(you)</span>}
+                      </div>
+                      <div className="flex items-center gap-1 shrink-0">
+                        {Array.from({ length: r.review.rating }).map((_, i) => (
+                          <Star key={i} className="w-3 h-3 fill-yellow-400 text-yellow-400" />
+                        ))}
+                      </div>
                     </div>
                     {r.review.comment ? (
-                      <div className="text-sm text-muted-foreground mt-2">{r.review.comment}</div>
-                    ) : (
-                      <div className="text-sm text-muted-foreground mt-2">No comment</div>
-                    )}
+                      <div className="text-sm text-muted-foreground mt-1">{r.review.comment}</div>
+                    ) : null}
                   </div>
                 ))
               ) : (
                 <div className="text-sm text-muted-foreground">No reviews yet.</div>
               )}
 
-              <div className="text-xs text-muted-foreground">
-                Want to browse more? Go back to <Link href="/nutrition/marketplace" className="underline">Marketplace</Link>.
+              <div className="text-xs text-muted-foreground pt-1">
+                Browse more in the <Link href="/nutrition/marketplace" className="underline">Marketplace</Link>.
               </div>
+            </CardContent>
+          </Card>
+
+          {/* Review form */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">
+                {myExistingReview ? "Update Your Review" : "Leave a Review"}
+              </CardTitle>
+              <CardDescription>
+                {user
+                  ? "You must have purchased this plan to leave a review."
+                  : "Sign in to leave a review."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {!user ? (
+                <Button variant="outline" className="w-full" onClick={() => setLocation("/auth/login")}>
+                  Sign in to review
+                </Button>
+              ) : (
+                <form onSubmit={handleSubmitReview} className="space-y-3">
+                  <div>
+                    <p className="text-sm font-medium mb-2">Your rating</p>
+                    <StarPicker
+                      value={myExistingReview ? (reviewRating || myExistingReview.review.rating) : reviewRating}
+                      onChange={setReviewRating}
+                    />
+                  </div>
+                  <Textarea
+                    placeholder="Share your experience with this meal plan (optional)…"
+                    value={reviewComment || (myExistingReview?.review.comment ?? "")}
+                    onChange={e => setReviewComment(e.target.value)}
+                    rows={3}
+                  />
+                  <Button type="submit" className="w-full" disabled={submittingReview}>
+                    <Send className="w-4 h-4 mr-2" />
+                    {submittingReview ? "Submitting…" : myExistingReview ? "Update Review" : "Submit Review"}
+                  </Button>
+                </form>
+              )}
             </CardContent>
           </Card>
         </div>

--- a/client/src/pages/pet-food/birds/index.tsx
+++ b/client/src/pages/pet-food/birds/index.tsx
@@ -432,6 +432,29 @@ export default function BirdsPage() {
     }
   };
 
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Bird Food Recipes',
+      text: 'Seed mixes, fruits, and treats for your feathered friends — browse bird food recipes on ChefSire.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-cyan-50 via-blue-50 to-sky-50">
       {/* RecipeKit Modal */}
@@ -465,7 +488,7 @@ export default function BirdsPage() {
               </Button>
             </Link>
             <div className="flex gap-2">
-              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
+              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20" onClick={handleSharePage}>
                 <Share2 className="h-4 w-4" />
               </Button>
               <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
@@ -521,7 +544,7 @@ export default function BirdsPage() {
           <CardContent className="p-6">
             <h3 className="text-lg font-bold text-gray-800 mb-4">Other Pet Food Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {sisterPetFoodPages.map((page) => {
+              {[...sisterPetFoodPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                 const Icon = page.icon;
                 return (
                   <Link key={page.id} href={page.path}>

--- a/client/src/pages/pet-food/cats/index.tsx
+++ b/client/src/pages/pet-food/cats/index.tsx
@@ -443,6 +443,29 @@ export default function CatsPage() {
     }
   };
 
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Cat Food Recipes',
+      text: 'High-protein, taurine-rich homemade meals for cats — browse cat food recipes on ChefSire.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 via-pink-50 to-fuchsia-50">
       {/* RecipeKit Modal */}
@@ -476,7 +499,7 @@ export default function CatsPage() {
               </Button>
             </Link>
             <div className="flex gap-2">
-              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
+              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20" onClick={handleSharePage}>
                 <Share2 className="h-4 w-4" />
               </Button>
               <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
@@ -532,7 +555,7 @@ export default function CatsPage() {
           <CardContent className="p-6">
             <h3 className="text-lg font-bold text-gray-800 mb-4">Other Pet Food Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {sisterPetFoodPages.map((page) => {
+              {[...sisterPetFoodPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                 const Icon = page.icon;
                 return (
                   <Link key={page.id} href={page.path}>

--- a/client/src/pages/pet-food/dogs/index.tsx
+++ b/client/src/pages/pet-food/dogs/index.tsx
@@ -434,6 +434,29 @@ export default function DogsPage() {
     }
   };
 
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Dog Food Recipes',
+      text: 'Nutritious homemade meals for your best friend — browse dog food recipes on ChefSire.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50">
       {/* RecipeKit Modal */}
@@ -467,7 +490,7 @@ export default function DogsPage() {
               </Button>
             </Link>
             <div className="flex gap-2">
-              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
+              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20" onClick={handleSharePage}>
                 <Share2 className="h-4 w-4" />
               </Button>
               <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
@@ -523,7 +546,7 @@ export default function DogsPage() {
           <CardContent className="p-6">
             <h3 className="text-lg font-bold text-gray-800 mb-4">Other Pet Food Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {sisterPetFoodPages.map((page) => {
+              {[...sisterPetFoodPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                 const Icon = page.icon;
                 return (
                   <Link key={page.id} href={page.path}>

--- a/client/src/pages/pet-food/index.tsx
+++ b/client/src/pages/pet-food/index.tsx
@@ -142,6 +142,29 @@ export default function PetFoodHub() {
   const [searchQuery, setSearchQuery] = useState('');
   const [hoveredCard, setHoveredCard] = useState<string | null>(null);
 
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Pet Food Recipes',
+      text: 'Homemade pet food recipes for dogs, cats, birds & small pets — browse on ChefSire.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-orange-50 via-purple-50 to-emerald-50">
       {/* HEADER */}
@@ -155,7 +178,7 @@ export default function PetFoodHub() {
               </Button>
             </Link>
             <div className="flex gap-2">
-              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
+              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20" onClick={handleSharePage}>
                 <Share2 className="h-4 w-4" />
               </Button>
               <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
@@ -249,7 +272,7 @@ export default function PetFoodHub() {
             Browse Pet Food Categories
           </h2>
           <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
-            {petCategories.map((category) => {
+            {[...petCategories].sort((a,b) => a.name.localeCompare(b.name)).map((category) => {
               const Icon = category.icon;
               return (
                 <Card

--- a/client/src/pages/pet-food/small-pets/index.tsx
+++ b/client/src/pages/pet-food/small-pets/index.tsx
@@ -432,6 +432,29 @@ export default function SmallPetsPage() {
     }
   };
 
+  const handleSharePage = async () => {
+    const shareData = {
+      title: 'Small Pet Food Recipes',
+      text: 'Hay-based diets and veggie mixes for rabbits, guinea pigs & more — browse small pet food recipes on ChefSire.',
+      url: typeof window !== 'undefined' ? window.location.href : ''
+    };
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}\n${shareData.url}`);
+        alert('Link copied to clipboard!');
+      } catch {
+        alert('Unable to share on this device.');
+      }
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-emerald-50 via-green-50 to-teal-50">
       {/* RecipeKit Modal */}
@@ -465,7 +488,7 @@ export default function SmallPetsPage() {
               </Button>
             </Link>
             <div className="flex gap-2">
-              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
+              <Button variant="ghost" size="sm" className="text-white hover:bg-white/20" onClick={handleSharePage}>
                 <Share2 className="h-4 w-4" />
               </Button>
               <Button variant="ghost" size="sm" className="text-white hover:bg-white/20">
@@ -521,7 +544,7 @@ export default function SmallPetsPage() {
           <CardContent className="p-6">
             <h3 className="text-lg font-bold text-gray-800 mb-4">Other Pet Food Categories</h3>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {sisterPetFoodPages.map((page) => {
+              {[...sisterPetFoodPages].sort((a,b) => a.name.localeCompare(b.name)).map((page) => {
                 const Icon = page.icon;
                 return (
                   <Link key={page.id} href={page.path}>

--- a/migrations/007_add_active_cleanse_programs.sql
+++ b/migrations/007_add_active_cleanse_programs.sql
@@ -1,0 +1,3 @@
+-- Add active cleanse programs tracking to user_drink_stats
+ALTER TABLE user_drink_stats
+  ADD COLUMN IF NOT EXISTS active_cleanse_programs jsonb NOT NULL DEFAULT '[]'::jsonb;

--- a/server/routes/meal-plans.ts
+++ b/server/routes/meal-plans.ts
@@ -406,6 +406,89 @@ router.post("/meal-plans/:id/review", requireAuth, async (req: Request, res: Res
   }
 });
 
+// Update meal plan blueprint (draft only)
+router.patch("/meal-plans/:id", requireAuth, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.id;
+    const planId = req.params.id;
+
+    const [existing] = await db
+      .select()
+      .from(mealPlanBlueprints)
+      .where(and(eq(mealPlanBlueprints.id, planId), eq(mealPlanBlueprints.creatorId, userId)))
+      .limit(1);
+
+    if (!existing) return res.status(404).json({ message: "Meal plan not found" });
+    if (existing.status === "published") {
+      return res.status(400).json({ message: "Published plans cannot be edited. Unpublish first." });
+    }
+
+    const {
+      title, description, priceInCents, duration, durationUnit,
+      category, difficulty, servings, dietaryLabels, tags,
+    } = req.body;
+
+    const [updated] = await db
+      .update(mealPlanBlueprints)
+      .set({
+        ...(title !== undefined && { title: title.trim() }),
+        ...(description !== undefined && { description: description || null }),
+        ...(priceInCents !== undefined && { priceInCents }),
+        ...(duration !== undefined && { duration }),
+        ...(durationUnit !== undefined && { durationUnit }),
+        ...(category !== undefined && { category }),
+        ...(difficulty !== undefined && { difficulty }),
+        ...(servings !== undefined && { servings }),
+        ...(dietaryLabels !== undefined && { dietaryLabels }),
+        ...(tags !== undefined && { tags }),
+      })
+      .where(eq(mealPlanBlueprints.id, planId))
+      .returning();
+
+    res.json({ blueprint: updated });
+  } catch (error) {
+    console.error("Error updating meal plan:", error);
+    res.status(500).json({ message: "Failed to update meal plan" });
+  }
+});
+
+// Delete meal plan blueprint (draft only, no purchases)
+router.delete("/meal-plans/:id", requireAuth, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.id;
+    const planId = req.params.id;
+
+    const [existing] = await db
+      .select()
+      .from(mealPlanBlueprints)
+      .where(and(eq(mealPlanBlueprints.id, planId), eq(mealPlanBlueprints.creatorId, userId)))
+      .limit(1);
+
+    if (!existing) return res.status(404).json({ message: "Meal plan not found" });
+    if (existing.status === "published") {
+      return res.status(400).json({ message: "Published plans cannot be deleted." });
+    }
+
+    const [hasPurchase] = await db
+      .select()
+      .from(mealPlanPurchases)
+      .where(eq(mealPlanPurchases.blueprintId, planId))
+      .limit(1);
+
+    if (hasPurchase) {
+      return res.status(400).json({ message: "Plans with purchases cannot be deleted." });
+    }
+
+    await db.delete(blueprintVersions).where(eq(blueprintVersions.blueprintId, planId));
+    await db.delete(mealPlanBlueprints).where(eq(mealPlanBlueprints.id, planId));
+
+    res.json({ ok: true });
+  } catch (error) {
+    console.error("Error deleting meal plan:", error);
+    res.status(500).json({ message: "Failed to delete meal plan" });
+  }
+});
+
 // Get creator analytics
 router.get("/analytics", requireAuth, async (req: Request, res: Response) => {
   try {

--- a/shared/schema/domains/drinks-creator.ts
+++ b/shared/schema/domains/drinks-creator.ts
@@ -495,5 +495,6 @@ export const userDrinkStats = pgTable("user_drink_stats", {
       earnedAt: string;
     }>
   >().default(sql`'[]'::jsonb`),
+  activeCleanseProgramIds: jsonb("active_cleanse_programs").$type<string[]>().default(sql`'[]'::jsonb`),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });


### PR DESCRIPTION
## Summary

- **Phase 1 — Fix broken features**: Added missing `PATCH /api/meal-plans/:id` and `DELETE /api/meal-plans/:id` routes; wired Edit and Delete buttons in `MealPlanCreator` with working modals and API calls; added review submission form to `MealPlanDetailsPage` with star picker, comment textarea, and cache invalidation on submit
- **Phase 2 — Diary → forward planner**: Visual planned/logged distinction (blue = future "Plan", orange = today "Log", gray = past); weekly projection card showing 7-day cumulative calories/protein/carbs/fat vs goals; grocery nudge toast when a meal is saved to a future date; updated empty state and button language throughout week, day, and month views

## Test plan

- [ ] Open Meal Planner → week view shows blue columns for future days, orange for today, gray for past
- [ ] "Plan" button appears on future slots, "Log" on today/past
- [ ] Add a meal to a future day → toast fires suggesting Grocery tab
- [ ] Weekly projection card appears once any meals exist, showing correct 7-day totals
- [ ] Month view: future days with meals show blue chips, past days show orange
- [ ] Go to Marketplace → open a meal plan detail page → submit a star rating + comment → review appears and stats update
- [ ] Go to My Plans (creator) → Edit button opens pre-filled form → save updates the plan
- [ ] Delete button visible on draft plans with 0 sales → confirmation modal → plan removed
- [ ] Edit button disabled on published plans with tooltip message

https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e)_