### PR TITLE
Add Store Readiness + Fix It panel

### DIFF
--- a/client/src/components/store/StoreBuilder.tsx
+++ b/client/src/components/store/StoreBuilder.tsx
@@ -5,10 +5,14 @@ import { Card } from "@/components/ui/card";
 import { useUser } from "@/contexts/UserContext";
 import { useToast } from "@/hooks/use-toast";
 import { ArrowLeft } from "lucide-react";
+import StoreReadinessPanel from "@/pages/store/components/StoreReadinessPanel";
+import type { MarketplaceProduct } from "@/lib/store/marketplaceTypes";
 
 // ── Draggable building-block components ────────────────────────────────────────
 const Container = ({ children }: { children?: React.ReactNode }) => (
-  <div className="p-4 border border-gray-200 rounded min-h-[60px]">{children}</div>
+  <div className="p-4 border border-gray-200 rounded min-h-[60px]">
+    {children}
+  </div>
 );
 
 const TextBlock = ({ text }: { text: string }) => (
@@ -21,7 +25,11 @@ const Banner = () => (
   </div>
 );
 
-const ProductCardBlock = ({ product }: { product: { name: string; price: number } }) => (
+const ProductCardBlock = ({
+  product,
+}: {
+  product: { name: string; price: number };
+}) => (
   <Card className="w-64">
     <div className="p-4 font-semibold">{product.name}</div>
     <div className="px-4 pb-4 text-gray-700">${product.price}</div>
@@ -36,7 +44,9 @@ const EditOverlay = ({ render }: { render: React.ReactElement }) => (
   <div className="relative group">
     {render}
     <div className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity">
-      <span className="bg-orange-500 text-white text-xs px-2 py-0.5 rounded shadow">drag</span>
+      <span className="bg-orange-500 text-white text-xs px-2 py-0.5 rounded shadow">
+        drag
+      </span>
     </div>
   </div>
 );
@@ -64,10 +74,29 @@ const SaveButton = ({
 // ── Main StoreBuilder component ────────────────────────────────────────────────
 interface StoreBuilderProps {
   storeId: string;
+  store?: any;
+  products?: MarketplaceProduct[];
+  productsLoaded?: boolean;
   onBack: () => void;
+  onReadinessAction?: (
+    action:
+      | "description"
+      | "banner"
+      | "featured"
+      | "category"
+      | "product"
+      | "publish",
+  ) => void;
 }
 
-export default function StoreBuilder({ storeId, onBack }: StoreBuilderProps) {
+export default function StoreBuilder({
+  storeId,
+  store,
+  products,
+  productsLoaded = false,
+  onBack,
+  onReadinessAction,
+}: StoreBuilderProps) {
   const { user } = useUser();
   const { toast } = useToast();
   const [initialLayout, setInitialLayout] = useState<string | null>(null);
@@ -78,7 +107,9 @@ export default function StoreBuilder({ storeId, onBack }: StoreBuilderProps) {
     if (!storeId) return;
     (async () => {
       try {
-        const res = await fetch(`/api/stores-crud/${storeId}`, { credentials: "include" });
+        const res = await fetch(`/api/stores-crud/${storeId}`, {
+          credentials: "include",
+        });
         if (res.ok) {
           const data = await res.json();
           if (data.store?.layout) setInitialLayout(data.store.layout);
@@ -91,7 +122,11 @@ export default function StoreBuilder({ storeId, onBack }: StoreBuilderProps) {
 
   const handleSave = async (editorState: string) => {
     if (!storeId || !user) {
-      toast({ title: "No store found", description: "Please create a store first.", variant: "destructive" });
+      toast({
+        title: "No store found",
+        description: "Please create a store first.",
+        variant: "destructive",
+      });
       return;
     }
     setSaving(true);
@@ -106,11 +141,19 @@ export default function StoreBuilder({ storeId, onBack }: StoreBuilderProps) {
         toast({ description: "Store layout saved!" });
       } else {
         const err = await res.json();
-        toast({ title: "Save failed", description: err.error || "Please try again.", variant: "destructive" });
+        toast({
+          title: "Save failed",
+          description: err.error || "Please try again.",
+          variant: "destructive",
+        });
       }
     } catch (err) {
       console.error("Save error:", err);
-      toast({ title: "Save failed", description: "An error occurred.", variant: "destructive" });
+      toast({
+        title: "Save failed",
+        description: "An error occurred.",
+        variant: "destructive",
+      });
     } finally {
       setSaving(false);
     }
@@ -130,13 +173,26 @@ export default function StoreBuilder({ storeId, onBack }: StoreBuilderProps) {
                 <ArrowLeft className="w-4 h-4" />
                 Back to Dashboard
               </button>
-              <h1 className="text-2xl font-bold text-gray-900">Store Builder</h1>
+              <h1 className="text-2xl font-bold text-gray-900">
+                Store Builder
+              </h1>
               <p className="text-gray-500 text-sm mt-1">
                 Drag and drop elements to customise your storefront layout
               </p>
             </div>
             <SaveButton onSave={handleSave} saving={saving} />
           </div>
+
+          {store && onReadinessAction && (
+            <div className="mb-6">
+              <StoreReadinessPanel
+                store={store}
+                products={products}
+                productsLoaded={productsLoaded}
+                onAction={onReadinessAction}
+              />
+            </div>
+          )}
 
           <div className="flex gap-5">
             {/* Element Palette */}
@@ -146,22 +202,38 @@ export default function StoreBuilder({ storeId, onBack }: StoreBuilderProps) {
               </h2>
               <div className="space-y-2">
                 <Element is={Container} canvas>
-                  <Button variant="outline" className="w-full justify-start text-sm">
+                  <Button
+                    variant="outline"
+                    className="w-full justify-start text-sm"
+                  >
                     📦 Container
                   </Button>
                 </Element>
                 <Element is={TextBlock} text="Your text here" canvas>
-                  <Button variant="outline" className="w-full justify-start text-sm">
+                  <Button
+                    variant="outline"
+                    className="w-full justify-start text-sm"
+                  >
                     📝 Text Block
                   </Button>
                 </Element>
                 <Element is={Banner} canvas>
-                  <Button variant="outline" className="w-full justify-start text-sm">
+                  <Button
+                    variant="outline"
+                    className="w-full justify-start text-sm"
+                  >
                     🎨 Banner
                   </Button>
                 </Element>
-                <Element is={ProductCardBlock} product={{ name: "Sample Product", price: 9.99 }} canvas>
-                  <Button variant="outline" className="w-full justify-start text-sm">
+                <Element
+                  is={ProductCardBlock}
+                  product={{ name: "Sample Product", price: 9.99 }}
+                  canvas
+                >
+                  <Button
+                    variant="outline"
+                    className="w-full justify-start text-sm"
+                  >
                     🛍 Product Card
                   </Button>
                 </Element>

--- a/client/src/components/store/StoreCustomization.tsx
+++ b/client/src/components/store/StoreCustomization.tsx
@@ -1,93 +1,127 @@
-import React, { useState } from 'react';
-import { Upload, X, Plus, Instagram, Facebook, Twitter, Mail, Phone, MapPin } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Label } from '@/components/ui/label';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Switch } from '@/components/ui/switch';
-import { useToast } from '@/hooks/use-toast';
+import React, { useEffect, useState } from "react";
+import {
+  Upload,
+  X,
+  Plus,
+  Instagram,
+  Facebook,
+  Twitter,
+  Mail,
+  Phone,
+  MapPin,
+} from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Switch } from "@/components/ui/switch";
+import { useToast } from "@/hooks/use-toast";
 
 interface StoreCustomizationProps {
   store: any;
   onUpdate: (config: any) => void;
+  defaultTab?: string;
 }
 
-export default function StoreCustomization({ store, onUpdate }: StoreCustomizationProps) {
+export default function StoreCustomization({
+  store,
+  onUpdate,
+  defaultTab = "branding",
+}: StoreCustomizationProps) {
   const { toast } = useToast();
   const customization = store?.layout || {};
+  const [activeTab, setActiveTab] = useState(defaultTab);
+  const [profileBio, setProfileBio] = useState(store?.bio || "");
   const [config, setConfig] = useState({
-    logo: customization?.logo || '',
-    bannerImage: customization?.bannerImage || '',
-    bannerTitle: customization?.bannerTitle || '',
-    bannerSubtitle: customization?.bannerSubtitle || '',
+    logo: customization?.logo || "",
+    bannerImage: customization?.bannerImage || "",
+    bannerTitle: customization?.bannerTitle || "",
+    bannerSubtitle: customization?.bannerSubtitle || "",
     showBanner: customization?.showBanner !== false,
     aboutEnabled: customization?.aboutEnabled || false,
-    aboutTitle: customization?.aboutTitle || 'About Us',
-    aboutContent: customization?.aboutContent || '',
-    announcementBar: customization?.announcementBar || '',
+    aboutTitle: customization?.aboutTitle || "About Us",
+    aboutContent: customization?.aboutContent || "",
+    announcementBar: customization?.announcementBar || "",
     announcementEnabled: customization?.announcementEnabled || false,
     socialLinks: customization?.socialLinks || {
-      instagram: '',
-      facebook: '',
-      twitter: '',
-      email: '',
-      phone: '',
+      instagram: "",
+      facebook: "",
+      twitter: "",
+      email: "",
+      phone: "",
     },
     contactInfo: customization?.contactInfo || {
-      address: '',
-      hours: '',
+      address: "",
+      hours: "",
     },
     layout: customization?.layout || {
       gridColumns: 4,
-      productCardStyle: 'elevated',
-      spacing: 'normal',
+      productCardStyle: "elevated",
+      spacing: "normal",
     },
     colors: customization?.colors || {
-      primary: '#FF6B35',
-      secondary: '#2C3E50',
-      accent: '#F7F7F7',
+      primary: "#FF6B35",
+      secondary: "#2C3E50",
+      accent: "#F7F7F7",
     },
   });
 
   const [uploading, setUploading] = useState(false);
 
-  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>, field: 'logo' | 'bannerImage') => {
+  useEffect(() => {
+    setActiveTab(defaultTab);
+  }, [defaultTab]);
+
+  useEffect(() => {
+    setProfileBio(store?.bio || "");
+  }, [store?.bio]);
+
+  const handleImageUpload = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+    field: "logo" | "bannerImage",
+  ) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
     setUploading(true);
     const formData = new FormData();
-    formData.append('file', file);
+    formData.append("file", file);
 
     try {
-      const response = await fetch('/api/upload', {
-        method: 'POST',
+      const response = await fetch("/api/upload", {
+        method: "POST",
         body: formData,
-        credentials: 'include',
+        credentials: "include",
       });
 
       if (response.ok) {
         const data = await response.json();
-        setConfig(prev => ({ ...prev, [field]: data.url }));
+        setConfig((prev) => ({ ...prev, [field]: data.url }));
         toast({
-          title: 'Image uploaded',
-          description: 'Your image has been uploaded successfully',
+          title: "Image uploaded",
+          description: "Your image has been uploaded successfully",
         });
       } else {
         toast({
-          title: 'Upload failed',
-          description: 'Failed to upload image',
-          variant: 'destructive',
+          title: "Upload failed",
+          description: "Failed to upload image",
+          variant: "destructive",
         });
       }
     } catch (error) {
-      console.error('Upload error:', error);
+      console.error("Upload error:", error);
       toast({
-        title: 'Upload failed',
-        description: 'An error occurred',
-        variant: 'destructive',
+        title: "Upload failed",
+        description: "An error occurred",
+        variant: "destructive",
       });
     } finally {
       setUploading(false);
@@ -96,15 +130,15 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
 
   const handleSave = async () => {
     try {
-      await onUpdate({ customization: config });
+      await onUpdate({ bio: profileBio.trim() || null, customization: config });
     } catch (error) {
-      console.error('Save error:', error);
+      console.error("Save error:", error);
     }
   };
 
   return (
     <div className="space-y-6">
-      <Tabs defaultValue="branding" className="w-full">
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
         <TabsList className="grid w-full grid-cols-4">
           <TabsTrigger value="branding">Branding</TabsTrigger>
           <TabsTrigger value="sections">Sections</TabsTrigger>
@@ -114,18 +148,48 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
 
         {/* Branding Tab */}
         <TabsContent value="branding" className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Store Profile</CardTitle>
+              <CardDescription>
+                Keep the public store name and description polished.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <Label htmlFor="store-description">Store Description</Label>
+                <Textarea
+                  id="store-description"
+                  placeholder="Tell shoppers what your store specializes in..."
+                  value={profileBio}
+                  onChange={(e) => setProfileBio(e.target.value)}
+                  rows={4}
+                  className="mt-1"
+                />
+                <p className="mt-1 text-xs text-gray-500">
+                  This appears near the top of your public storefront.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
           {/* Logo Upload */}
           <Card>
             <CardHeader>
               <CardTitle>Store Logo</CardTitle>
-              <CardDescription>Upload your store logo (recommended: 200x200px)</CardDescription>
+              <CardDescription>
+                Upload your store logo (recommended: 200x200px)
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               {config.logo ? (
                 <div className="relative inline-block">
-                  <img src={config.logo} alt="Logo" className="h-32 w-32 object-contain border rounded-lg" />
+                  <img
+                    src={config.logo}
+                    alt="Logo"
+                    className="h-32 w-32 object-contain border rounded-lg"
+                  />
                   <button
-                    onClick={() => setConfig(prev => ({ ...prev, logo: '' }))}
+                    onClick={() => setConfig((prev) => ({ ...prev, logo: "" }))}
                     className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full p-1 hover:bg-red-600"
                   >
                     <X size={16} />
@@ -135,13 +199,15 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                 <label className="flex flex-col items-center justify-center w-full h-32 border-2 border-dashed border-gray-300 rounded-lg cursor-pointer hover:bg-gray-50">
                   <div className="flex flex-col items-center justify-center pt-5 pb-6">
                     <Upload className="w-8 h-8 mb-2 text-gray-400" />
-                    <p className="text-sm text-gray-500">Click to upload logo</p>
+                    <p className="text-sm text-gray-500">
+                      Click to upload logo
+                    </p>
                   </div>
                   <input
                     type="file"
                     className="hidden"
                     accept="image/*"
-                    onChange={(e) => handleImageUpload(e, 'logo')}
+                    onChange={(e) => handleImageUpload(e, "logo")}
                     disabled={uploading}
                   />
                 </label>
@@ -153,7 +219,9 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
           <Card>
             <CardHeader>
               <CardTitle>Custom Colors</CardTitle>
-              <CardDescription>Override theme colors with your brand colors</CardDescription>
+              <CardDescription>
+                Override theme colors with your brand colors
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="grid grid-cols-3 gap-4">
@@ -163,19 +231,23 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                     <Input
                       type="color"
                       value={config.colors.primary}
-                      onChange={(e) => setConfig(prev => ({
-                        ...prev,
-                        colors: { ...prev.colors, primary: e.target.value }
-                      }))}
+                      onChange={(e) =>
+                        setConfig((prev) => ({
+                          ...prev,
+                          colors: { ...prev.colors, primary: e.target.value },
+                        }))
+                      }
                       className="w-16 h-10"
                     />
                     <Input
                       type="text"
                       value={config.colors.primary}
-                      onChange={(e) => setConfig(prev => ({
-                        ...prev,
-                        colors: { ...prev.colors, primary: e.target.value }
-                      }))}
+                      onChange={(e) =>
+                        setConfig((prev) => ({
+                          ...prev,
+                          colors: { ...prev.colors, primary: e.target.value },
+                        }))
+                      }
                       className="flex-1"
                     />
                   </div>
@@ -186,19 +258,23 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                     <Input
                       type="color"
                       value={config.colors.secondary}
-                      onChange={(e) => setConfig(prev => ({
-                        ...prev,
-                        colors: { ...prev.colors, secondary: e.target.value }
-                      }))}
+                      onChange={(e) =>
+                        setConfig((prev) => ({
+                          ...prev,
+                          colors: { ...prev.colors, secondary: e.target.value },
+                        }))
+                      }
                       className="w-16 h-10"
                     />
                     <Input
                       type="text"
                       value={config.colors.secondary}
-                      onChange={(e) => setConfig(prev => ({
-                        ...prev,
-                        colors: { ...prev.colors, secondary: e.target.value }
-                      }))}
+                      onChange={(e) =>
+                        setConfig((prev) => ({
+                          ...prev,
+                          colors: { ...prev.colors, secondary: e.target.value },
+                        }))
+                      }
                       className="flex-1"
                     />
                   </div>
@@ -209,19 +285,23 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                     <Input
                       type="color"
                       value={config.colors.accent}
-                      onChange={(e) => setConfig(prev => ({
-                        ...prev,
-                        colors: { ...prev.colors, accent: e.target.value }
-                      }))}
+                      onChange={(e) =>
+                        setConfig((prev) => ({
+                          ...prev,
+                          colors: { ...prev.colors, accent: e.target.value },
+                        }))
+                      }
                       className="w-16 h-10"
                     />
                     <Input
                       type="text"
                       value={config.colors.accent}
-                      onChange={(e) => setConfig(prev => ({
-                        ...prev,
-                        colors: { ...prev.colors, accent: e.target.value }
-                      }))}
+                      onChange={(e) =>
+                        setConfig((prev) => ({
+                          ...prev,
+                          colors: { ...prev.colors, accent: e.target.value },
+                        }))
+                      }
                       className="flex-1"
                     />
                   </div>
@@ -239,11 +319,18 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
               <div className="flex items-center justify-between">
                 <div>
                   <CardTitle>Announcement Bar</CardTitle>
-                  <CardDescription>Show a message at the top of your store</CardDescription>
+                  <CardDescription>
+                    Show a message at the top of your store
+                  </CardDescription>
                 </div>
                 <Switch
                   checked={config.announcementEnabled}
-                  onCheckedChange={(checked) => setConfig(prev => ({ ...prev, announcementEnabled: checked }))}
+                  onCheckedChange={(checked) =>
+                    setConfig((prev) => ({
+                      ...prev,
+                      announcementEnabled: checked,
+                    }))
+                  }
                 />
               </div>
             </CardHeader>
@@ -252,7 +339,12 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                 <Input
                   placeholder="e.g., Free shipping on orders over $50!"
                   value={config.announcementBar}
-                  onChange={(e) => setConfig(prev => ({ ...prev, announcementBar: e.target.value }))}
+                  onChange={(e) =>
+                    setConfig((prev) => ({
+                      ...prev,
+                      announcementBar: e.target.value,
+                    }))
+                  }
                 />
               </CardContent>
             )}
@@ -264,11 +356,15 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
               <div className="flex items-center justify-between">
                 <div>
                   <CardTitle>Hero Banner</CardTitle>
-                  <CardDescription>Large banner image at the top of your store</CardDescription>
+                  <CardDescription>
+                    Large banner image at the top of your store
+                  </CardDescription>
                 </div>
                 <Switch
                   checked={config.showBanner}
-                  onCheckedChange={(checked) => setConfig(prev => ({ ...prev, showBanner: checked }))}
+                  onCheckedChange={(checked) =>
+                    setConfig((prev) => ({ ...prev, showBanner: checked }))
+                  }
                 />
               </div>
             </CardHeader>
@@ -276,9 +372,15 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
               <CardContent className="space-y-4">
                 {config.bannerImage ? (
                   <div className="relative">
-                    <img src={config.bannerImage} alt="Banner" className="w-full h-48 object-cover rounded-lg" />
+                    <img
+                      src={config.bannerImage}
+                      alt="Banner"
+                      className="w-full h-48 object-cover rounded-lg"
+                    />
                     <button
-                      onClick={() => setConfig(prev => ({ ...prev, bannerImage: '' }))}
+                      onClick={() =>
+                        setConfig((prev) => ({ ...prev, bannerImage: "" }))
+                      }
                       className="absolute top-2 right-2 bg-red-500 text-white rounded-full p-1 hover:bg-red-600"
                     >
                       <X size={16} />
@@ -288,14 +390,18 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                   <label className="flex flex-col items-center justify-center w-full h-48 border-2 border-dashed border-gray-300 rounded-lg cursor-pointer hover:bg-gray-50">
                     <div className="flex flex-col items-center justify-center">
                       <Upload className="w-8 h-8 mb-2 text-gray-400" />
-                      <p className="text-sm text-gray-500">Click to upload banner image</p>
-                      <p className="text-xs text-gray-400">Recommended: 1200x400px</p>
+                      <p className="text-sm text-gray-500">
+                        Click to upload banner image
+                      </p>
+                      <p className="text-xs text-gray-400">
+                        Recommended: 1200x400px
+                      </p>
                     </div>
                     <input
                       type="file"
                       className="hidden"
                       accept="image/*"
-                      onChange={(e) => handleImageUpload(e, 'bannerImage')}
+                      onChange={(e) => handleImageUpload(e, "bannerImage")}
                       disabled={uploading}
                     />
                   </label>
@@ -305,7 +411,12 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                   <Input
                     placeholder="Welcome to our store!"
                     value={config.bannerTitle}
-                    onChange={(e) => setConfig(prev => ({ ...prev, bannerTitle: e.target.value }))}
+                    onChange={(e) =>
+                      setConfig((prev) => ({
+                        ...prev,
+                        bannerTitle: e.target.value,
+                      }))
+                    }
                     className="mt-1"
                   />
                 </div>
@@ -314,7 +425,12 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                   <Input
                     placeholder="Discover amazing products"
                     value={config.bannerSubtitle}
-                    onChange={(e) => setConfig(prev => ({ ...prev, bannerSubtitle: e.target.value }))}
+                    onChange={(e) =>
+                      setConfig((prev) => ({
+                        ...prev,
+                        bannerSubtitle: e.target.value,
+                      }))
+                    }
                     className="mt-1"
                   />
                 </div>
@@ -328,11 +444,15 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
               <div className="flex items-center justify-between">
                 <div>
                   <CardTitle>About Section</CardTitle>
-                  <CardDescription>Tell customers about your store</CardDescription>
+                  <CardDescription>
+                    Tell customers about your store
+                  </CardDescription>
                 </div>
                 <Switch
                   checked={config.aboutEnabled}
-                  onCheckedChange={(checked) => setConfig(prev => ({ ...prev, aboutEnabled: checked }))}
+                  onCheckedChange={(checked) =>
+                    setConfig((prev) => ({ ...prev, aboutEnabled: checked }))
+                  }
                 />
               </div>
             </CardHeader>
@@ -342,7 +462,12 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                   <Label>Section Title</Label>
                   <Input
                     value={config.aboutTitle}
-                    onChange={(e) => setConfig(prev => ({ ...prev, aboutTitle: e.target.value }))}
+                    onChange={(e) =>
+                      setConfig((prev) => ({
+                        ...prev,
+                        aboutTitle: e.target.value,
+                      }))
+                    }
                     className="mt-1"
                   />
                 </div>
@@ -351,7 +476,12 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                   <Textarea
                     placeholder="Tell your story..."
                     value={config.aboutContent}
-                    onChange={(e) => setConfig(prev => ({ ...prev, aboutContent: e.target.value }))}
+                    onChange={(e) =>
+                      setConfig((prev) => ({
+                        ...prev,
+                        aboutContent: e.target.value,
+                      }))
+                    }
                     rows={6}
                     className="mt-1"
                   />
@@ -366,23 +496,27 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
           <Card>
             <CardHeader>
               <CardTitle>Product Grid Layout</CardTitle>
-              <CardDescription>Customize how products are displayed</CardDescription>
+              <CardDescription>
+                Customize how products are displayed
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-6">
               <div>
                 <Label>Grid Columns (Desktop)</Label>
                 <div className="grid grid-cols-4 gap-2 mt-2">
-                  {[2, 3, 4, 5].map(cols => (
+                  {[2, 3, 4, 5].map((cols) => (
                     <button
                       key={cols}
-                      onClick={() => setConfig(prev => ({
-                        ...prev,
-                        layout: { ...prev.layout, gridColumns: cols }
-                      }))}
+                      onClick={() =>
+                        setConfig((prev) => ({
+                          ...prev,
+                          layout: { ...prev.layout, gridColumns: cols },
+                        }))
+                      }
                       className={`p-4 border-2 rounded-lg text-center font-semibold transition-colors ${
                         config.layout.gridColumns === cols
-                          ? 'border-orange-500 bg-orange-50 text-orange-700'
-                          : 'border-gray-200 hover:border-gray-300'
+                          ? "border-orange-500 bg-orange-50 text-orange-700"
+                          : "border-gray-200 hover:border-gray-300"
                       }`}
                     >
                       {cols} Col
@@ -395,14 +529,19 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                 <Label>Card Style</Label>
                 <div className="grid grid-cols-2 gap-4 mt-2">
                   <button
-                    onClick={() => setConfig(prev => ({
-                      ...prev,
-                      layout: { ...prev.layout, productCardStyle: 'elevated' }
-                    }))}
+                    onClick={() =>
+                      setConfig((prev) => ({
+                        ...prev,
+                        layout: {
+                          ...prev.layout,
+                          productCardStyle: "elevated",
+                        },
+                      }))
+                    }
                     className={`p-6 border-2 rounded-lg transition-colors ${
-                      config.layout.productCardStyle === 'elevated'
-                        ? 'border-orange-500 bg-orange-50'
-                        : 'border-gray-200 hover:border-gray-300'
+                      config.layout.productCardStyle === "elevated"
+                        ? "border-orange-500 bg-orange-50"
+                        : "border-gray-200 hover:border-gray-300"
                     }`}
                   >
                     <div className="bg-white p-4 rounded-lg shadow-lg mb-2">
@@ -413,14 +552,16 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                     <p className="text-xs text-gray-500">Cards with shadow</p>
                   </button>
                   <button
-                    onClick={() => setConfig(prev => ({
-                      ...prev,
-                      layout: { ...prev.layout, productCardStyle: 'flat' }
-                    }))}
+                    onClick={() =>
+                      setConfig((prev) => ({
+                        ...prev,
+                        layout: { ...prev.layout, productCardStyle: "flat" },
+                      }))
+                    }
                     className={`p-6 border-2 rounded-lg transition-colors ${
-                      config.layout.productCardStyle === 'flat'
-                        ? 'border-orange-500 bg-orange-50'
-                        : 'border-gray-200 hover:border-gray-300'
+                      config.layout.productCardStyle === "flat"
+                        ? "border-orange-500 bg-orange-50"
+                        : "border-gray-200 hover:border-gray-300"
                     }`}
                   >
                     <div className="bg-white p-4 rounded-lg border mb-2">
@@ -437,20 +578,22 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                 <Label>Spacing</Label>
                 <div className="grid grid-cols-3 gap-2 mt-2">
                   {[
-                    { value: 'compact', label: 'Compact' },
-                    { value: 'normal', label: 'Normal' },
-                    { value: 'relaxed', label: 'Relaxed' },
-                  ].map(option => (
+                    { value: "compact", label: "Compact" },
+                    { value: "normal", label: "Normal" },
+                    { value: "relaxed", label: "Relaxed" },
+                  ].map((option) => (
                     <button
                       key={option.value}
-                      onClick={() => setConfig(prev => ({
-                        ...prev,
-                        layout: { ...prev.layout, spacing: option.value }
-                      }))}
+                      onClick={() =>
+                        setConfig((prev) => ({
+                          ...prev,
+                          layout: { ...prev.layout, spacing: option.value },
+                        }))
+                      }
                       className={`p-3 border-2 rounded-lg text-center text-sm font-medium transition-colors ${
                         config.layout.spacing === option.value
-                          ? 'border-orange-500 bg-orange-50 text-orange-700'
-                          : 'border-gray-200 hover:border-gray-300'
+                          ? "border-orange-500 bg-orange-50 text-orange-700"
+                          : "border-gray-200 hover:border-gray-300"
                       }`}
                     >
                       {option.label}
@@ -468,7 +611,9 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
           <Card>
             <CardHeader>
               <CardTitle>Social Media Links</CardTitle>
-              <CardDescription>Connect with customers on social platforms</CardDescription>
+              <CardDescription>
+                Connect with customers on social platforms
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               <div>
@@ -479,10 +624,15 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                 <Input
                   placeholder="https://instagram.com/yourstore"
                   value={config.socialLinks.instagram}
-                  onChange={(e) => setConfig(prev => ({
-                    ...prev,
-                    socialLinks: { ...prev.socialLinks, instagram: e.target.value }
-                  }))}
+                  onChange={(e) =>
+                    setConfig((prev) => ({
+                      ...prev,
+                      socialLinks: {
+                        ...prev.socialLinks,
+                        instagram: e.target.value,
+                      },
+                    }))
+                  }
                   className="mt-1"
                 />
               </div>
@@ -494,10 +644,15 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                 <Input
                   placeholder="https://facebook.com/yourstore"
                   value={config.socialLinks.facebook}
-                  onChange={(e) => setConfig(prev => ({
-                    ...prev,
-                    socialLinks: { ...prev.socialLinks, facebook: e.target.value }
-                  }))}
+                  onChange={(e) =>
+                    setConfig((prev) => ({
+                      ...prev,
+                      socialLinks: {
+                        ...prev.socialLinks,
+                        facebook: e.target.value,
+                      },
+                    }))
+                  }
                   className="mt-1"
                 />
               </div>
@@ -509,10 +664,15 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                 <Input
                   placeholder="https://twitter.com/yourstore"
                   value={config.socialLinks.twitter}
-                  onChange={(e) => setConfig(prev => ({
-                    ...prev,
-                    socialLinks: { ...prev.socialLinks, twitter: e.target.value }
-                  }))}
+                  onChange={(e) =>
+                    setConfig((prev) => ({
+                      ...prev,
+                      socialLinks: {
+                        ...prev.socialLinks,
+                        twitter: e.target.value,
+                      },
+                    }))
+                  }
                   className="mt-1"
                 />
               </div>
@@ -525,10 +685,15 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                   type="email"
                   placeholder="contact@yourstore.com"
                   value={config.socialLinks.email}
-                  onChange={(e) => setConfig(prev => ({
-                    ...prev,
-                    socialLinks: { ...prev.socialLinks, email: e.target.value }
-                  }))}
+                  onChange={(e) =>
+                    setConfig((prev) => ({
+                      ...prev,
+                      socialLinks: {
+                        ...prev.socialLinks,
+                        email: e.target.value,
+                      },
+                    }))
+                  }
                   className="mt-1"
                 />
               </div>
@@ -541,10 +706,15 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                   type="tel"
                   placeholder="(555) 123-4567"
                   value={config.socialLinks.phone}
-                  onChange={(e) => setConfig(prev => ({
-                    ...prev,
-                    socialLinks: { ...prev.socialLinks, phone: e.target.value }
-                  }))}
+                  onChange={(e) =>
+                    setConfig((prev) => ({
+                      ...prev,
+                      socialLinks: {
+                        ...prev.socialLinks,
+                        phone: e.target.value,
+                      },
+                    }))
+                  }
                   className="mt-1"
                 />
               </div>
@@ -555,7 +725,9 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
           <Card>
             <CardHeader>
               <CardTitle>Store Information</CardTitle>
-              <CardDescription>Display your store location and hours</CardDescription>
+              <CardDescription>
+                Display your store location and hours
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               <div>
@@ -566,10 +738,15 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                 <Textarea
                   placeholder="123 Main St, City, State 12345"
                   value={config.contactInfo.address}
-                  onChange={(e) => setConfig(prev => ({
-                    ...prev,
-                    contactInfo: { ...prev.contactInfo, address: e.target.value }
-                  }))}
+                  onChange={(e) =>
+                    setConfig((prev) => ({
+                      ...prev,
+                      contactInfo: {
+                        ...prev.contactInfo,
+                        address: e.target.value,
+                      },
+                    }))
+                  }
                   rows={3}
                   className="mt-1"
                 />
@@ -579,10 +756,15 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
                 <Textarea
                   placeholder="Mon-Fri: 9am-6pm&#10;Sat-Sun: 10am-4pm"
                   value={config.contactInfo.hours}
-                  onChange={(e) => setConfig(prev => ({
-                    ...prev,
-                    contactInfo: { ...prev.contactInfo, hours: e.target.value }
-                  }))}
+                  onChange={(e) =>
+                    setConfig((prev) => ({
+                      ...prev,
+                      contactInfo: {
+                        ...prev.contactInfo,
+                        hours: e.target.value,
+                      },
+                    }))
+                  }
                   rows={3}
                   className="mt-1"
                 />
@@ -595,12 +777,15 @@ export default function StoreCustomization({ store, onUpdate }: StoreCustomizati
       {/* Save Button */}
       <div className="flex justify-end gap-3 pt-4 border-t">
         <Button
-          onClick={() => window.location.href = `/store/${store.handle}`}
+          onClick={() => (window.location.href = `/store/${store.handle}`)}
           variant="outline"
         >
           Preview Store
         </Button>
-        <Button onClick={handleSave} className="bg-orange-500 hover:bg-orange-600">
+        <Button
+          onClick={handleSave}
+          className="bg-orange-500 hover:bg-orange-600"
+        >
           Save Changes
         </Button>
       </div>

--- a/client/src/pages/store/StoreDashboard.tsx
+++ b/client/src/pages/store/StoreDashboard.tsx
@@ -1,7 +1,13 @@
 import React, { useState, useEffect } from "react";
 import { useLocation } from "wouter";
 import {
-  Package, ShoppingCart, Edit, Sparkles, Palette, BarChart3, Crown,
+  Package,
+  ShoppingCart,
+  Edit,
+  Sparkles,
+  Palette,
+  BarChart3,
+  Crown,
 } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useUser } from "@/contexts/UserContext";
@@ -20,6 +26,8 @@ import StoreDashboardHeader from "./components/StoreDashboardHeader";
 import StoreDashboardProductsTab from "./components/StoreDashboardProductsTab";
 import StoreDashboardOrdersTab from "./components/StoreDashboardOrdersTab";
 import StoreDashboardCustomizeTab from "./components/StoreDashboardCustomizeTab";
+import StoreReadinessPanel from "./components/StoreReadinessPanel";
+import type { MarketplaceProduct } from "@/lib/store/marketplaceTypes";
 import StoreDashboardThemeTab from "./components/StoreDashboardThemeTab";
 import {
   buildSubscriptionCheckoutPayload,
@@ -40,11 +48,15 @@ export default function StoreDashboard() {
   const [stats, setStats] = useState<DashboardStats>(DEFAULT_DASHBOARD_STATS);
   const [tier, setTier] = useState<any>(null);
   const [recentSales, setRecentSales] = useState<any[]>([]);
+  const [products, setProducts] = useState<MarketplaceProduct[]>([]);
+  const [productsLoaded, setProductsLoaded] = useState(false);
   const [loading, setLoading] = useState(true);
   const [publishing, setPublishing] = useState(false);
   const [selectedTheme, setSelectedTheme] = useState("modern");
   const [showPlansModal, setShowPlansModal] = useState(false);
   const [showBuilder, setShowBuilder] = useState(false);
+  const [activeTab, setActiveTab] = useState("products");
+  const [customizeInitialTab, setCustomizeInitialTab] = useState("branding");
 
   useEffect(() => {
     if (user?.id) loadDashboard();
@@ -54,7 +66,9 @@ export default function StoreDashboard() {
     setLoading(true);
     try {
       // Load store
-      const storeRes = await fetch(`/api/stores/user/${user!.id}`, { credentials: "include" });
+      const storeRes = await fetch(`/api/stores/user/${user!.id}`, {
+        credentials: "include",
+      });
       if (storeRes.ok) {
         const storeData = await storeRes.json();
         const s = storeData.store;
@@ -65,36 +79,56 @@ export default function StoreDashboard() {
           // Products
           let productStats = getInitialProductStats();
           try {
-            const products = await getSellerMarketplaceProducts(user!.id, { credentials: "include" });
+            const sellerProducts = await getSellerMarketplaceProducts(
+              user!.id,
+              { credentials: "include" },
+            );
+            setProducts(sellerProducts);
+            setProductsLoaded(true);
             productStats = {
-              totalProducts: products.length,
-              publishedProducts: products.filter((p: any) => p.isActive).length,
+              totalProducts: sellerProducts.length,
+              publishedProducts: sellerProducts.filter((p: any) => p.isActive)
+                .length,
             };
           } catch {
+            setProducts([]);
+            setProductsLoaded(false);
             productStats = getInitialProductStats();
           }
 
           // Store stats
-          const statsRes = await fetch(`/api/stores/${s.id}/stats`, { credentials: "include" });
+          const statsRes = await fetch(`/api/stores/${s.id}/stats`, {
+            credentials: "include",
+          });
           let storeStats = getInitialStoreStats();
           if (statsRes.ok) {
             const sd = await statsRes.json();
             storeStats = sd.stats || storeStats;
           }
 
-          setStats({ ...productStats, totalViews: storeStats.totalViews, totalSales: storeStats.totalSales, revenue: storeStats.totalRevenue, monthlyRevenue: 0 });
+          setStats({
+            ...productStats,
+            totalViews: storeStats.totalViews,
+            totalSales: storeStats.totalSales,
+            revenue: storeStats.totalRevenue,
+            monthlyRevenue: 0,
+          });
         }
       }
 
       // Subscription tier
-      const tierRes = await fetch("/api/subscriptions/my-tier", { credentials: "include" });
+      const tierRes = await fetch("/api/subscriptions/my-tier", {
+        credentials: "include",
+      });
       if (tierRes.ok) {
         const td = await tierRes.json();
         setTier(td);
       }
 
       // Recent sales
-      const salesRes = await fetch("/api/orders/my-sales?limit=10", { credentials: "include" });
+      const salesRes = await fetch("/api/orders/my-sales?limit=10", {
+        credentials: "include",
+      });
       if (salesRes.ok) {
         const sd = await salesRes.json();
         setRecentSales(sd.sales || []);
@@ -126,10 +160,18 @@ export default function StoreDashboard() {
             : "Your store is now hidden from the public",
         });
       } else {
-        toast({ title: "Error", description: "Failed to update store status", variant: "destructive" });
+        toast({
+          title: "Error",
+          description: "Failed to update store status",
+          variant: "destructive",
+        });
       }
     } catch {
-      toast({ title: "Error", description: "An error occurred", variant: "destructive" });
+      toast({
+        title: "Error",
+        description: "An error occurred",
+        variant: "destructive",
+      });
     } finally {
       setPublishing(false);
     }
@@ -148,10 +190,18 @@ export default function StoreDashboard() {
       if (res.ok) {
         toast({ description: "Theme updated!" });
       } else {
-        toast({ title: "Error", description: "Failed to update theme", variant: "destructive" });
+        toast({
+          title: "Error",
+          description: "Failed to update theme",
+          variant: "destructive",
+        });
       }
     } catch {
-      toast({ title: "Error", description: "Failed to update theme", variant: "destructive" });
+      toast({
+        title: "Error",
+        description: "Failed to update theme",
+        variant: "destructive",
+      });
     }
   };
 
@@ -169,16 +219,72 @@ export default function StoreDashboard() {
         setStore(data.store);
         toast({ description: "Store customization saved!" });
       } else {
-        toast({ title: "Error", description: "Failed to save customization", variant: "destructive" });
+        toast({
+          title: "Error",
+          description: "Failed to save customization",
+          variant: "destructive",
+        });
       }
     } catch {
-      toast({ title: "Error", description: "Failed to save customization", variant: "destructive" });
+      toast({
+        title: "Error",
+        description: "Failed to save customization",
+        variant: "destructive",
+      });
     }
   };
 
-  const handleSubscriptionUpgrade = async (tierName: string, isTrial = false) => {
+  const handleReadinessAction = (
+    action:
+      | "description"
+      | "banner"
+      | "featured"
+      | "category"
+      | "product"
+      | "publish",
+  ) => {
+    if (action === "product" || action === "category") {
+      setLocation("/store/products/new");
+      return;
+    }
+
+    if (action === "description") {
+      setCustomizeInitialTab("branding");
+      setActiveTab("customize");
+      return;
+    }
+
+    if (action === "banner") {
+      setCustomizeInitialTab("sections");
+      setActiveTab("customize");
+      return;
+    }
+
+    if (action === "featured") {
+      setActiveTab("products");
+      toast({
+        title: "Choose a product",
+        description:
+          "Open a product and use the existing product controls to feature it, if available.",
+      });
+      return;
+    }
+
+    if (action === "publish") {
+      handleTogglePublish();
+    }
+  };
+
+  const handleSubscriptionUpgrade = async (
+    tierName: string,
+    isTrial = false,
+  ) => {
     if (!user) {
-      toast({ title: "Not logged in", description: "Please log in to upgrade.", variant: "destructive" });
+      toast({
+        title: "Not logged in",
+        description: "Please log in to upgrade.",
+        variant: "destructive",
+      });
       return;
     }
     try {
@@ -187,32 +293,59 @@ export default function StoreDashboard() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           ...buildSubscriptionCheckoutPayload(tierName, isTrial, user),
-        })
+        }),
       });
       const data = await resp.json();
       if (!resp.ok || !data?.url) {
         const errorMsg = data?.error || "Could not start checkout";
         if (isMissingPlanVariationError(errorMsg)) {
-          toast({ title: "Coming soon", description: "Subscription service is being configured. Please check back later.", variant: "destructive" });
+          toast({
+            title: "Coming soon",
+            description:
+              "Subscription service is being configured. Please check back later.",
+            variant: "destructive",
+          });
         } else {
-          toast({ title: "Checkout error", description: errorMsg, variant: "destructive" });
+          toast({
+            title: "Checkout error",
+            description: errorMsg,
+            variant: "destructive",
+          });
         }
         return;
       }
       // Optimistically update local trial state before redirect
       if (isTrial) {
-        const trialEnds = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+        const trialEnds = new Date(
+          Date.now() + 30 * 24 * 60 * 60 * 1000,
+        ).toISOString();
         updateUser({ subscription: tierName as any, trialEndDate: trialEnds });
       }
       window.location.href = data.url; // Redirect to Square-hosted checkout
     } catch (e) {
       console.error("Square upgrade error:", e);
-      toast({ title: "Checkout error", description: "There was a problem starting checkout. Please try again.", variant: "destructive" });
+      toast({
+        title: "Checkout error",
+        description: "There was a problem starting checkout. Please try again.",
+        variant: "destructive",
+      });
     }
   };
 
   if (showBuilder && store) {
-    return <StoreBuilder storeId={store.id} onBack={() => setShowBuilder(false)} />;
+    return (
+      <StoreBuilder
+        storeId={store.id}
+        store={store}
+        products={products}
+        productsLoaded={productsLoaded}
+        onBack={() => setShowBuilder(false)}
+        onReadinessAction={(action) => {
+          setShowBuilder(false);
+          handleReadinessAction(action);
+        }}
+      />
+    );
   }
 
   if (loading) {
@@ -221,7 +354,11 @@ export default function StoreDashboard() {
 
   // No store yet
   if (!store) {
-    return <StoreDashboardEmptyState onCreateStore={() => setLocation("/store/create")} />;
+    return (
+      <StoreDashboardEmptyState
+        onCreateStore={() => setLocation("/store/create")}
+      />
+    );
   }
 
   const currentTier = tier?.currentTier || user?.subscription || "free";
@@ -231,7 +368,6 @@ export default function StoreDashboard() {
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-
         <StoreDashboardHeader
           storeName={store.name}
           storeHandle={store.handle}
@@ -242,38 +378,59 @@ export default function StoreDashboard() {
           onTogglePublish={handleTogglePublish}
         />
 
+        <StoreReadinessPanel
+          store={store}
+          products={products}
+          productsLoaded={productsLoaded}
+          onAction={handleReadinessAction}
+        />
+
         {/* Stats Grid */}
         <StoreDashboardStatsGrid stats={stats} />
 
         {/* Main Tabs */}
-        <Tabs defaultValue="products" className="space-y-6">
+        <Tabs
+          value={activeTab}
+          onValueChange={setActiveTab}
+          className="space-y-6"
+        >
           <TabsList className="flex-wrap h-auto gap-1">
             <TabsTrigger value="products">
-              <Package className="w-4 h-4 mr-1.5" />Products
+              <Package className="w-4 h-4 mr-1.5" />
+              Products
             </TabsTrigger>
             <TabsTrigger value="orders">
-              <ShoppingCart className="w-4 h-4 mr-1.5" />Orders
+              <ShoppingCart className="w-4 h-4 mr-1.5" />
+              Orders
             </TabsTrigger>
             <TabsTrigger value="builder">
-              <Edit className="w-4 h-4 mr-1.5" />Store Builder
+              <Edit className="w-4 h-4 mr-1.5" />
+              Store Builder
             </TabsTrigger>
             <TabsTrigger value="customize">
-              <Sparkles className="w-4 h-4 mr-1.5" />Customize
+              <Sparkles className="w-4 h-4 mr-1.5" />
+              Customize
             </TabsTrigger>
             <TabsTrigger value="theme">
-              <Palette className="w-4 h-4 mr-1.5" />Theme
+              <Palette className="w-4 h-4 mr-1.5" />
+              Theme
             </TabsTrigger>
             <TabsTrigger value="analytics">
-              <BarChart3 className="w-4 h-4 mr-1.5" />Analytics
+              <BarChart3 className="w-4 h-4 mr-1.5" />
+              Analytics
             </TabsTrigger>
             <TabsTrigger value="subscription">
-              <Crown className="w-4 h-4 mr-1.5" />Subscription
+              <Crown className="w-4 h-4 mr-1.5" />
+              Subscription
             </TabsTrigger>
           </TabsList>
 
           {/* Products Tab */}
           <TabsContent value="products">
-            <StoreDashboardProductsTab sellerId={user!.id} totalProducts={stats.totalProducts} />
+            <StoreDashboardProductsTab
+              sellerId={user!.id}
+              totalProducts={stats.totalProducts}
+            />
           </TabsContent>
 
           {/* Orders Tab */}
@@ -283,17 +440,26 @@ export default function StoreDashboard() {
 
           {/* Store Builder Tab */}
           <TabsContent value="builder">
-            <StoreDashboardBuilderTab onOpenBuilder={() => setShowBuilder(true)} />
+            <StoreDashboardBuilderTab
+              onOpenBuilder={() => setShowBuilder(true)}
+            />
           </TabsContent>
 
           {/* Customize Tab */}
           <TabsContent value="customize">
-            <StoreDashboardCustomizeTab store={store} onUpdate={handleCustomizationUpdate} />
+            <StoreDashboardCustomizeTab
+              store={store}
+              onUpdate={handleCustomizationUpdate}
+              defaultTab={customizeInitialTab}
+            />
           </TabsContent>
 
           {/* Theme Tab */}
           <TabsContent value="theme">
-            <StoreDashboardThemeTab selectedTheme={selectedTheme} onSelectTheme={handleThemeChange} />
+            <StoreDashboardThemeTab
+              selectedTheme={selectedTheme}
+              onSelectTheme={handleThemeChange}
+            />
           </TabsContent>
 
           {/* Analytics Tab */}
@@ -316,7 +482,11 @@ export default function StoreDashboard() {
         <StoreDashboardQuickActions
           storeHandle={store.handle}
           onCustomerInsightsClick={() =>
-            toast({ title: "Coming Soon", description: "Customer insights will be available in a future update" })
+            toast({
+              title: "Coming Soon",
+              description:
+                "Customer insights will be available in a future update",
+            })
           }
         />
       </div>

--- a/client/src/pages/store/components/StoreDashboardCustomizeTab.tsx
+++ b/client/src/pages/store/components/StoreDashboardCustomizeTab.tsx
@@ -1,20 +1,37 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import StoreCustomization from "@/components/store/StoreCustomization";
 
 type StoreDashboardCustomizeTabProps = {
   store: any;
   onUpdate: (updates: any) => void;
+  defaultTab?: string;
 };
 
-export default function StoreDashboardCustomizeTab({ store, onUpdate }: StoreDashboardCustomizeTabProps) {
+export default function StoreDashboardCustomizeTab({
+  store,
+  onUpdate,
+  defaultTab,
+}: StoreDashboardCustomizeTabProps) {
   return (
     <Card>
       <CardHeader>
         <CardTitle>Store Customization</CardTitle>
-        <CardDescription>Branding, banner, about section, social links, and layout</CardDescription>
+        <CardDescription>
+          Branding, banner, about section, social links, and layout
+        </CardDescription>
       </CardHeader>
       <CardContent>
-        <StoreCustomization store={store} onUpdate={onUpdate} />
+        <StoreCustomization
+          store={store}
+          onUpdate={onUpdate}
+          defaultTab={defaultTab}
+        />
       </CardContent>
     </Card>
   );

--- a/client/src/pages/store/components/StoreReadinessPanel.tsx
+++ b/client/src/pages/store/components/StoreReadinessPanel.tsx
@@ -1,0 +1,279 @@
+import {
+  AlertCircle,
+  CheckCircle2,
+  Image,
+  Layers3,
+  PackagePlus,
+  PencilLine,
+  Star,
+  Store as StoreIcon,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import type { MarketplaceProduct } from "@/lib/store/marketplaceTypes";
+
+type ReadinessAction =
+  | "description"
+  | "banner"
+  | "featured"
+  | "category"
+  | "product"
+  | "publish";
+
+type StoreReadinessPanelProps = {
+  store: any;
+  products?: MarketplaceProduct[];
+  productsLoaded: boolean;
+  onAction: (action: ReadinessAction) => void;
+};
+
+type ReadinessSignal = {
+  key: string;
+  label: string;
+  description: string;
+  status: "ready" | "attention";
+  action?: {
+    label: string;
+    type: ReadinessAction;
+  };
+};
+
+const hasText = (value: unknown) =>
+  typeof value === "string" && value.trim().length > 0;
+
+const getLayoutObject = (store: any): Record<string, any> => {
+  const layout = store?.layout;
+  return layout && typeof layout === "object" && !Array.isArray(layout)
+    ? layout
+    : {};
+};
+
+const hasFeaturedField = (products: MarketplaceProduct[]) =>
+  products.some((product) =>
+    Object.prototype.hasOwnProperty.call(product, "isFeatured"),
+  );
+
+export function getStoreReadinessSignals(
+  store: any,
+  products: MarketplaceProduct[] | undefined,
+  productsLoaded: boolean,
+): ReadinessSignal[] {
+  const layout = getLayoutObject(store);
+  const productList = productsLoaded ? products || [] : undefined;
+  const signals: ReadinessSignal[] = [];
+
+  const hasDescription =
+    hasText(store?.bio) ||
+    (layout.aboutEnabled === true && hasText(layout.aboutContent));
+  if (!hasDescription) {
+    signals.push({
+      key: "missing-description",
+      label: "Store is missing a description",
+      description:
+        "Add a short bio or about section so shoppers know what you sell.",
+      status: "attention",
+      action: { label: "Add Description", type: "description" },
+    });
+  }
+
+  const bannerIsEnabled = layout.showBanner !== false;
+  if (bannerIsEnabled && !hasText(layout.bannerImage)) {
+    signals.push({
+      key: "missing-banner",
+      label: "Add a banner image",
+      description:
+        "A hero banner makes the storefront feel more polished at a glance.",
+      status: "attention",
+      action: { label: "Upload Banner", type: "banner" },
+    });
+  }
+
+  if (productList) {
+    if (productList.length === 0) {
+      signals.push({
+        key: "missing-products",
+        label: "Add your first product",
+        description:
+          "Your store needs at least one product before shoppers have something to browse.",
+        status: "attention",
+        action: { label: "Add First Product", type: "product" },
+      });
+    } else if (productList.length < 3) {
+      signals.push({
+        key: "catalog-depth",
+        label: "Add more products to improve discovery",
+        description: `${productList.length} product${productList.length === 1 ? "" : "s"} listed. A few more items can make the store feel fuller.`,
+        status: "attention",
+        action: { label: "Add Product", type: "product" },
+      });
+    }
+
+    const categoryCount = new Set(
+      productList
+        .map((product) => product.category)
+        .filter(
+          (category) =>
+            hasText(category) && category.trim().toLowerCase() !== "other",
+        ),
+    ).size;
+    if (productList.length > 0 && categoryCount === 0) {
+      signals.push({
+        key: "missing-categories",
+        label: "Store has no categories yet",
+        description:
+          "Use product categories to help customers understand your catalog quickly.",
+        status: "attention",
+        action: { label: "Create Category", type: "category" },
+      });
+    }
+
+    if (
+      productList.length > 0 &&
+      hasFeaturedField(productList) &&
+      !productList.some((product) => product.isFeatured)
+    ) {
+      signals.push({
+        key: "missing-featured-products",
+        label: "No featured products selected",
+        description:
+          "Feature one strong product to give new shoppers a clear starting point.",
+        status: "attention",
+        action: { label: "Add Featured Product", type: "featured" },
+      });
+    }
+  }
+
+  if (store?.published === false) {
+    signals.push({
+      key: "not-published",
+      label: "Store is not published",
+      description:
+        "Publish when the basics look good so customers can see your storefront.",
+      status: "attention",
+      action: { label: "Publish Store", type: "publish" },
+    });
+  }
+
+  if (signals.length === 0) {
+    signals.push({
+      key: "ready",
+      label: "Store looks ready to publish ✅",
+      description: store?.published
+        ? "Basics, catalog signals, and visibility look good."
+        : "Basics and catalog signals look good.",
+      status: "ready",
+    });
+  }
+
+  return signals;
+}
+
+const iconForSignal = (signal: ReadinessSignal) => {
+  if (signal.status === "ready")
+    return <CheckCircle2 className="h-4 w-4 text-green-600" />;
+  if (signal.key.includes("description"))
+    return <PencilLine className="h-4 w-4 text-orange-500" />;
+  if (signal.key.includes("banner"))
+    return <Image className="h-4 w-4 text-orange-500" />;
+  if (signal.key.includes("categor"))
+    return <Layers3 className="h-4 w-4 text-orange-500" />;
+  if (signal.key.includes("featured"))
+    return <Star className="h-4 w-4 text-orange-500" />;
+  if (signal.key.includes("product"))
+    return <PackagePlus className="h-4 w-4 text-orange-500" />;
+  return <AlertCircle className="h-4 w-4 text-orange-500" />;
+};
+
+export default function StoreReadinessPanel({
+  store,
+  products,
+  productsLoaded,
+  onAction,
+}: StoreReadinessPanelProps) {
+  const signals = getStoreReadinessSignals(store, products, productsLoaded);
+  const attentionSignals = signals.filter(
+    (signal) => signal.status === "attention",
+  );
+  const ready = attentionSignals.length === 0;
+  const totalChecks = ready ? signals.length : signals.length + 1;
+  const completedChecks = ready
+    ? signals.length
+    : Math.max(totalChecks - attentionSignals.length, 0);
+  const progress =
+    totalChecks > 0 ? Math.round((completedChecks / totalChecks) * 100) : 0;
+
+  return (
+    <Card className="border-orange-200 bg-gradient-to-r from-orange-50 via-white to-blue-50">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <StoreIcon className="h-5 w-5 text-orange-600" />
+              Store Readiness + Fix It
+            </CardTitle>
+            <CardDescription>
+              Lightweight checks to polish your storefront before sharing it.
+            </CardDescription>
+          </div>
+          <Badge
+            variant={ready ? "default" : "secondary"}
+            className={ready ? "bg-green-600 hover:bg-green-600" : ""}
+          >
+            {ready ? "Ready" : `${attentionSignals.length} to fix`}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-1">
+          <div className="flex items-center justify-between text-xs text-gray-600">
+            <span>Readiness progress</span>
+            <span>{progress}%</span>
+          </div>
+          <Progress value={progress} className="h-2" />
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2">
+          {signals.map((signal) => (
+            <div key={signal.key} className="rounded-lg border bg-white p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex gap-2">
+                  <div className="mt-0.5">{iconForSignal(signal)}</div>
+                  <div>
+                    <p className="text-sm font-medium text-gray-900">
+                      {signal.label}
+                    </p>
+                    <p className="mt-1 text-xs text-gray-600">
+                      {signal.description}
+                    </p>
+                  </div>
+                </div>
+                <Badge variant="outline" className="shrink-0">
+                  {signal.status === "ready" ? "Ready" : "Fix It"}
+                </Badge>
+              </div>
+              {signal.action && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="mt-3"
+                  onClick={() => onAction(signal.action!.type)}
+                >
+                  {signal.action.label}
+                </Button>
+              )}
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide lightweight readiness awareness and actionable “Fix It” guidance in the store dashboard and builder mirroring existing meal-planner readiness patterns.
- Surface obvious polish gaps (description, banner, catalog quality, categories, featured product, publish state) so sellers know what to fix before publishing without adding onboarding or backend changes.
- Keep changes strictly additive, reuse existing navigation/modals/forms, and avoid redesigning store systems.

### Description
- Added a new `StoreReadinessPanel` component that computes and displays readiness signals, a progress bar, and Fix It quick actions using only client state (`store`, `store.layout`, loaded seller products, categories, optional `isFeatured`, and `store.published`).
- Exact readiness signals added: “Store is missing a description”, “Add a banner image”, “Add your first product”, “Add more products to improve discovery”, “Store has no categories yet”, “No featured products selected”, “Store is not published”, and a positive “Store looks ready to publish ✅”.
- Exact quick actions added: `Add Description` (opens Customize→Branding), `Upload Banner` (opens Customize→Sections), `Add First Product` / `Add Product` and `Create Category` (route to `/store/products/new`), `Add Featured Product` (opens Products tab and guides to product controls when supported), and `Publish Store` (calls the existing publish toggle handler).
- Wired the panel into the top of `StoreDashboard` and inside the `StoreBuilder` editor; added loading of seller products to the dashboard (safe fallback when product fetch fails), and added a simple store description editor and `defaultTab` prop in the existing customization UI so readiness actions can deep-link into an existing flow without backend or schema changes.
- Files changed: `client/src/pages/store/components/StoreReadinessPanel.tsx` (new), `client/src/pages/store/StoreDashboard.tsx`, `client/src/components/store/StoreBuilder.tsx`, `client/src/components/store/StoreCustomization.tsx`, and `client/src/pages/store/components/StoreDashboardCustomizeTab.tsx`.

### Testing
- Ran `npm run build` and the full build completed successfully (client and server bundles produced). ✅
- Ran `npm run build:client` and `npm run build:server` individually and both completed successfully, with Vite/Esbuild warnings only about chunk sizes unrelated to this feature. ✅
- Ran `npm run check` (TypeScript) which surfaced pre-existing repository-wide type errors unrelated to these changes, so lint/type-check failures are not caused by this PR; readiness UI changes are pure UI additions that compile in the app build. ❌ (TS check reports are unrelated to this change)
- Restored generated artifacts after the build churn per instructions: `client/src/generated/drink-canonical.json`, `server/generated/drink-index.json`, and `server/generated/pet-food-index.json` (no rerun of build after restore).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc2b98c40832580afade316693fa7)