### PR TITLE
Stabilize Potent Potables image fallbacks

### DIFF
--- a/client/src/generated/drink-canonical.json
+++ b/client/src/generated/drink-canonical.json
@@ -13592,7 +13592,7 @@
           "Stir gently",
           "Express orange peel over drink and garnish with cherry"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "https://images.unsplash.com/photo-1514362545857-3bc16c4c7d1b?w=400&h=300&fit=crop"
       }
     },
     {
@@ -36364,7 +36364,7 @@
           "Stir gently",
           "Express orange peel over drink and garnish with cherry"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "https://images.unsplash.com/photo-1514362545857-3bc16c4c7d1b?w=400&h=300&fit=crop"
       }
     },
     "martini": {
@@ -45543,5 +45543,5 @@
       }
     }
   },
-  "generatedAt": "2026-05-08T00:40:50.720Z"
+  "generatedAt": "2026-05-09T12:49:49.355Z"
 }

--- a/scripts/generate-drink-index.ts
+++ b/scripts/generate-drink-index.ts
@@ -64,12 +64,22 @@ const POTENT_POTABLES_ROUTE_ASSET_PATHS: Record<string, string> = {
   '/drinks/potent-potables/whiskey-bourbon': `${POTENT_POTABLES_ASSET_BASE}/whiskey-bourbon.svg`,
 };
 
-function getRecipeImage(recipe: DrinkRecipeLike, sourceRoute: string): string | null {
-  const localPotentPotablesImage = POTENT_POTABLES_ROUTE_ASSET_PATHS[sourceRoute];
-  if (localPotentPotablesImage) return localPotentPotablesImage;
+function getExplicitRecipeImage(recipe: DrinkRecipeLike): string | null {
   if (typeof recipe.image === 'string' && recipe.image.trim()) return recipe.image;
   if (typeof recipe.imageUrl === 'string' && recipe.imageUrl.trim()) return recipe.imageUrl;
   return null;
+}
+
+function getRouteFallbackImage(sourceRoute: string): string | null {
+  return POTENT_POTABLES_ROUTE_ASSET_PATHS[sourceRoute] ?? null;
+}
+
+function getRecipeImage(recipe: DrinkRecipeLike, sourceRoute: string): string | null {
+  return getExplicitRecipeImage(recipe) ?? getRouteFallbackImage(sourceRoute);
+}
+
+function isPotentPotablesLocalAsset(image: string | null | undefined): boolean {
+  return typeof image === 'string' && image.startsWith(`${POTENT_POTABLES_ASSET_BASE}/`);
 }
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -158,7 +168,7 @@ function asStringList(value: unknown): string[] {
   return [];
 }
 
-function normalizeRecipe(recipe: Record<string, unknown>, sourceTitle: string, sourceRoute: string): Record<string, unknown> {
+function normalizeRecipe(recipe: Record<string, unknown>, sourceTitle: string, sourceRoute: string, imageOverride?: string | null): Record<string, unknown> {
   const nestedRecipe = recipe?.recipe as { measurements?: unknown[]; directions?: unknown } | undefined;
   const nestedMeasurements = Array.isArray(nestedRecipe?.measurements)
     ? nestedRecipe.measurements
@@ -183,7 +193,7 @@ function normalizeRecipe(recipe: Record<string, unknown>, sourceTitle: string, s
   );
   const defaultInstruction = `Follow the preparation method shown on the ${sourceTitle} card and serve immediately.`;
 
-  const fallbackImage = getRecipeImage(recipe as DrinkRecipeLike, sourceRoute);
+  const fallbackImage = imageOverride ?? getRecipeImage(recipe as DrinkRecipeLike, sourceRoute);
 
   return {
     ...recipe,
@@ -271,16 +281,23 @@ async function main() {
             duplicateRoute: existing.sourceRoute,
           });
 
+          const nextExplicitImage = getExplicitRecipeImage(recipe);
+          const resolvedImage =
+            nextExplicitImage ??
+            (isPotentPotablesLocalAsset(existing.image)
+              ? getRouteFallbackImage(routeEntry.route)
+              : existing.image) ??
+            getRouteFallbackImage(routeEntry.route);
+
           existing.sourceRoute = routeEntry.route;
           existing.sourceTitle = routeEntry.title;
-          existing.image =
-            getRecipeImage(recipe, routeEntry.route) ?? existing.image;
+          existing.image = resolvedImage;
 
           const canonicalEntry = canonicalEntryByKey[key];
           if (canonicalEntry) {
             canonicalEntry.sourceRoute = routeEntry.route;
             canonicalEntry.sourceTitle = routeEntry.title;
-            canonicalEntry.recipe = normalizeRecipe(recipe as Record<string, unknown>, routeEntry.title, routeEntry.route);
+            canonicalEntry.recipe = normalizeRecipe(recipe as Record<string, unknown>, routeEntry.title, routeEntry.route, resolvedImage);
           }
         } else {
           duplicates.push({

--- a/server/generated/drink-index.json
+++ b/server/generated/drink-index.json
@@ -1805,7 +1805,7 @@
       "slug": "old-fashioned",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "https://images.unsplash.com/photo-1514362545857-3bc16c4c7d1b?w=400&h=300&fit=crop",
       "route": "/drinks/recipe/old-fashioned"
     },
     "martini": {
@@ -4999,7 +4999,7 @@
       "slug": "old-fashioned",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "https://images.unsplash.com/photo-1514362545857-3bc16c4c7d1b?w=400&h=300&fit=crop",
       "route": "/drinks/recipe/old-fashioned"
     },
     "martini": {
@@ -6721,5 +6721,5 @@
       "duplicateRoute": "/drinks/potent-potables/whiskey-bourbon"
     }
   ],
-  "generatedAt": "2026-05-08T00:40:50.720Z"
+  "generatedAt": "2026-05-09T12:49:49.355Z"
 }


### PR DESCRIPTION
### Motivation
- The drink-index generator was choosing Potent Potables category SVGs before explicit recipe images, which downgraded richer recipe photography when duplicate route resolution moved recipes into Potent Potables.
- Fix must be minimal and preserve existing local SVG category artwork as fallbacks while restoring recipe-specific imagery where present.

### Description
- Change image selection order in `scripts/generate-drink-index.ts` to prefer explicit `recipe.image` / `recipe.imageUrl` first, then the Potent Potables route/category SVG fallback. (added `getExplicitRecipeImage`, `getRouteFallbackImage`, `getRecipeImage`).
- When a duplicate recipe is reassigned to a higher-priority Potent Potables route, preserve existing non-local explicit images (or the newly explicit image) rather than unconditionally overwriting with the category SVG; propagate the resolved image into the canonical entry via `normalizeRecipe(..., imageOverride)`. (duplicate-route resolution logic updated).
- Regenerated drink index outputs to reflect the corrected behavior so recipes with richer explicit images (e.g., Old Fashioned) keep those images while other Potent Potables entries still use local SVG fallbacks; updated files: `server/generated/drink-index.json`, `client/src/generated/drink-canonical.json`.
- Confirmed local SVG assets and route/category mappings remain intact and are still used as fallbacks (see `client/src/constants/drink-images.ts`).

Files changed:
- `scripts/generate-drink-index.ts`
- `server/generated/drink-index.json` (regenerated)
- `client/src/generated/drink-canonical.json` (regenerated)

Current fallback hierarchy after this pass:
- Index generation: explicit recipe `image` / `imageUrl` → Potent Potables route/category SVG → null.
- Canonicalization on duplicate: prefer explicit recipe images, preserve non-local explicit images over local SVG fallbacks, otherwise use route SVG.
- Recipe page render: canonical recipe image/imageUrl → user recipe image → category fallback; on image load error swap to category fallback.

### Testing
- Ran `npm run generate:drink-index` to regenerate indexes and validate image selection behavior; command completed and reported indexing (see logs). (success)
- Ran `npm run verify:drink-index` to confirm generated file presence and counts; command completed and verified `/server/generated/drink-index.json` with expected entries. (success)
- Verified that all referenced Potent Potables SVG paths exist under `client/public/images/drinks/potent-potables` with a quick path-existence check of constants → no missing assets. (success)
- Built client and server with `npm run build:client` and `npm run build:server` to ensure runtime packaging is unaffected; builds completed successfully (Vite produced standard warnings unrelated to this change). (success)

All automated checks passed and the change is safe to merge; recommended next step is to curate richer recipe-specific imagery for high-traffic Potent Potables recipes so SVGs remain fallbacks rather than dominant visuals.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff2a6bbcdc8325af83491a8c9f6215)