### PR TITLE
P1: BiteMap error boundary + SeasonalEvents upcoming label

### DIFF
--- a/client/src/components/SeasonalEvents.tsx
+++ b/client/src/components/SeasonalEvents.tsx
@@ -115,7 +115,7 @@ export function SeasonalEventsList() {
         <section>
           <div className="flex items-center gap-2 mb-4">
             <Calendar className="h-6 w-6 text-muted-foreground" />
-            <h2 className="text-2xl font-bold">Coming Soon</h2>
+            <h2 className="text-2xl font-bold">Upcoming Events</h2>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {upcoming.map((event) => (

--- a/client/src/pages/bitemap/index.tsx
+++ b/client/src/pages/bitemap/index.tsx
@@ -25,6 +25,7 @@ import { usePlaceDetails } from "@/hooks/usePlaceDetails";
 
 import MapView from "./components/MapView";
 import RestaurantCard from "./components/RestaurantCard";
+import { SectionErrorBoundary } from "@/components/ErrorBoundary";
 
 /* -----------------------------
    Minimal local modal
@@ -290,7 +291,9 @@ export default function BiteMapPage() {
       {/* Map */}
       {mapOpen && (
         <>
-          <MapView center={center} markers={markers} />
+          <SectionErrorBoundary sectionName="BiteMap">
+            <MapView center={center} markers={markers} />
+          </SectionErrorBoundary>
           <Separator className="my-2" />
         </>
       )}


### PR DESCRIPTION
## Summary

- **BiteMap error boundary** — wrap `MapView` in `SectionErrorBoundary` so a Google Maps API failure (missing key, network error, quota exceeded) shows a retry UI instead of crashing the whole BiteMap page
- **SeasonalEvents label** — rename the "Coming Soon" section heading to "Upcoming Events" (it labels the upcoming events section, not a placeholder)

## Test plan

- [ ] Open `/bitemap`, enable map view — confirm map still loads normally
- [ ] Simulate a Maps API failure (block the API script in devtools network) — confirm the map section shows the SectionErrorBoundary retry card instead of a white crash
- [ ] Open the events page with upcoming events — confirm the section heading now reads "Upcoming Events"

https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e)_