### PR TITLE
Update .gitignore to ignore build/test artifacts and logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,12 @@ server/.env
 /uploads
 /tmp
 server/generated/drink-index.json
+
+# build/test artifacts
+*.tsbuildinfo
+coverage/
+.nyc_output/
+.cache/
+.vite/
+.eslintcache
+*.log


### PR DESCRIPTION
### Motivation
- Prevent committing transient build, test and tooling cache files such as `*.tsbuildinfo`, `coverage/`, `.nyc_output/`, `.cache/`, `.vite/`, `.eslintcache`, and `*.log` so the repository remains clean.

### Description
- Added new ignore patterns to `.gitignore` for `*.tsbuildinfo`, `coverage/`, `.nyc_output/`, `.cache/`, `.vite/`, `.eslintcache`, and `*.log`.

### Testing
- No automated tests were run for this non-functional `.gitignore` change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f911fc4498832581b087d0ab5f523a)