### PR TITLE
Add Fix It trend reason to meal planner completion block

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -2802,6 +2802,37 @@ const NutritionMealPlanner = () => {
     };
   }, [activeFixItDayCompletion, activeFixItResolvedBaseline]);
 
+  const activeFixItTrendReasonText = useMemo<string | null>(() => {
+    if (!activeFixItTarget?.issueType || !activeFixItDayCompletion || activeFixItResolvedBaseline === null) return null;
+    const delta = activeFixItDayCompletion.resolvedIssues - activeFixItResolvedBaseline;
+
+    if (activeFixItTarget.issueType === 'missing-meals') {
+      if (delta > 0) return 'You filled empty meal slots.';
+      if (delta < 0) return 'New empty meal slots appeared.';
+      return 'No changes to meal coverage.';
+    }
+
+    if (activeFixItTarget.issueType === 'missing-details') {
+      if (delta > 0) return 'You completed missing nutrition details.';
+      if (delta < 0) return 'More meals are missing details.';
+      return 'No changes to nutrition details.';
+    }
+
+    if (activeFixItTarget.issueType === 'low-protein') {
+      if (delta > 0) return 'Protein is closer to your target.';
+      if (delta < 0) return 'Protein dropped further from target.';
+      return 'No change in protein levels.';
+    }
+
+    if (activeFixItTarget.issueType === 'calorie-balance') {
+      if (delta > 0) return 'Calories are more balanced.';
+      if (delta < 0) return 'Calories moved further from target range.';
+      return 'No change in calorie balance.';
+    }
+
+    return null;
+  }, [activeFixItDayCompletion, activeFixItResolvedBaseline, activeFixItTarget?.issueType]);
+
   const activeFixItUnresolvedHint = useMemo<string | null>(() => {
     if (!activeFixItTarget || !activeFixItTarget.targetDay || !activeFixItProgressMiniState) return null;
     if (activeFixItProgressMiniState.unresolvedCount <= 0) return null;
@@ -3810,6 +3841,9 @@ const NutritionMealPlanner = () => {
                             )}
                             {activeFixItCompletionDeltaText ? (
                               <p className="mt-1 text-xs text-gray-600">{activeFixItCompletionDeltaText}</p>
+                            ) : null}
+                            {activeFixItTrendReasonText ? (
+                              <p className="mt-1 text-xs text-gray-500">{activeFixItTrendReasonText}</p>
                             ) : null}
                           </div>
                         ) : null}


### PR DESCRIPTION
### Motivation
- Users see a trend chip but not why the trend changed, so add a short explanatory line to make the Fix It Day Completion feedback more actionable. 
- The change must be additive, use only existing signals, and remain scoped to meal planning / nutrition UI only.

### Description
- Added a memoized `activeFixItTrendReasonText` in `client/src/components/NutritionMealPlanner.tsx` that returns `null` when active target/context is missing and otherwise maps `issueType` + completion delta direction to the exact reason strings for `missing-meals`, `missing-details`, `low-protein`, and `calorie-balance`.
- Rendered the trend reason directly under the existing completion delta line inside the Fix It Day Completion block with subtle styling (`text-xs text-gray-500`) and no new icons, badges, or chips.
- Change is additive and preserves all existing behavior: no backend, no persistence, no new data models, and no modifications to completion calculations, delta logic, or the trend chip.
- Files changed: `client/src/components/NutritionMealPlanner.tsx` only.

### Testing
- Ran `npm run build`, `npm run build:client`, and `npm run build:server`, and all builds completed successfully.
- The build regenerated drink/pet-food index artifacts but those files were restored before finalizing: `client/src/generated/drink-canonical.json`, `server/generated/drink-index.json`, and `server/generated/pet-food-index.json` were restored and not kept in the final change set.
- Validation conclusion: builds passed and the change is scoped, additive, and safe to merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5fcb39c04832589ee970133b1f0f4)