### PR TITLE
Add Product Quality Readiness panel

### DIFF
--- a/client/src/components/store/ProductManager.tsx
+++ b/client/src/components/store/ProductManager.tsx
@@ -5,7 +5,7 @@ import { Product } from '../../types/store';
 import { getStoreProducts, deleteProduct } from '../../lib/store/products';
 
 interface ProductManagerProps {
-  sellerId: string;
+  sellerId: string | number;
 }
 
 export const ProductManager: React.FC<ProductManagerProps> = ({ sellerId }) => {

--- a/client/src/components/store/StoreBuilder.tsx
+++ b/client/src/components/store/StoreBuilder.tsx
@@ -85,6 +85,7 @@ interface StoreBuilderProps {
       | "featured"
       | "category"
       | "product"
+      | "productQuality"
       | "publish",
   ) => void;
 }

--- a/client/src/lib/store/products.ts
+++ b/client/src/lib/store/products.ts
@@ -26,7 +26,7 @@ export const createProduct = async (productData: Omit<Product, 'id' | 'created_a
   return data.product;
 };
 
-export const getStoreProducts = async (sellerId: string): Promise<Product[]> => {
+export const getStoreProducts = async (sellerId: string | number): Promise<Product[]> => {
   const response = await fetch(`/api/marketplace/sellers/${sellerId}/products`, {
     credentials: 'include',
   });

--- a/client/src/pages/store/StoreDashboard.tsx
+++ b/client/src/pages/store/StoreDashboard.tsx
@@ -241,6 +241,7 @@ export default function StoreDashboard() {
       | "featured"
       | "category"
       | "product"
+      | "productQuality"
       | "publish",
   ) => {
     if (action === "product" || action === "category") {
@@ -251,6 +252,11 @@ export default function StoreDashboard() {
     if (action === "description") {
       setCustomizeInitialTab("branding");
       setActiveTab("customize");
+      return;
+    }
+
+    if (action === "productQuality") {
+      setActiveTab("products");
       return;
     }
 
@@ -430,6 +436,8 @@ export default function StoreDashboard() {
             <StoreDashboardProductsTab
               sellerId={user!.id}
               totalProducts={stats.totalProducts}
+              products={products}
+              productsLoaded={productsLoaded}
             />
           </TabsContent>
 

--- a/client/src/pages/store/components/ProductQualityReadinessPanel.tsx
+++ b/client/src/pages/store/components/ProductQualityReadinessPanel.tsx
@@ -1,0 +1,260 @@
+import {
+  AlertCircle,
+  CheckCircle2,
+  Image,
+  Layers3,
+  PackagePlus,
+  PencilLine,
+  ShoppingBag,
+} from "lucide-react";
+import { Link } from "wouter";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { MarketplaceProduct } from "@/lib/store/marketplaceTypes";
+
+type ProductQualityIssueKey =
+  | "missing-image"
+  | "missing-description"
+  | "missing-category"
+  | "out-of-stock"
+  | "not-active";
+
+type ProductQualityIssue = {
+  key: ProductQualityIssueKey;
+  label: string;
+};
+
+type ProductQualityAction = {
+  product: MarketplaceProduct;
+  issues: ProductQualityIssue[];
+};
+
+type ProductQualityReadinessPanelProps = {
+  products: MarketplaceProduct[];
+  productsLoaded: boolean;
+};
+
+const hasText = (value: unknown) =>
+  typeof value === "string" && value.trim().length > 0;
+
+const hasProductImage = (product: MarketplaceProduct) =>
+  Array.isArray(product.images) && product.images.some(hasText);
+
+const hasUsefulDescription = (product: MarketplaceProduct) =>
+  hasText(product.description) && product.description.trim().length >= 30;
+
+const hasUsefulCategory = (product: MarketplaceProduct) =>
+  hasText(product.category) &&
+  product.category.trim().toLowerCase() !== "other";
+
+export function getProductQualityActions(
+  products: MarketplaceProduct[],
+): ProductQualityAction[] {
+  return products
+    .map((product) => {
+      const issues: ProductQualityIssue[] = [];
+
+      if (!hasProductImage(product)) {
+        issues.push({
+          key: "missing-image",
+          label: "Add a clear product photo",
+        });
+      }
+
+      if (!hasUsefulDescription(product)) {
+        issues.push({
+          key: "missing-description",
+          label: "Write a fuller description",
+        });
+      }
+
+      if (!hasUsefulCategory(product)) {
+        issues.push({
+          key: "missing-category",
+          label: "Choose a specific category",
+        });
+      }
+
+      if (typeof product.inventory === "number" && product.inventory <= 0) {
+        issues.push({
+          key: "out-of-stock",
+          label: "Restock or update inventory",
+        });
+      }
+
+      if (product.isActive === false) {
+        issues.push({
+          key: "not-active",
+          label: "Make the listing active when ready",
+        });
+      }
+
+      return { product, issues };
+    })
+    .filter((action) => action.issues.length > 0)
+    .sort((a, b) => b.issues.length - a.issues.length);
+}
+
+const iconForIssue = (key: ProductQualityIssueKey) => {
+  if (key === "missing-image") return <Image className="h-3.5 w-3.5" />;
+  if (key === "missing-category")
+    return <Layers3 className="h-3.5 w-3.5" />;
+  if (key === "out-of-stock") return <ShoppingBag className="h-3.5 w-3.5" />;
+  if (key === "not-active") return <AlertCircle className="h-3.5 w-3.5" />;
+  return <PencilLine className="h-3.5 w-3.5" />;
+};
+
+export default function ProductQualityReadinessPanel({
+  products,
+  productsLoaded,
+}: ProductQualityReadinessPanelProps) {
+  if (!productsLoaded) {
+    return (
+      <Card className="border-dashed bg-gray-50">
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <ShoppingBag className="h-4 w-4 text-gray-500" />
+            Product Quality Readiness
+          </CardTitle>
+          <CardDescription>
+            Loading product checks from your current catalog.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  const qualityActions = getProductQualityActions(products);
+  const polishedCount = Math.max(products.length - qualityActions.length, 0);
+  const shownActions = qualityActions.slice(0, 4);
+  const remainingActions = Math.max(
+    qualityActions.length - shownActions.length,
+    0,
+  );
+
+  return (
+    <Card className="border-blue-100 bg-blue-50/40">
+      <CardHeader className="pb-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <ShoppingBag className="h-4 w-4 text-blue-600" />
+              Product Quality Readiness
+            </CardTitle>
+            <CardDescription>
+              Lightweight listing checks so the catalog feels polished in the storefront.
+            </CardDescription>
+          </div>
+          <Badge
+            variant={qualityActions.length === 0 ? "default" : "secondary"}
+            className={
+              qualityActions.length === 0
+                ? "bg-green-600 hover:bg-green-600"
+                : ""
+            }
+          >
+            {qualityActions.length === 0
+              ? "Products polished"
+              : `${qualityActions.length} product${
+                  qualityActions.length === 1 ? "" : "s"
+                } need attention`}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {products.length === 0 ? (
+          <div className="flex flex-col gap-3 rounded-lg border bg-white p-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="font-medium text-gray-900">
+                No products to review yet
+              </p>
+              <p className="mt-1 text-sm text-gray-600">
+                Add a product first, then this panel will point out any quick
+                listing polish.
+              </p>
+            </div>
+            <Link href="/store/products/new">
+              <Button className="bg-orange-500 hover:bg-orange-600">
+                <PackagePlus className="mr-1.5 h-4 w-4" />
+                Add Product
+              </Button>
+            </Link>
+          </div>
+        ) : qualityActions.length === 0 ? (
+          <div className="flex gap-3 rounded-lg border border-green-100 bg-white p-4">
+            <CheckCircle2 className="mt-0.5 h-5 w-5 text-green-600" />
+            <div>
+              <p className="font-medium text-gray-900">
+                Your current products cover the basics.
+              </p>
+              <p className="mt-1 text-sm text-gray-600">
+                Photos, descriptions, categories, inventory, and active status
+                look ready for shoppers.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between text-sm text-gray-600">
+              <span>
+                {polishedCount} of {products.length} products pass these quick
+                checks.
+              </span>
+              <span>
+                {qualityActions.length} action
+                {qualityActions.length === 1 ? "" : "s"}
+              </span>
+            </div>
+            {shownActions.map(({ product, issues }) => (
+              <div key={product.id} className="rounded-lg border bg-white p-3">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <p className="font-medium text-gray-900">
+                      {product.name || "Untitled product"}
+                    </p>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {issues.slice(0, 3).map((issue) => (
+                        <Badge
+                          key={issue.key}
+                          variant="outline"
+                          className="gap-1 bg-orange-50 text-orange-700"
+                        >
+                          {iconForIssue(issue.key)}
+                          {issue.label}
+                        </Badge>
+                      ))}
+                      {issues.length > 3 ? (
+                        <Badge variant="outline">
+                          +{issues.length - 3} more
+                        </Badge>
+                      ) : null}
+                    </div>
+                  </div>
+                  <Link href={`/store/products/edit/${product.id}`}>
+                    <Button type="button" variant="outline" size="sm">
+                      Edit Product
+                    </Button>
+                  </Link>
+                </div>
+              </div>
+            ))}
+            {remainingActions > 0 ? (
+              <p className="text-xs text-gray-500">
+                {remainingActions} more product
+                {remainingActions === 1 ? "" : "s"} also need quick polish. Use
+                the product list below to continue.
+              </p>
+            ) : null}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/pages/store/components/StoreDashboardProductsTab.tsx
+++ b/client/src/pages/store/components/StoreDashboardProductsTab.tsx
@@ -1,34 +1,56 @@
 import { Link } from "wouter";
 import { Plus } from "lucide-react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ProductManager } from "@/components/store/ProductManager";
+import type { MarketplaceProduct } from "@/lib/store/marketplaceTypes";
+import ProductQualityReadinessPanel from "./ProductQualityReadinessPanel";
 
 type StoreDashboardProductsTabProps = {
   sellerId: number;
   totalProducts: number;
+  products: MarketplaceProduct[];
+  productsLoaded: boolean;
 };
 
-export default function StoreDashboardProductsTab({ sellerId, totalProducts }: StoreDashboardProductsTabProps) {
+export default function StoreDashboardProductsTab({
+  sellerId,
+  totalProducts,
+  products,
+  productsLoaded,
+}: StoreDashboardProductsTabProps) {
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center justify-between">
-          <div>
-            <CardTitle>Product Management</CardTitle>
-            <CardDescription>Manage your store's product listings</CardDescription>
+    <div className="space-y-4">
+      <ProductQualityReadinessPanel
+        products={products}
+        productsLoaded={productsLoaded}
+      />
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>Product Management</CardTitle>
+              <CardDescription>Manage your store's product listings</CardDescription>
+            </div>
+            <Link href="/store/products/new">
+              <Button className="bg-orange-500 hover:bg-orange-600">
+                <Plus className="w-4 h-4 mr-1.5" />
+                {totalProducts === 0 ? "Add First Product" : "Add Product"}
+              </Button>
+            </Link>
           </div>
-          <Link href="/store/products/new">
-            <Button className="bg-orange-500 hover:bg-orange-600">
-              <Plus className="w-4 h-4 mr-1.5" />
-              {totalProducts === 0 ? "Add First Product" : "Add Product"}
-            </Button>
-          </Link>
-        </div>
-      </CardHeader>
-      <CardContent>
-        <ProductManager sellerId={sellerId} />
-      </CardContent>
-    </Card>
+        </CardHeader>
+        <CardContent>
+          <ProductManager sellerId={sellerId} />
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/client/src/pages/store/components/StoreReadinessPanel.tsx
+++ b/client/src/pages/store/components/StoreReadinessPanel.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import type { MarketplaceProduct } from "@/lib/store/marketplaceTypes";
+import { getProductQualityActions } from "./ProductQualityReadinessPanel";
 
 type ReadinessAction =
   | "description"
@@ -26,6 +27,7 @@ type ReadinessAction =
   | "featured"
   | "category"
   | "product"
+  | "productQuality"
   | "publish";
 
 type StoreReadinessPanelProps = {
@@ -147,6 +149,18 @@ export function getStoreReadinessSignals(
           "Feature one strong product to give new shoppers a clear starting point.",
         status: "attention",
         action: { label: "Add Featured Product", type: "featured" },
+      });
+    }
+
+    const productQualityActions = getProductQualityActions(productList);
+    if (productQualityActions.length > 0) {
+      signals.push({
+        key: "product-quality",
+        label: `${productQualityActions.length} product${productQualityActions.length === 1 ? "" : "s"} need polish`,
+        description:
+          "Review product photos, descriptions, categories, inventory, and active status before sharing the store.",
+        status: "attention",
+        action: { label: "Review Products", type: "productQuality" },
       });
     }
   }


### PR DESCRIPTION
### Motivation
- Provide lightweight product-level quality guidance so sellers can quickly see which listings need attention before the storefront feels polished. 
- Keep the change UI-only and additive, reusing existing product edit/create routes and avoiding backend changes.

### Description
- Add a new `ProductQualityReadinessPanel` component with `getProductQualityActions` that flags missing images, thin descriptions, generic/missing categories, out-of-stock inventory, and inactive listings (`client/src/pages/store/components/ProductQualityReadinessPanel.tsx`).
- Surface product-quality signal in the existing store-level readiness checks by calling `getProductQualityActions` inside `getStoreReadinessSignals` and exposing a `Review Products` action that routes to the products tab (`client/src/pages/store/components/StoreReadinessPanel.tsx`).
- Embed the new panel above the product manager in the Products tab and pass already-loaded marketplace products into the tab so the panel is UI-only (`client/src/pages/store/components/StoreDashboardProductsTab.tsx`, `client/src/pages/store/StoreDashboard.tsx`).
- Preserve existing flows and quick actions by linking to `/store/products/new` and `/store/products/edit/:id` for add/edit, and add a `productQuality` readiness action type routed to the Products tab; widen seller ID types where needed (`client/src/components/store/ProductManager.tsx`, `client/src/lib/store/products.ts`, `client/src/components/store/StoreBuilder.tsx`).

### Testing
- Ran `npm run build:client` which completed successfully and produced the client bundles. 
- Ran the repo type-check `npm run check` (runs `tsc`) which reported unrelated, pre-existing TypeScript issues across the repo; these failures are outside the scope of this UI-only change and did not block the client build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0465e4888325b8a234dc9de80d43)