### PR TITLE
P2: Fix Instagram OAuth UX + stores.ts cleanup

### DIFF
--- a/client/src/components/SeasonalEvents.tsx
+++ b/client/src/components/SeasonalEvents.tsx
@@ -115,7 +115,7 @@ export function SeasonalEventsList() {
         <section>
           <div className="flex items-center gap-2 mb-4">
             <Calendar className="h-6 w-6 text-muted-foreground" />
-            <h2 className="text-2xl font-bold">Coming Soon</h2>
+            <h2 className="text-2xl font-bold">Upcoming Events</h2>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {upcoming.map((event) => (

--- a/client/src/pages/auth/login.tsx
+++ b/client/src/pages/auth/login.tsx
@@ -175,14 +175,8 @@ export default function LoginPage() {
               className="flex justify-center items-center gap-2 py-3 px-4 bg-white text-gray-700 rounded-2xl font-semibold hover:bg-gray-100 transition-all duration-200 shadow-md hover:shadow-lg"
             >
               <FaFacebook className="w-5 h-5 text-blue-600" />
-              <span className="hidden sm:inline">Facebook</span>
-            </a>
-            <a
-              href="/api/auth/instagram"
-              className="flex justify-center items-center gap-2 py-3 px-4 bg-white text-gray-700 rounded-2xl font-semibold hover:bg-gray-100 transition-all duration-200 shadow-md hover:shadow-lg"
-            >
-              <FaInstagram className="w-5 h-5 text-pink-600" />
-              <span className="hidden sm:inline">Instagram</span>
+              <FaInstagram className="w-4 h-4 text-pink-600" />
+              <span className="hidden sm:inline">Facebook / Instagram</span>
             </a>
             <a
               href="/api/auth/tiktok"

--- a/client/src/pages/auth/signup.tsx
+++ b/client/src/pages/auth/signup.tsx
@@ -943,14 +943,8 @@ export default function SignupPage() {
               className="flex justify-center items-center gap-2 py-3 px-4 bg-white text-gray-700 rounded-2xl font-semibold hover:bg-gray-100 transition-all duration-200 shadow-md hover:shadow-lg"
             >
               <FaFacebook className="w-5 h-5 text-blue-600" />
-              <span className="hidden sm:inline">Facebook</span>
-            </a>
-            <a
-              href="/api/auth/instagram"
-              className="flex justify-center items-center gap-2 py-3 px-4 bg-white text-gray-700 rounded-2xl font-semibold hover:bg-gray-100 transition-all duration-200 shadow-md hover:shadow-lg"
-            >
-              <FaInstagram className="w-5 h-5 text-pink-600" />
-              <span className="hidden sm:inline">Instagram</span>
+              <FaInstagram className="w-4 h-4 text-pink-600" />
+              <span className="hidden sm:inline">Facebook / Instagram</span>
             </a>
             <a
               href="/api/auth/tiktok"

--- a/client/src/pages/bitemap/index.tsx
+++ b/client/src/pages/bitemap/index.tsx
@@ -25,6 +25,7 @@ import { usePlaceDetails } from "@/hooks/usePlaceDetails";
 
 import MapView from "./components/MapView";
 import RestaurantCard from "./components/RestaurantCard";
+import { SectionErrorBoundary } from "@/components/ErrorBoundary";
 
 /* -----------------------------
    Minimal local modal
@@ -290,7 +291,9 @@ export default function BiteMapPage() {
       {/* Map */}
       {mapOpen && (
         <>
-          <MapView center={center} markers={markers} />
+          <SectionErrorBoundary sectionName="BiteMap">
+            <MapView center={center} markers={markers} />
+          </SectionErrorBoundary>
           <Separator className="my-2" />
         </>
       )}

--- a/server/routes/stores.ts
+++ b/server/routes/stores.ts
@@ -2,13 +2,7 @@ import { Router } from "express";
 
 const router = Router();
 
-/**
- * SQUARE PAYMENT ROUTES
- * ----------------------
- * This file is for Square payment integration routes.
- * Store management routes are in stores-crud.ts
- */
-
-// TODO: Add Square payment routes here if needed
+// Store management routes are in stores-crud.ts
+// Square payment routes are in payments.ts
 
 export default router;


### PR DESCRIPTION
## Summary

- **Instagram OAuth UX** — Instagram's Basic Display API is deprecated; Instagram login now goes through Facebook/Meta OAuth. The separate "Instagram" button was silently redirecting to Facebook, which was confusing. Merged into one "Facebook / Instagram" button showing both icons on login and signup pages.
- **stores.ts cleanup** — removed the stale "Add Square payment routes here" TODO comment. Square payment routes live in `payments.ts`; the comment was outdated and misleading.
- **P2 audit findings** — TikTok OAuth, store CRUD, product listing, order flow, and recipe fallbacks are all fully working. No gaps found beyond the Instagram UX issue above.

## Test plan

- [ ] Click "Facebook / Instagram" on login — confirm Facebook OAuth flow starts
- [ ] Click "Facebook / Instagram" on signup — confirm same
- [ ] Confirm no standalone "Instagram" button appears on either page

https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e)_