### PR TITLE
Add premium Potent Potables drink imagery

### DIFF
--- a/client/public/images/drinks/potent-potables/premium/daiquiri.svg
+++ b/client/public/images/drinks/potent-potables/premium/daiquiri.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">ChefSire Daiquiri premium drink artwork</title>
+  <desc id="desc">Classic daiquiri coupe with rum, lime, simple syrup, and citrus garnish.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#053b49"/><stop offset="1" stop-color="#33bfd0"/></linearGradient>
+    <linearGradient id="glass" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#ffffff" stop-opacity=".52"/><stop offset=".5" stop-color="#ffffff" stop-opacity=".15"/><stop offset="1" stop-color="#ffffff" stop-opacity=".36"/></linearGradient>
+    <radialGradient id="halo" cx="50%" cy="42%" r="58%"><stop stop-color="#b9f44a" stop-opacity=".55"/><stop offset="1" stop-color="#b9f44a" stop-opacity="0"/></radialGradient>
+  </defs>
+  <rect width="960" height="540" rx="0" fill="url(#bg)"/>
+  <circle cx="480" cy="256" r="280" fill="url(#halo)"/>
+  <path d="M70 428c110-74 186-74 296 0s188 74 304 0 162-74 220-26v138H70z" fill="#fff" opacity=".10"/>
+  <g opacity=".38" fill="#fff"><circle cx="154" cy="126" r="7"/><circle cx="220" cy="206" r="4"/><circle cx="784" cy="116" r="6"/><circle cx="812" cy="286" r="4"/><circle cx="692" cy="374" r="5"/></g>
+  <g filter="none"><path d="M352 158h256l-96 168h-64z" fill="url(#glass)" stroke="#fff" stroke-width="6" opacity=".9"/><path d="M390 190h180l-70 108h-40z" fill="#d9fbf1" opacity=".84"/><path d="M480 326v90" stroke="#fff" stroke-width="10" opacity=".8"/><path d="M420 444h120" stroke="#fff" stroke-width="12" stroke-linecap="round" opacity=".82"/><circle cx="584" cy="184" r="44" fill="#9be642"/><circle cx="584" cy="184" r="27" fill="none" stroke="#fff" stroke-width="5" opacity=".65"/><path d="M584 140v88M540 184h88M552 152l64 64M616 152l-64 64" stroke="#fff" stroke-width="3" opacity=".55"/></g>
+  <path d="M290 472h380" stroke="#fff" stroke-opacity=".26" stroke-width="18" stroke-linecap="round"/>
+</svg>

--- a/client/public/images/drinks/potent-potables/premium/margarita.svg
+++ b/client/public/images/drinks/potent-potables/premium/margarita.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">ChefSire Margarita premium drink artwork</title>
+  <desc id="desc">Salt-rimmed margarita coupe with tequila, lime, and orange liqueur.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#25440e"/><stop offset="1" stop-color="#d7a51f"/></linearGradient>
+    <linearGradient id="glass" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#ffffff" stop-opacity=".52"/><stop offset=".5" stop-color="#ffffff" stop-opacity=".15"/><stop offset="1" stop-color="#ffffff" stop-opacity=".36"/></linearGradient>
+    <radialGradient id="halo" cx="50%" cy="42%" r="58%"><stop stop-color="#ffffff" stop-opacity=".55"/><stop offset="1" stop-color="#ffffff" stop-opacity="0"/></radialGradient>
+  </defs>
+  <rect width="960" height="540" rx="0" fill="url(#bg)"/>
+  <circle cx="480" cy="256" r="280" fill="url(#halo)"/>
+  <path d="M70 428c110-74 186-74 296 0s188 74 304 0 162-74 220-26v138H70z" fill="#fff" opacity=".10"/>
+  <g opacity=".38" fill="#fff"><circle cx="154" cy="126" r="7"/><circle cx="220" cy="206" r="4"/><circle cx="784" cy="116" r="6"/><circle cx="812" cy="286" r="4"/><circle cx="692" cy="374" r="5"/></g>
+  <g filter="none"><path d="M352 158h256l-96 168h-64z" fill="url(#glass)" stroke="#fff" stroke-width="6" opacity=".9"/><path d="M390 190h180l-70 108h-40z" fill="#d8f36a" opacity=".84"/><path d="M480 326v90" stroke="#fff" stroke-width="10" opacity=".8"/><path d="M420 444h120" stroke="#fff" stroke-width="12" stroke-linecap="round" opacity=".82"/><circle cx="584" cy="184" r="44" fill="#9be642"/><circle cx="584" cy="184" r="27" fill="none" stroke="#fff" stroke-width="5" opacity=".65"/><path d="M584 140v88M540 184h88M552 152l64 64M616 152l-64 64" stroke="#fff" stroke-width="3" opacity=".55"/></g>
+  <path d="M290 472h380" stroke="#fff" stroke-opacity=".26" stroke-width="18" stroke-linecap="round"/>
+</svg>

--- a/client/public/images/drinks/potent-potables/premium/martini.svg
+++ b/client/public/images/drinks/potent-potables/premium/martini.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">ChefSire Martini premium drink artwork</title>
+  <desc id="desc">Chilled martini glass with clear spirit, vermouth, olive, and lemon highlights.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#1d2540"/><stop offset="1" stop-color="#8996b8"/></linearGradient>
+    <linearGradient id="glass" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#ffffff" stop-opacity=".52"/><stop offset=".5" stop-color="#ffffff" stop-opacity=".15"/><stop offset="1" stop-color="#ffffff" stop-opacity=".36"/></linearGradient>
+    <radialGradient id="halo" cx="50%" cy="42%" r="58%"><stop stop-color="#b7d7ff" stop-opacity=".55"/><stop offset="1" stop-color="#b7d7ff" stop-opacity="0"/></radialGradient>
+  </defs>
+  <rect width="960" height="540" rx="0" fill="url(#bg)"/>
+  <circle cx="480" cy="256" r="280" fill="url(#halo)"/>
+  <path d="M70 428c110-74 186-74 296 0s188 74 304 0 162-74 220-26v138H70z" fill="#fff" opacity=".10"/>
+  <g opacity=".38" fill="#fff"><circle cx="154" cy="126" r="7"/><circle cx="220" cy="206" r="4"/><circle cx="784" cy="116" r="6"/><circle cx="812" cy="286" r="4"/><circle cx="692" cy="374" r="5"/></g>
+  <g filter="none"><path d="M334 126h292L506 286h-52z" fill="url(#glass)" stroke="#fff" stroke-width="6" opacity=".9"/><path d="M374 154h212l-86 102h-40z" fill="#e9f3ff" opacity=".82"/><path d="M480 286v112" stroke="#fff" stroke-width="10" opacity=".8"/><path d="M420 430h120" stroke="#fff" stroke-width="12" stroke-linecap="round" opacity=".82"/><path d="M570 154l-120 94" stroke="#d9c28d" stroke-width="7" stroke-linecap="round"/><circle cx="560" cy="162" r="24" fill="#8cac3f"/><circle cx="566" cy="160" r="8" fill="#d8433e"/><circle cx="524" cy="192" r="22" fill="#9bbd47"/><circle cx="530" cy="190" r="7" fill="#d8433e"/></g>
+  <path d="M290 472h380" stroke="#fff" stroke-opacity=".26" stroke-width="18" stroke-linecap="round"/>
+</svg>

--- a/client/public/images/drinks/potent-potables/premium/mocktails-rich.svg
+++ b/client/public/images/drinks/potent-potables/premium/mocktails-rich.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">ChefSire Mocktails premium drink artwork</title>
+  <desc id="desc">Premium mocktail category artwork with layered fruit, botanicals, bubbles, and no-alcohol sparkle.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#073b4c"/><stop offset="1" stop-color="#42c5b8"/></linearGradient>
+    <linearGradient id="glass" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#ffffff" stop-opacity=".52"/><stop offset=".5" stop-color="#ffffff" stop-opacity=".15"/><stop offset="1" stop-color="#ffffff" stop-opacity=".36"/></linearGradient>
+    <radialGradient id="halo" cx="50%" cy="42%" r="58%"><stop stop-color="#ffdf6b" stop-opacity=".55"/><stop offset="1" stop-color="#ffdf6b" stop-opacity="0"/></radialGradient>
+  </defs>
+  <rect width="960" height="540" rx="0" fill="url(#bg)"/>
+  <circle cx="480" cy="256" r="280" fill="url(#halo)"/>
+  <path d="M70 428c110-74 186-74 296 0s188 74 304 0 162-74 220-26v138H70z" fill="#fff" opacity=".10"/>
+  <g opacity=".38" fill="#fff"><circle cx="154" cy="126" r="7"/><circle cx="220" cy="206" r="4"/><circle cx="784" cy="116" r="6"/><circle cx="812" cy="286" r="4"/><circle cx="692" cy="374" r="5"/></g>
+  <g filter="none"><path d="M372 122h216l-20 330H392z" fill="url(#glass)" stroke="#fff" stroke-width="6" opacity=".88"/><path d="M394 248h172l-12 176H406z" fill="#87f5d2" opacity=".86"/><g opacity=".34" fill="#fff"><circle cx="426" cy="182" r="20"/><circle cx="482" cy="166" r="18"/><circle cx="532" cy="205" r="24"/><circle cx="452" cy="236" r="16"/></g><circle cx="575" cy="170" r="34" fill="#ff6f8f"/><circle cx="608" cy="208" r="24" fill="#ffdf6b"/><path d="M548 208c-34-10-48 18-44 48 36 4 58-16 44-48z" fill="#5ce08a"/></g>
+  <path d="M290 472h380" stroke="#fff" stroke-opacity=".26" stroke-width="18" stroke-linecap="round"/>
+</svg>

--- a/client/public/images/drinks/potent-potables/premium/mojito.svg
+++ b/client/public/images/drinks/potent-potables/premium/mojito.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">ChefSire Mojito premium drink artwork</title>
+  <desc id="desc">Tall mojito with mint, lime, crushed ice, and sparkling bubbles.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#083b2c"/><stop offset="1" stop-color="#20a36b"/></linearGradient>
+    <linearGradient id="glass" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#ffffff" stop-opacity=".52"/><stop offset=".5" stop-color="#ffffff" stop-opacity=".15"/><stop offset="1" stop-color="#ffffff" stop-opacity=".36"/></linearGradient>
+    <radialGradient id="halo" cx="50%" cy="42%" r="58%"><stop stop-color="#72ef9c" stop-opacity=".55"/><stop offset="1" stop-color="#72ef9c" stop-opacity="0"/></radialGradient>
+  </defs>
+  <rect width="960" height="540" rx="0" fill="url(#bg)"/>
+  <circle cx="480" cy="256" r="280" fill="url(#halo)"/>
+  <path d="M70 428c110-74 186-74 296 0s188 74 304 0 162-74 220-26v138H70z" fill="#fff" opacity=".10"/>
+  <g opacity=".38" fill="#fff"><circle cx="154" cy="126" r="7"/><circle cx="220" cy="206" r="4"/><circle cx="784" cy="116" r="6"/><circle cx="812" cy="286" r="4"/><circle cx="692" cy="374" r="5"/></g>
+  <g filter="none"><path d="M372 122h216l-20 330H392z" fill="url(#glass)" stroke="#fff" stroke-width="6" opacity=".88"/><path d="M394 248h172l-12 176H406z" fill="#c7f3df" opacity=".86"/><g opacity=".34" fill="#fff"><circle cx="426" cy="182" r="20"/><circle cx="482" cy="166" r="18"/><circle cx="532" cy="205" r="24"/><circle cx="452" cy="236" r="16"/></g><path d="M568 142c-58 0-78 48-58 86 54 0 82-42 58-86zM610 172c-46-10-74 24-66 58 42 10 76-18 66-58z" fill="#54e682"/><path d="M536 232c16-42 30-66 56-92" stroke="#1d7d4f" stroke-width="7" stroke-linecap="round"/></g>
+  <path d="M290 472h380" stroke="#fff" stroke-opacity=".26" stroke-width="18" stroke-linecap="round"/>
+</svg>

--- a/client/public/images/drinks/potent-potables/premium/old-fashioned.svg
+++ b/client/public/images/drinks/potent-potables/premium/old-fashioned.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">ChefSire Old Fashioned premium drink artwork</title>
+  <desc id="desc">Rocks glass with amber whiskey, large cube, bitters, orange peel, and cherry.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#20100b"/><stop offset="1" stop-color="#8a3f13"/></linearGradient>
+    <linearGradient id="glass" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#ffffff" stop-opacity=".52"/><stop offset=".5" stop-color="#ffffff" stop-opacity=".15"/><stop offset="1" stop-color="#ffffff" stop-opacity=".36"/></linearGradient>
+    <radialGradient id="halo" cx="50%" cy="42%" r="58%"><stop stop-color="#ffb347" stop-opacity=".55"/><stop offset="1" stop-color="#ffb347" stop-opacity="0"/></radialGradient>
+  </defs>
+  <rect width="960" height="540" rx="0" fill="url(#bg)"/>
+  <circle cx="480" cy="256" r="280" fill="url(#halo)"/>
+  <path d="M70 428c110-74 186-74 296 0s188 74 304 0 162-74 220-26v138H70z" fill="#fff" opacity=".10"/>
+  <g opacity=".38" fill="#fff"><circle cx="154" cy="126" r="7"/><circle cx="220" cy="206" r="4"/><circle cx="784" cy="116" r="6"/><circle cx="812" cy="286" r="4"/><circle cx="692" cy="374" r="5"/></g>
+  <g filter="none"><path d="M350 178h260l-30 274H380z" fill="url(#glass)" stroke="#fff" stroke-width="6" opacity=".88"/><path d="M385 275h190l-14 143H401z" fill="#c46a22" opacity=".88"/><rect x="430" y="220" width="78" height="78" rx="16" fill="#fff" opacity=".28" transform="rotate(-8 469 259)"/><rect x="494" y="245" width="62" height="62" rx="14" fill="#fff" opacity=".18" transform="rotate(10 525 276)"/><circle cx="584" cy="184" r="44" fill="#ff9f2e"/><circle cx="584" cy="184" r="27" fill="none" stroke="#fff" stroke-width="5" opacity=".65"/><path d="M584 140v88M540 184h88M552 152l64 64M616 152l-64 64" stroke="#fff" stroke-width="3" opacity=".55"/></g>
+  <path d="M290 472h380" stroke="#fff" stroke-opacity=".26" stroke-width="18" stroke-linecap="round"/>
+</svg>

--- a/client/public/images/drinks/potent-potables/premium/rum-rich.svg
+++ b/client/public/images/drinks/potent-potables/premium/rum-rich.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">ChefSire Rum Cocktails premium drink artwork</title>
+  <desc id="desc">Premium rum category artwork with tropical rum cocktail, lime, and sugar-cane warmth.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#3b1508"/><stop offset="1" stop-color="#e66e28"/></linearGradient>
+    <linearGradient id="glass" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#ffffff" stop-opacity=".52"/><stop offset=".5" stop-color="#ffffff" stop-opacity=".15"/><stop offset="1" stop-color="#ffffff" stop-opacity=".36"/></linearGradient>
+    <radialGradient id="halo" cx="50%" cy="42%" r="58%"><stop stop-color="#ffd36c" stop-opacity=".55"/><stop offset="1" stop-color="#ffd36c" stop-opacity="0"/></radialGradient>
+  </defs>
+  <rect width="960" height="540" rx="0" fill="url(#bg)"/>
+  <circle cx="480" cy="256" r="280" fill="url(#halo)"/>
+  <path d="M70 428c110-74 186-74 296 0s188 74 304 0 162-74 220-26v138H70z" fill="#fff" opacity=".10"/>
+  <g opacity=".38" fill="#fff"><circle cx="154" cy="126" r="7"/><circle cx="220" cy="206" r="4"/><circle cx="784" cy="116" r="6"/><circle cx="812" cy="286" r="4"/><circle cx="692" cy="374" r="5"/></g>
+  <g filter="none"><path d="M386 120c70 28 170 28 188 0-42 96-24 202 4 276 18 46-26 70-98 70s-116-24-98-70c28-74 46-180 4-276z" fill="url(#glass)" stroke="#fff" stroke-width="6" opacity=".88"/><path d="M402 252h156c-2 52 12 98 24 138 12 38-26 54-102 54s-114-16-102-54c12-40 26-86 24-138z" fill="#f0a02d" opacity=".86"/><path d="M574 130c42 14 60 48 48 90-45-4-72-38-48-90z" fill="#5fe38f"/><path d="M606 154c34 28 40 64 12 96-38-22-48-62-12-96z" fill="#36c978"/><circle cx="565" cy="214" r="35" fill="#ffcb54"/><path d="M565 179v70M530 214h70" stroke="#fff" stroke-width="4" opacity=".55"/></g>
+  <path d="M290 472h380" stroke="#fff" stroke-opacity=".26" stroke-width="18" stroke-linecap="round"/>
+</svg>

--- a/client/public/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg
+++ b/client/public/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">ChefSire Whiskey & Bourbon premium drink artwork</title>
+  <desc id="desc">Premium whiskey and bourbon category artwork with amber pour, barrel tones, and orange peel.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#1b0d08"/><stop offset="1" stop-color="#a24713"/></linearGradient>
+    <linearGradient id="glass" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#ffffff" stop-opacity=".52"/><stop offset=".5" stop-color="#ffffff" stop-opacity=".15"/><stop offset="1" stop-color="#ffffff" stop-opacity=".36"/></linearGradient>
+    <radialGradient id="halo" cx="50%" cy="42%" r="58%"><stop stop-color="#f6b23a" stop-opacity=".55"/><stop offset="1" stop-color="#f6b23a" stop-opacity="0"/></radialGradient>
+  </defs>
+  <rect width="960" height="540" rx="0" fill="url(#bg)"/>
+  <circle cx="480" cy="256" r="280" fill="url(#halo)"/>
+  <path d="M70 428c110-74 186-74 296 0s188 74 304 0 162-74 220-26v138H70z" fill="#fff" opacity=".10"/>
+  <g opacity=".38" fill="#fff"><circle cx="154" cy="126" r="7"/><circle cx="220" cy="206" r="4"/><circle cx="784" cy="116" r="6"/><circle cx="812" cy="286" r="4"/><circle cx="692" cy="374" r="5"/></g>
+  <g filter="none"><path d="M350 178h260l-30 274H380z" fill="url(#glass)" stroke="#fff" stroke-width="6" opacity=".88"/><path d="M385 275h190l-14 143H401z" fill="#b95816" opacity=".88"/><rect x="430" y="220" width="78" height="78" rx="16" fill="#fff" opacity=".28" transform="rotate(-8 469 259)"/><rect x="494" y="245" width="62" height="62" rx="14" fill="#fff" opacity=".18" transform="rotate(10 525 276)"/><circle cx="584" cy="184" r="44" fill="#ff9f2e"/><circle cx="584" cy="184" r="27" fill="none" stroke="#fff" stroke-width="5" opacity=".65"/><path d="M584 140v88M540 184h88M552 152l64 64M616 152l-64 64" stroke="#fff" stroke-width="3" opacity=".55"/></g>
+  <path d="M290 472h380" stroke="#fff" stroke-opacity=".26" stroke-width="18" stroke-linecap="round"/>
+</svg>

--- a/client/src/constants/drink-images.ts
+++ b/client/src/constants/drink-images.ts
@@ -6,6 +6,7 @@
  */
 
 const POTENT_POTABLES_ASSET_BASE = '/images/drinks/potent-potables';
+const POTENT_POTABLES_PREMIUM_ASSET_BASE = `${POTENT_POTABLES_ASSET_BASE}/premium`;
 
 export const POTENT_POTABLES_CATEGORY_ASSET_PATHS = {
   cocktails: `${POTENT_POTABLES_ASSET_BASE}/cocktails.svg`,
@@ -29,6 +30,21 @@ export const POTENT_POTABLES_CATEGORY_ASSET_PATHS = {
   hotDrinks: `${POTENT_POTABLES_ASSET_BASE}/hot-drinks.svg`,
 } as const;
 
+
+export const POTENT_POTABLES_RECIPE_ASSET_PATHS = {
+  oldFashioned: `${POTENT_POTABLES_PREMIUM_ASSET_BASE}/old-fashioned.svg`,
+  mojito: `${POTENT_POTABLES_PREMIUM_ASSET_BASE}/mojito.svg`,
+  margarita: `${POTENT_POTABLES_PREMIUM_ASSET_BASE}/margarita.svg`,
+  martini: `${POTENT_POTABLES_PREMIUM_ASSET_BASE}/martini.svg`,
+  daiquiri: `${POTENT_POTABLES_PREMIUM_ASSET_BASE}/daiquiri.svg`,
+} as const;
+
+export const POTENT_POTABLES_RICH_CATEGORY_ASSET_PATHS = {
+  rum: `${POTENT_POTABLES_PREMIUM_ASSET_BASE}/rum-rich.svg`,
+  whiskeyBourbon: `${POTENT_POTABLES_PREMIUM_ASSET_BASE}/whiskey-bourbon-rich.svg`,
+  mocktails: `${POTENT_POTABLES_PREMIUM_ASSET_BASE}/mocktails-rich.svg`,
+} as const;
+
 export const POTENT_POTABLES_ROUTE_ASSET_PATHS: Record<string, string> = {
   '/drinks/potent-potables': POTENT_POTABLES_CATEGORY_ASSET_PATHS.cocktails,
   '/drinks/potent-potables/cocktails': POTENT_POTABLES_CATEGORY_ASSET_PATHS.cocktails,
@@ -48,6 +64,17 @@ export const POTENT_POTABLES_ROUTE_ASSET_PATHS: Record<string, string> = {
   '/drinks/potent-potables/seasonal': POTENT_POTABLES_CATEGORY_ASSET_PATHS.seasonal,
   '/drinks/potent-potables/hot-drinks': POTENT_POTABLES_CATEGORY_ASSET_PATHS.hotDrinks,
 };
+
+
+export const POTENT_POTABLES_RICH_ROUTE_ASSET_PATHS: Record<string, string> = {
+  '/drinks/potent-potables/rum': POTENT_POTABLES_RICH_CATEGORY_ASSET_PATHS.rum,
+  '/drinks/potent-potables/whiskey-bourbon': POTENT_POTABLES_RICH_CATEGORY_ASSET_PATHS.whiskeyBourbon,
+  '/drinks/potent-potables/mocktails': POTENT_POTABLES_RICH_CATEGORY_ASSET_PATHS.mocktails,
+};
+
+export function getPotentPotablesRichAssetByRoute(route: string): string {
+  return POTENT_POTABLES_RICH_ROUTE_ASSET_PATHS[route] ?? '';
+}
 
 export function getPotentPotablesAssetByRoute(route: string): string {
   return POTENT_POTABLES_ROUTE_ASSET_PATHS[route] ?? '';

--- a/client/src/data/drinks/potent-potables/daiquiri.ts
+++ b/client/src/data/drinks/potent-potables/daiquiri.ts
@@ -1,10 +1,12 @@
 import { DrinkRecipe } from "@/data/drinks/types";
+import { POTENT_POTABLES_RECIPE_ASSET_PATHS } from "@/constants/drink-images";
 
 export const daiquiris: DrinkRecipe[] = [
   {
     id: "daiquiri-1",
     name: "Classic Daiquiri",
     description: "Rum, lime, and sugar—perfectly balanced.",
+    image: POTENT_POTABLES_RECIPE_ASSET_PATHS.daiquiri,
     category: "classic",
     era: "1900s",
     method: "Shake",

--- a/client/src/data/drinks/potent-potables/gin.ts
+++ b/client/src/data/drinks/potent-potables/gin.ts
@@ -1,4 +1,5 @@
 import { DrinkRecipe, slugifyDrinkName } from "@/data/drinks/types";
+import { POTENT_POTABLES_RECIPE_ASSET_PATHS } from "@/constants/drink-images";
 
 export const ginRecipes: DrinkRecipe[] = [
   {
@@ -80,6 +81,7 @@ export const ginRecipes: DrinkRecipe[] = [
     id: slugifyDrinkName("Martini"),
     name: "Martini",
     description: "Clean and spirit-forward gin cocktail",
+    image: POTENT_POTABLES_RECIPE_ASSET_PATHS.martini,
     spiritType: "London Dry Gin",
     origin: "United States",
     glassware: "Martini Glass",

--- a/client/src/data/drinks/potent-potables/martinis.ts
+++ b/client/src/data/drinks/potent-potables/martinis.ts
@@ -1,10 +1,12 @@
 import { DrinkRecipe } from "@/data/drinks/types";
+import { POTENT_POTABLES_RECIPE_ASSET_PATHS } from "@/constants/drink-images";
 
 export const martinis: DrinkRecipe[] = [
   {
     id: 'martini-1',
     name: 'Classic Gin Martini',
     description: 'The original - gin and dry vermouth, stirred to perfection',
+    image: POTENT_POTABLES_RECIPE_ASSET_PATHS.martini,
     baseSpirit: 'Gin',
     style: 'Classic',
     glassware: 'Martini Glass',

--- a/client/src/data/drinks/potent-potables/rum.ts
+++ b/client/src/data/drinks/potent-potables/rum.ts
@@ -1,10 +1,12 @@
 import { DrinkRecipe } from "@/data/drinks/types";
+import { POTENT_POTABLES_RECIPE_ASSET_PATHS } from "@/constants/drink-images";
 
 export const rumCocktails: DrinkRecipe[] = [
   {
     id: 'rum-1',
     name: 'Mojito',
     description: 'Refreshing Cuban classic with mint and lime',
+    image: POTENT_POTABLES_RECIPE_ASSET_PATHS.mojito,
     spiritType: 'White Rum',
     origin: 'Havana, Cuba',
     glassware: 'Highball Glass',
@@ -45,6 +47,7 @@ export const rumCocktails: DrinkRecipe[] = [
     id: 'rum-2',
     name: 'Daiquiri',
     description: 'Perfect balance of rum, lime, and sugar',
+    image: POTENT_POTABLES_RECIPE_ASSET_PATHS.daiquiri,
     spiritType: 'White Rum',
     origin: 'Santiago de Cuba',
     glassware: 'Coupe Glass',

--- a/client/src/data/drinks/potent-potables/tequila-mezcal.ts
+++ b/client/src/data/drinks/potent-potables/tequila-mezcal.ts
@@ -1,10 +1,12 @@
 import { DrinkRecipe } from "@/data/drinks/types";
+import { POTENT_POTABLES_RECIPE_ASSET_PATHS } from "@/constants/drink-images";
 
 export const tequilaMezcalCocktails: DrinkRecipe[] = [
   {
     id: 'tequila-1',
     name: 'Classic Margarita',
     description: 'The perfect balance of tequila, lime, and orange liqueur',
+    image: POTENT_POTABLES_RECIPE_ASSET_PATHS.margarita,
     spiritType: 'Blanco Tequila',
     origin: 'Mexico',
     glassware: 'Margarita Glass',

--- a/client/src/data/drinks/potent-potables/whiskey-bourbon.ts
+++ b/client/src/data/drinks/potent-potables/whiskey-bourbon.ts
@@ -1,10 +1,12 @@
 import { DrinkRecipe } from "@/data/drinks/types";
+import { POTENT_POTABLES_RECIPE_ASSET_PATHS } from "@/constants/drink-images";
 
 export const whiskeyCocktails: DrinkRecipe[] = [
   {
     id: 'whiskey-1',
     name: 'Old Fashioned',
     description: 'The grandfather of cocktails - bourbon, sugar, bitters',
+    image: POTENT_POTABLES_RECIPE_ASSET_PATHS.oldFashioned,
     spiritType: 'Bourbon',
     origin: 'Louisville, Kentucky',
     glassware: 'Old Fashioned Glass',

--- a/client/src/generated/drink-canonical.json
+++ b/client/src/generated/drink-canonical.json
@@ -13550,6 +13550,7 @@
         "id": "whiskey-1",
         "name": "Old Fashioned",
         "description": "The grandfather of cocktails - bourbon, sugar, bitters",
+        "image": "/images/drinks/potent-potables/premium/old-fashioned.svg",
         "spiritType": "Bourbon",
         "origin": "Louisville, Kentucky",
         "glassware": "Old Fashioned Glass",
@@ -13591,8 +13592,7 @@
           "Add bourbon and large ice cube",
           "Stir gently",
           "Express orange peel over drink and garnish with cherry"
-        ],
-        "image": "https://images.unsplash.com/photo-1514362545857-3bc16c4c7d1b?w=400&h=300&fit=crop"
+        ]
       }
     },
     {
@@ -13604,6 +13604,7 @@
         "id": "martini",
         "name": "Martini",
         "description": "Clean and spirit-forward gin cocktail",
+        "image": "/images/drinks/potent-potables/premium/martini.svg",
         "spiritType": "London Dry Gin",
         "origin": "United States",
         "glassware": "Martini Glass",
@@ -13642,8 +13643,7 @@
           "Stir gin and dry vermouth with ice until chilled",
           "Strain into a chilled martini glass",
           "Garnish with a lemon twist or olive"
-        ],
-        "image": "/images/drinks/potent-potables/gin.svg"
+        ]
       }
     },
     {
@@ -13696,7 +13696,7 @@
           "Strain into chilled coupe",
           "Garnish with cherry"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     },
     {
@@ -13803,7 +13803,7 @@
           "Strain into coupe",
           "Add bitters design on foam"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     },
     {
@@ -13815,6 +13815,7 @@
         "id": "rum-2",
         "name": "Daiquiri",
         "description": "Perfect balance of rum, lime, and sugar",
+        "image": "/images/drinks/potent-potables/premium/daiquiri.svg",
         "spiritType": "White Rum",
         "origin": "Santiago de Cuba",
         "glassware": "Coupe Glass",
@@ -13856,8 +13857,7 @@
           "Shake all ingredients vigorously with ice",
           "Double strain into chilled coupe glass",
           "Garnish with lime wheel"
-        ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        ]
       }
     },
     {
@@ -13912,7 +13912,7 @@
           "Strain into prepared glass",
           "Express lemon peel and discard"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     },
     {
@@ -13968,7 +13968,7 @@
           "Top with more crushed ice",
           "Garnish with mint sprig and powdered sugar"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     },
     {
@@ -14521,6 +14521,7 @@
         "id": "daiquiri-1",
         "name": "Classic Daiquiri",
         "description": "Rum, lime, and sugar—perfectly balanced.",
+        "image": "/images/drinks/potent-potables/premium/daiquiri.svg",
         "category": "classic",
         "era": "1900s",
         "method": "Shake",
@@ -14543,8 +14544,7 @@
           "Shake rum, lime, and syrup with ice",
           "Fine strain into a chilled coupe",
           "Garnish with lime wheel"
-        ],
-        "image": "/images/drinks/potent-potables/daiquiri.svg"
+        ]
       }
     },
     {
@@ -17525,6 +17525,7 @@
         "id": "martini-1",
         "name": "Classic Gin Martini",
         "description": "The original - gin and dry vermouth, stirred to perfection",
+        "image": "/images/drinks/potent-potables/premium/martini.svg",
         "baseSpirit": "Gin",
         "style": "Classic",
         "glassware": "Martini Glass",
@@ -17566,8 +17567,7 @@
           "Stir for 30 seconds until very cold",
           "Strain into chilled martini glass",
           "Garnish with lemon twist or olives"
-        ],
-        "image": "/images/drinks/potent-potables/martinis.svg"
+        ]
       }
     },
     {
@@ -18120,7 +18120,7 @@
           "Top with tonic water",
           "Garnish with cucumber ribbon and basil"
         ],
-        "image": "/images/drinks/potent-potables/mocktails.svg"
+        "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg"
       }
     },
     {
@@ -18228,7 +18228,7 @@
           "Stir gently",
           "Garnish with lavender sprig and lemon wheel"
         ],
-        "image": "/images/drinks/potent-potables/mocktails.svg"
+        "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg"
       }
     },
     {
@@ -18284,7 +18284,7 @@
           "Top with club soda",
           "Garnish with watermelon triangle and mint"
         ],
-        "image": "/images/drinks/potent-potables/mocktails.svg"
+        "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg"
       }
     },
     {
@@ -18339,7 +18339,7 @@
           "Stir gently",
           "Garnish with lime wheel, mint sprig, and candied ginger"
         ],
-        "image": "/images/drinks/potent-potables/mocktails.svg"
+        "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg"
       }
     },
     {
@@ -18395,7 +18395,7 @@
           "Top with club soda",
           "Garnish with berry skewer and basil leaf"
         ],
-        "image": "/images/drinks/potent-potables/mocktails.svg"
+        "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg"
       }
     },
     {
@@ -18450,7 +18450,7 @@
           "Add pomegranate seeds",
           "Garnish with rosemary sprig"
         ],
-        "image": "/images/drinks/potent-potables/mocktails.svg"
+        "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg"
       }
     },
     {
@@ -18506,7 +18506,7 @@
           "Top with lime sparkling water",
           "Garnish with lime wheel"
         ],
-        "image": "/images/drinks/potent-potables/mocktails.svg"
+        "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg"
       }
     },
     {
@@ -18559,7 +18559,7 @@
           "Pour into highball glass",
           "Garnish with pineapple wedge and cilantro sprig"
         ],
-        "image": "/images/drinks/potent-potables/mocktails.svg"
+        "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg"
       }
     },
     {
@@ -18615,7 +18615,7 @@
           "Strain into chilled martini glass",
           "Garnish with 3 coffee beans"
         ],
-        "image": "/images/drinks/potent-potables/mocktails.svg"
+        "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg"
       }
     },
     {
@@ -18627,6 +18627,7 @@
         "id": "rum-1",
         "name": "Mojito",
         "description": "Refreshing Cuban classic with mint and lime",
+        "image": "/images/drinks/potent-potables/premium/mojito.svg",
         "spiritType": "White Rum",
         "origin": "Havana, Cuba",
         "glassware": "Highball Glass",
@@ -18671,8 +18672,7 @@
           "Add rum and ice",
           "Top with soda water",
           "Stir gently and garnish with mint sprig and lime wheel"
-        ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        ]
       }
     },
     {
@@ -18729,7 +18729,7 @@
           "Pour into hurricane glass",
           "Garnish with pineapple wedge and cherry"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     {
@@ -18787,7 +18787,7 @@
           "Strain over crushed ice in rocks glass",
           "Garnish elaborately with mint sprig, spent lime shell, and pineapple"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     {
@@ -18843,7 +18843,7 @@
           "Top with ginger beer",
           "Stir gently and garnish with lime wedge"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     {
@@ -18902,7 +18902,7 @@
           "Strain over crushed ice in tiki mug",
           "Garnish elaborately with mint, cherry, and pineapple"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     {
@@ -18958,7 +18958,7 @@
           "Add rum and top with Coca-Cola",
           "Stir gently"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     {
@@ -19017,7 +19017,7 @@
           "Float grenadine",
           "Garnish with orange slice and cherry"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     {
@@ -19073,7 +19073,7 @@
           "Stir",
           "Add ice if desired"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     {
@@ -19131,7 +19131,7 @@
           "Top with freshly grated nutmeg",
           "Garnish with orange slice and cherry"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     {
@@ -19187,7 +19187,7 @@
           "Strain over fresh ice in rocks glass",
           "Garnish with pineapple wedge"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     {
@@ -19244,7 +19244,7 @@
           "Stir until well chilled",
           "Express orange peel over drink and garnish"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     {
@@ -20918,6 +20918,7 @@
         "id": "tequila-1",
         "name": "Classic Margarita",
         "description": "The perfect balance of tequila, lime, and orange liqueur",
+        "image": "/images/drinks/potent-potables/premium/margarita.svg",
         "spiritType": "Blanco Tequila",
         "origin": "Mexico",
         "glassware": "Margarita Glass",
@@ -20962,8 +20963,7 @@
           "Shake tequila, lime juice, and triple sec with ice",
           "Strain into prepared glass over fresh ice",
           "Garnish with lime wheel"
-        ],
-        "image": "/images/drinks/potent-potables/tequila-mezcal.svg"
+        ]
       }
     },
     {
@@ -22499,7 +22499,7 @@
           "Strain into old fashioned glass with large ice cube",
           "Express orange peel and garnish"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     },
     {
@@ -22552,7 +22552,7 @@
           "Stir gently once",
           "Express lemon peel and garnish"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     },
     {
@@ -22605,7 +22605,7 @@
           "Strain into old fashioned glass with fresh ice",
           "Garnish with lemon wheel"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     },
     {
@@ -22660,7 +22660,7 @@
           "Carefully float red wine on top using spoon",
           "Garnish with lemon"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     },
     {
@@ -22715,7 +22715,7 @@
           "Strain into glass with fresh ice",
           "Garnish with mint sprig"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     },
     {
@@ -22767,7 +22767,7 @@
           "Shake for 10 seconds until well-chilled",
           "Strain into chilled coupe glass"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     }
   ],
@@ -36322,6 +36322,7 @@
         "id": "whiskey-1",
         "name": "Old Fashioned",
         "description": "The grandfather of cocktails - bourbon, sugar, bitters",
+        "image": "/images/drinks/potent-potables/premium/old-fashioned.svg",
         "spiritType": "Bourbon",
         "origin": "Louisville, Kentucky",
         "glassware": "Old Fashioned Glass",
@@ -36363,8 +36364,7 @@
           "Add bourbon and large ice cube",
           "Stir gently",
           "Express orange peel over drink and garnish with cherry"
-        ],
-        "image": "https://images.unsplash.com/photo-1514362545857-3bc16c4c7d1b?w=400&h=300&fit=crop"
+        ]
       }
     },
     "martini": {
@@ -36376,6 +36376,7 @@
         "id": "martini",
         "name": "Martini",
         "description": "Clean and spirit-forward gin cocktail",
+        "image": "/images/drinks/potent-potables/premium/martini.svg",
         "spiritType": "London Dry Gin",
         "origin": "United States",
         "glassware": "Martini Glass",
@@ -36414,8 +36415,7 @@
           "Stir gin and dry vermouth with ice until chilled",
           "Strain into a chilled martini glass",
           "Garnish with a lemon twist or olive"
-        ],
-        "image": "/images/drinks/potent-potables/gin.svg"
+        ]
       }
     },
     "manhattan": {
@@ -36468,7 +36468,7 @@
           "Strain into chilled coupe",
           "Garnish with cherry"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     },
     "negroni": {
@@ -36575,7 +36575,7 @@
           "Strain into coupe",
           "Add bitters design on foam"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     },
     "daiquiri": {
@@ -36587,6 +36587,7 @@
         "id": "rum-2",
         "name": "Daiquiri",
         "description": "Perfect balance of rum, lime, and sugar",
+        "image": "/images/drinks/potent-potables/premium/daiquiri.svg",
         "spiritType": "White Rum",
         "origin": "Santiago de Cuba",
         "glassware": "Coupe Glass",
@@ -36628,8 +36629,7 @@
           "Shake all ingredients vigorously with ice",
           "Double strain into chilled coupe glass",
           "Garnish with lime wheel"
-        ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        ]
       }
     },
     "sazerac": {
@@ -36684,7 +36684,7 @@
           "Strain into prepared glass",
           "Express lemon peel and discard"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     },
     "mint-julep": {
@@ -36740,7 +36740,7 @@
           "Top with more crushed ice",
           "Garnish with mint sprig and powdered sugar"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     },
     "sidecar": {
@@ -37293,6 +37293,7 @@
         "id": "daiquiri-1",
         "name": "Classic Daiquiri",
         "description": "Rum, lime, and sugar—perfectly balanced.",
+        "image": "/images/drinks/potent-potables/premium/daiquiri.svg",
         "category": "classic",
         "era": "1900s",
         "method": "Shake",
@@ -37315,8 +37316,7 @@
           "Shake rum, lime, and syrup with ice",
           "Fine strain into a chilled coupe",
           "Garnish with lime wheel"
-        ],
-        "image": "/images/drinks/potent-potables/daiquiri.svg"
+        ]
       }
     },
     "hemingway-daiquiri": {
@@ -40297,6 +40297,7 @@
         "id": "martini-1",
         "name": "Classic Gin Martini",
         "description": "The original - gin and dry vermouth, stirred to perfection",
+        "image": "/images/drinks/potent-potables/premium/martini.svg",
         "baseSpirit": "Gin",
         "style": "Classic",
         "glassware": "Martini Glass",
@@ -40338,8 +40339,7 @@
           "Stir for 30 seconds until very cold",
           "Strain into chilled martini glass",
           "Garnish with lemon twist or olives"
-        ],
-        "image": "/images/drinks/potent-potables/martinis.svg"
+        ]
       }
     },
     "vodka-martini": {
@@ -40892,7 +40892,7 @@
           "Top with tonic water",
           "Garnish with cucumber ribbon and basil"
         ],
-        "image": "/images/drinks/potent-potables/mocktails.svg"
+        "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg"
       }
     },
     "tropical-sunrise": {
@@ -41000,7 +41000,7 @@
           "Stir gently",
           "Garnish with lavender sprig and lemon wheel"
         ],
-        "image": "/images/drinks/potent-potables/mocktails.svg"
+        "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg"
       }
     },
     "watermelon-mint-smash": {
@@ -41056,7 +41056,7 @@
           "Top with club soda",
           "Garnish with watermelon triangle and mint"
         ],
-        "image": "/images/drinks/potent-potables/mocktails.svg"
+        "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg"
       }
     },
     "ginger-spice-mule": {
@@ -41111,7 +41111,7 @@
           "Stir gently",
           "Garnish with lime wheel, mint sprig, and candied ginger"
         ],
-        "image": "/images/drinks/potent-potables/mocktails.svg"
+        "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg"
       }
     },
     "berry-basil-smash": {
@@ -41167,7 +41167,7 @@
           "Top with club soda",
           "Garnish with berry skewer and basil leaf"
         ],
-        "image": "/images/drinks/potent-potables/mocktails.svg"
+        "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg"
       }
     },
     "pomegranate-sparkler": {
@@ -41222,7 +41222,7 @@
           "Add pomegranate seeds",
           "Garnish with rosemary sprig"
         ],
-        "image": "/images/drinks/potent-potables/mocktails.svg"
+        "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg"
       }
     },
     "mango-chili-margarita": {
@@ -41278,7 +41278,7 @@
           "Top with lime sparkling water",
           "Garnish with lime wheel"
         ],
-        "image": "/images/drinks/potent-potables/mocktails.svg"
+        "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg"
       }
     },
     "pineapple-cilantro-refresher": {
@@ -41331,7 +41331,7 @@
           "Pour into highball glass",
           "Garnish with pineapple wedge and cilantro sprig"
         ],
-        "image": "/images/drinks/potent-potables/mocktails.svg"
+        "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg"
       }
     },
     "espresso-martini-mocktail": {
@@ -41387,7 +41387,7 @@
           "Strain into chilled martini glass",
           "Garnish with 3 coffee beans"
         ],
-        "image": "/images/drinks/potent-potables/mocktails.svg"
+        "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg"
       }
     },
     "mojito": {
@@ -41399,6 +41399,7 @@
         "id": "rum-1",
         "name": "Mojito",
         "description": "Refreshing Cuban classic with mint and lime",
+        "image": "/images/drinks/potent-potables/premium/mojito.svg",
         "spiritType": "White Rum",
         "origin": "Havana, Cuba",
         "glassware": "Highball Glass",
@@ -41443,8 +41444,7 @@
           "Add rum and ice",
           "Top with soda water",
           "Stir gently and garnish with mint sprig and lime wheel"
-        ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        ]
       }
     },
     "pia-colada": {
@@ -41501,7 +41501,7 @@
           "Pour into hurricane glass",
           "Garnish with pineapple wedge and cherry"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     "mai-tai": {
@@ -41559,7 +41559,7 @@
           "Strain over crushed ice in rocks glass",
           "Garnish elaborately with mint sprig, spent lime shell, and pineapple"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     "dark-and-stormy": {
@@ -41615,7 +41615,7 @@
           "Top with ginger beer",
           "Stir gently and garnish with lime wedge"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     "zombie": {
@@ -41674,7 +41674,7 @@
           "Strain over crushed ice in tiki mug",
           "Garnish elaborately with mint, cherry, and pineapple"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     "cuba-libre": {
@@ -41730,7 +41730,7 @@
           "Add rum and top with Coca-Cola",
           "Stir gently"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     "hurricane": {
@@ -41789,7 +41789,7 @@
           "Float grenadine",
           "Garnish with orange slice and cherry"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     "ti-punch": {
@@ -41845,7 +41845,7 @@
           "Stir",
           "Add ice if desired"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     "painkiller": {
@@ -41903,7 +41903,7 @@
           "Top with freshly grated nutmeg",
           "Garnish with orange slice and cherry"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     "jungle-bird": {
@@ -41959,7 +41959,7 @@
           "Strain over fresh ice in rocks glass",
           "Garnish with pineapple wedge"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     "rum-old-fashioned": {
@@ -42016,7 +42016,7 @@
           "Stir until well chilled",
           "Express orange peel over drink and garnish"
         ],
-        "image": "/images/drinks/potent-potables/rum.svg"
+        "image": "/images/drinks/potent-potables/premium/rum-rich.svg"
       }
     },
     "penicillin": {
@@ -43690,6 +43690,7 @@
         "id": "tequila-1",
         "name": "Classic Margarita",
         "description": "The perfect balance of tequila, lime, and orange liqueur",
+        "image": "/images/drinks/potent-potables/premium/margarita.svg",
         "spiritType": "Blanco Tequila",
         "origin": "Mexico",
         "glassware": "Margarita Glass",
@@ -43734,8 +43735,7 @@
           "Shake tequila, lime juice, and triple sec with ice",
           "Strain into prepared glass over fresh ice",
           "Garnish with lime wheel"
-        ],
-        "image": "/images/drinks/potent-potables/tequila-mezcal.svg"
+        ]
       }
     },
     "paloma": {
@@ -45271,7 +45271,7 @@
           "Strain into old fashioned glass with large ice cube",
           "Express orange peel and garnish"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     },
     "whiskey-highball": {
@@ -45324,7 +45324,7 @@
           "Stir gently once",
           "Express lemon peel and garnish"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     },
     "gold-rush": {
@@ -45377,7 +45377,7 @@
           "Strain into old fashioned glass with fresh ice",
           "Garnish with lemon wheel"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     },
     "new-york-sour": {
@@ -45432,7 +45432,7 @@
           "Carefully float red wine on top using spoon",
           "Garnish with lemon"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     },
     "whiskey-smash": {
@@ -45487,7 +45487,7 @@
           "Strain into glass with fresh ice",
           "Garnish with mint sprig"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     },
     "paper-plane": {
@@ -45539,9 +45539,9 @@
           "Shake for 10 seconds until well-chilled",
           "Strain into chilled coupe glass"
         ],
-        "image": "/images/drinks/potent-potables/whiskey-bourbon.svg"
+        "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg"
       }
     }
   },
-  "generatedAt": "2026-05-09T12:49:49.355Z"
+  "generatedAt": "2026-05-09T16:43:22.570Z"
 }

--- a/client/src/pages/drinks/potent-potables/index.tsx
+++ b/client/src/pages/drinks/potent-potables/index.tsx
@@ -18,7 +18,7 @@ import RecipeKit from '@/components/recipes/RecipeKit';
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 import { otherDrinkHubs } from '../data/detoxes';
 import { sortByName } from '@/lib/sort-by-name';
-import { POTENT_POTABLES_CATEGORY_ASSET_PATHS } from '@/constants/drink-images';
+import { POTENT_POTABLES_CATEGORY_ASSET_PATHS, POTENT_POTABLES_RICH_CATEGORY_ASSET_PATHS } from '@/constants/drink-images';
 
 type Measured = { amount: number | string; unit: string; item: string; note?: string };
 const m = (amount: number | string, unit: string, item: string, note: string = ''): Measured => ({ amount, unit, item, note });
@@ -74,7 +74,8 @@ const potentPotablesSubcategories = [
     count: 12,
     route: '/drinks/potent-potables/whiskey-bourbon',
     description: 'Kentucky classics',
-    image: POTENT_POTABLES_CATEGORY_ASSET_PATHS.whiskeyBourbon,
+    image: POTENT_POTABLES_RICH_CATEGORY_ASSET_PATHS.whiskeyBourbon,
+    fallbackImage: POTENT_POTABLES_CATEGORY_ASSET_PATHS.whiskeyBourbon,
     bgColor: 'bg-amber-50',
     borderColor: 'border-amber-200',
     textColor: 'text-amber-600',
@@ -105,7 +106,8 @@ const potentPotablesSubcategories = [
     count: 12,
     route: '/drinks/potent-potables/rum',
     description: 'Caribbean vibes',
-    image: POTENT_POTABLES_CATEGORY_ASSET_PATHS.rum,
+    image: POTENT_POTABLES_RICH_CATEGORY_ASSET_PATHS.rum,
+    fallbackImage: POTENT_POTABLES_CATEGORY_ASSET_PATHS.rum,
     bgColor: 'bg-orange-50',
     borderColor: 'border-orange-200',
     textColor: 'text-orange-600',
@@ -258,7 +260,8 @@ const potentPotablesSubcategories = [
     count: 12,
     route: '/drinks/potent-potables/mocktails',
     description: 'Zero-proof',
-    image: POTENT_POTABLES_CATEGORY_ASSET_PATHS.mocktails,
+    image: POTENT_POTABLES_RICH_CATEGORY_ASSET_PATHS.mocktails,
+    fallbackImage: POTENT_POTABLES_CATEGORY_ASSET_PATHS.mocktails,
     bgColor: 'bg-emerald-50',
     borderColor: 'border-emerald-200',
     textColor: 'text-emerald-600',
@@ -514,6 +517,12 @@ export default function PotentPotablesPage() {
                             className={`w-full h-full object-cover transition-transform duration-300 ${
                               hoveredCard === category.id ? 'scale-110' : 'scale-100'
                             }`}
+                            onError={(event) => {
+                              const fallbackImage = 'fallbackImage' in category ? category.fallbackImage : undefined;
+                              if (fallbackImage && !event.currentTarget.src.endsWith(fallbackImage)) {
+                                event.currentTarget.src = fallbackImage;
+                              }
+                            }}
                           />
                         )}
                         <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />

--- a/client/src/pages/drinks/recipe/[slug].tsx
+++ b/client/src/pages/drinks/recipe/[slug].tsx
@@ -11,7 +11,7 @@ import { addRecentlyViewedDrinkSlug } from "@/components/drinks/RecentlyViewedDr
 import { recordDrinkViewActivity } from "@/lib/drinks-activity";
 import DrinksPlatformNav from "@/components/drinks/DrinksPlatformNav";
 import { getCanonicalDrinkRecipeBySlug } from "@/data/drinks/canonical";
-import { getPotentPotablesAssetByRoute } from "@/constants/drink-images";
+import { DRINK_FALLBACK_IMAGES, getPotentPotablesAssetByRoute, getPotentPotablesRichAssetByRoute } from "@/constants/drink-images";
 import { postEngagementEvent } from "@/lib/engagement-events";
 import CreatorFollowButton from "@/components/drinks/CreatorFollowButton";
 import SaveToCollectionDialog from "@/components/drinks/SaveToCollectionDialog";
@@ -250,8 +250,10 @@ function CanonicalDrinkRecipeContent({ slug }: { slug: string }) {
   }
 
   const recipe = canonicalRecipe?.recipe;
+  const categoryRicherImage = canonicalRecipe ? getPotentPotablesRichAssetByRoute(canonicalRecipe.sourceRoute) : "";
   const categoryFallbackImage = canonicalRecipe ? getPotentPotablesAssetByRoute(canonicalRecipe.sourceRoute) : "";
-  const imageUrl = (typeof recipe?.image === "string" ? recipe.image : typeof recipe?.imageUrl === "string" ? recipe.imageUrl : "") || userRecipe?.image || categoryFallbackImage;
+  const genericCocktailFallbackImage = DRINK_FALLBACK_IMAGES.cocktail;
+  const imageUrl = (typeof recipe?.image === "string" ? recipe.image : typeof recipe?.imageUrl === "string" ? recipe.imageUrl : "") || userRecipe?.image || categoryRicherImage || categoryFallbackImage || genericCocktailFallbackImage;
   const ingredients = asList(recipe?.ingredients ?? userRecipe?.ingredients ?? []);
   const instructionSteps = asList(recipe?.instructions ?? userRecipe?.instructions ?? []);
   const description = recipe?.description ?? userRecipe?.description;
@@ -355,8 +357,18 @@ function CanonicalDrinkRecipeContent({ slug }: { slug: string }) {
               className="w-full max-h-[360px] object-cover rounded-lg border"
               loading="lazy"
               onError={(event) => {
+                if (categoryRicherImage && !event.currentTarget.src.endsWith(categoryRicherImage)) {
+                  event.currentTarget.src = categoryRicherImage;
+                  return;
+                }
+
                 if (categoryFallbackImage && !event.currentTarget.src.endsWith(categoryFallbackImage)) {
                   event.currentTarget.src = categoryFallbackImage;
+                  return;
+                }
+
+                if (!event.currentTarget.src.endsWith(genericCocktailFallbackImage)) {
+                  event.currentTarget.src = genericCocktailFallbackImage;
                 }
               }}
             />

--- a/scripts/generate-drink-index.ts
+++ b/scripts/generate-drink-index.ts
@@ -43,6 +43,7 @@ type CanonicalDrinkFile = {
 type DrinkRecipeLike = { name?: string; image?: unknown; imageUrl?: unknown };
 
 const POTENT_POTABLES_ASSET_BASE = '/images/drinks/potent-potables';
+const POTENT_POTABLES_PREMIUM_ASSET_BASE = `${POTENT_POTABLES_ASSET_BASE}/premium`;
 
 const POTENT_POTABLES_ROUTE_ASSET_PATHS: Record<string, string> = {
   '/drinks/potent-potables': `${POTENT_POTABLES_ASSET_BASE}/cocktails.svg`,
@@ -64,10 +65,21 @@ const POTENT_POTABLES_ROUTE_ASSET_PATHS: Record<string, string> = {
   '/drinks/potent-potables/whiskey-bourbon': `${POTENT_POTABLES_ASSET_BASE}/whiskey-bourbon.svg`,
 };
 
+
+const POTENT_POTABLES_RICH_ROUTE_ASSET_PATHS: Record<string, string> = {
+  '/drinks/potent-potables/rum': `${POTENT_POTABLES_PREMIUM_ASSET_BASE}/rum-rich.svg`,
+  '/drinks/potent-potables/whiskey-bourbon': `${POTENT_POTABLES_PREMIUM_ASSET_BASE}/whiskey-bourbon-rich.svg`,
+  '/drinks/potent-potables/mocktails': `${POTENT_POTABLES_PREMIUM_ASSET_BASE}/mocktails-rich.svg`,
+};
+
 function getExplicitRecipeImage(recipe: DrinkRecipeLike): string | null {
   if (typeof recipe.image === 'string' && recipe.image.trim()) return recipe.image;
   if (typeof recipe.imageUrl === 'string' && recipe.imageUrl.trim()) return recipe.imageUrl;
   return null;
+}
+
+function getRouteRicherImage(sourceRoute: string): string | null {
+  return POTENT_POTABLES_RICH_ROUTE_ASSET_PATHS[sourceRoute] ?? null;
 }
 
 function getRouteFallbackImage(sourceRoute: string): string | null {
@@ -75,7 +87,7 @@ function getRouteFallbackImage(sourceRoute: string): string | null {
 }
 
 function getRecipeImage(recipe: DrinkRecipeLike, sourceRoute: string): string | null {
-  return getExplicitRecipeImage(recipe) ?? getRouteFallbackImage(sourceRoute);
+  return getExplicitRecipeImage(recipe) ?? getRouteRicherImage(sourceRoute) ?? getRouteFallbackImage(sourceRoute);
 }
 
 function isPotentPotablesLocalAsset(image: string | null | undefined): boolean {
@@ -285,8 +297,9 @@ async function main() {
           const resolvedImage =
             nextExplicitImage ??
             (isPotentPotablesLocalAsset(existing.image)
-              ? getRouteFallbackImage(routeEntry.route)
+              ? getRouteRicherImage(routeEntry.route) ?? getRouteFallbackImage(routeEntry.route)
               : existing.image) ??
+            getRouteRicherImage(routeEntry.route) ??
             getRouteFallbackImage(routeEntry.route);
 
           existing.sourceRoute = routeEntry.route;

--- a/server/generated/drink-index.json
+++ b/server/generated/drink-index.json
@@ -1805,7 +1805,7 @@
       "slug": "old-fashioned",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "https://images.unsplash.com/photo-1514362545857-3bc16c4c7d1b?w=400&h=300&fit=crop",
+      "image": "/images/drinks/potent-potables/premium/old-fashioned.svg",
       "route": "/drinks/recipe/old-fashioned"
     },
     "martini": {
@@ -1813,7 +1813,7 @@
       "slug": "martini",
       "sourceRoute": "/drinks/potent-potables/gin",
       "sourceTitle": "Gin",
-      "image": "/images/drinks/potent-potables/gin.svg",
+      "image": "/images/drinks/potent-potables/premium/martini.svg",
       "route": "/drinks/recipe/martini"
     },
     "manhattan": {
@@ -1821,7 +1821,7 @@
       "slug": "manhattan",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/manhattan"
     },
     "negroni": {
@@ -1837,7 +1837,7 @@
       "slug": "whiskey-sour",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/whiskey-sour"
     },
     "daiquiri": {
@@ -1845,7 +1845,7 @@
       "slug": "daiquiri",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/daiquiri.svg",
       "route": "/drinks/recipe/daiquiri"
     },
     "sazerac": {
@@ -1853,7 +1853,7 @@
       "slug": "sazerac",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/sazerac"
     },
     "mint julep": {
@@ -1861,7 +1861,7 @@
       "slug": "mint-julep",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/mint-julep"
     },
     "sidecar": {
@@ -1965,7 +1965,7 @@
       "slug": "classic-daiquiri",
       "sourceRoute": "/drinks/potent-potables/daiquiri",
       "sourceTitle": "Daiquiri",
-      "image": "/images/drinks/potent-potables/daiquiri.svg",
+      "image": "/images/drinks/potent-potables/premium/daiquiri.svg",
       "route": "/drinks/recipe/classic-daiquiri"
     },
     "hemingway daiquiri": {
@@ -2445,7 +2445,7 @@
       "slug": "classic-gin-martini",
       "sourceRoute": "/drinks/potent-potables/martinis",
       "sourceTitle": "Martinis",
-      "image": "/images/drinks/potent-potables/martinis.svg",
+      "image": "/images/drinks/potent-potables/premium/martini.svg",
       "route": "/drinks/recipe/classic-gin-martini"
     },
     "vodka martini": {
@@ -2525,7 +2525,7 @@
       "slug": "cucumber-cooler",
       "sourceRoute": "/drinks/potent-potables/mocktails",
       "sourceTitle": "Mocktails",
-      "image": "/images/drinks/potent-potables/mocktails.svg",
+      "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg",
       "route": "/drinks/recipe/cucumber-cooler"
     },
     "tropical sunrise": {
@@ -2541,7 +2541,7 @@
       "slug": "lavender-lemonade-fizz",
       "sourceRoute": "/drinks/potent-potables/mocktails",
       "sourceTitle": "Mocktails",
-      "image": "/images/drinks/potent-potables/mocktails.svg",
+      "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg",
       "route": "/drinks/recipe/lavender-lemonade-fizz"
     },
     "watermelon mint smash": {
@@ -2549,7 +2549,7 @@
       "slug": "watermelon-mint-smash",
       "sourceRoute": "/drinks/potent-potables/mocktails",
       "sourceTitle": "Mocktails",
-      "image": "/images/drinks/potent-potables/mocktails.svg",
+      "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg",
       "route": "/drinks/recipe/watermelon-mint-smash"
     },
     "ginger spice mule": {
@@ -2557,7 +2557,7 @@
       "slug": "ginger-spice-mule",
       "sourceRoute": "/drinks/potent-potables/mocktails",
       "sourceTitle": "Mocktails",
-      "image": "/images/drinks/potent-potables/mocktails.svg",
+      "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg",
       "route": "/drinks/recipe/ginger-spice-mule"
     },
     "berry basil smash": {
@@ -2565,7 +2565,7 @@
       "slug": "berry-basil-smash",
       "sourceRoute": "/drinks/potent-potables/mocktails",
       "sourceTitle": "Mocktails",
-      "image": "/images/drinks/potent-potables/mocktails.svg",
+      "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg",
       "route": "/drinks/recipe/berry-basil-smash"
     },
     "pomegranate sparkler": {
@@ -2573,7 +2573,7 @@
       "slug": "pomegranate-sparkler",
       "sourceRoute": "/drinks/potent-potables/mocktails",
       "sourceTitle": "Mocktails",
-      "image": "/images/drinks/potent-potables/mocktails.svg",
+      "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg",
       "route": "/drinks/recipe/pomegranate-sparkler"
     },
     "mango chili margarita": {
@@ -2581,7 +2581,7 @@
       "slug": "mango-chili-margarita",
       "sourceRoute": "/drinks/potent-potables/mocktails",
       "sourceTitle": "Mocktails",
-      "image": "/images/drinks/potent-potables/mocktails.svg",
+      "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg",
       "route": "/drinks/recipe/mango-chili-margarita"
     },
     "pineapple cilantro refresher": {
@@ -2589,7 +2589,7 @@
       "slug": "pineapple-cilantro-refresher",
       "sourceRoute": "/drinks/potent-potables/mocktails",
       "sourceTitle": "Mocktails",
-      "image": "/images/drinks/potent-potables/mocktails.svg",
+      "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg",
       "route": "/drinks/recipe/pineapple-cilantro-refresher"
     },
     "espresso martini (mocktail)": {
@@ -2597,7 +2597,7 @@
       "slug": "espresso-martini-mocktail",
       "sourceRoute": "/drinks/potent-potables/mocktails",
       "sourceTitle": "Mocktails",
-      "image": "/images/drinks/potent-potables/mocktails.svg",
+      "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg",
       "route": "/drinks/recipe/espresso-martini-mocktail"
     },
     "mojito": {
@@ -2605,7 +2605,7 @@
       "slug": "mojito",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/mojito.svg",
       "route": "/drinks/recipe/mojito"
     },
     "piña colada": {
@@ -2613,7 +2613,7 @@
       "slug": "pia-colada",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/pia-colada"
     },
     "mai tai": {
@@ -2621,7 +2621,7 @@
       "slug": "mai-tai",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/mai-tai"
     },
     "dark and stormy": {
@@ -2629,7 +2629,7 @@
       "slug": "dark-and-stormy",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/dark-and-stormy"
     },
     "zombie": {
@@ -2637,7 +2637,7 @@
       "slug": "zombie",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/zombie"
     },
     "cuba libre": {
@@ -2645,7 +2645,7 @@
       "slug": "cuba-libre",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/cuba-libre"
     },
     "hurricane": {
@@ -2653,7 +2653,7 @@
       "slug": "hurricane",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/hurricane"
     },
     "ti' punch": {
@@ -2661,7 +2661,7 @@
       "slug": "ti-punch",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/ti-punch"
     },
     "painkiller": {
@@ -2669,7 +2669,7 @@
       "slug": "painkiller",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/painkiller"
     },
     "jungle bird": {
@@ -2677,7 +2677,7 @@
       "slug": "jungle-bird",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/jungle-bird"
     },
     "rum old fashioned": {
@@ -2685,7 +2685,7 @@
       "slug": "rum-old-fashioned",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/rum-old-fashioned"
     },
     "penicillin": {
@@ -2925,7 +2925,7 @@
       "slug": "classic-margarita",
       "sourceRoute": "/drinks/potent-potables/tequila-mezcal",
       "sourceTitle": "Tequila & Mezcal",
-      "image": "/images/drinks/potent-potables/tequila-mezcal.svg",
+      "image": "/images/drinks/potent-potables/premium/margarita.svg",
       "route": "/drinks/recipe/classic-margarita"
     },
     "paloma": {
@@ -3149,7 +3149,7 @@
       "slug": "boulevardier",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/boulevardier"
     },
     "whiskey highball": {
@@ -3157,7 +3157,7 @@
       "slug": "whiskey-highball",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/whiskey-highball"
     },
     "gold rush": {
@@ -3165,7 +3165,7 @@
       "slug": "gold-rush",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/gold-rush"
     },
     "new york sour": {
@@ -3173,7 +3173,7 @@
       "slug": "new-york-sour",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/new-york-sour"
     },
     "whiskey smash": {
@@ -3181,7 +3181,7 @@
       "slug": "whiskey-smash",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/whiskey-smash"
     },
     "paper plane": {
@@ -3189,7 +3189,7 @@
       "slug": "paper-plane",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/paper-plane"
     }
   },
@@ -4999,7 +4999,7 @@
       "slug": "old-fashioned",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "https://images.unsplash.com/photo-1514362545857-3bc16c4c7d1b?w=400&h=300&fit=crop",
+      "image": "/images/drinks/potent-potables/premium/old-fashioned.svg",
       "route": "/drinks/recipe/old-fashioned"
     },
     "martini": {
@@ -5007,7 +5007,7 @@
       "slug": "martini",
       "sourceRoute": "/drinks/potent-potables/gin",
       "sourceTitle": "Gin",
-      "image": "/images/drinks/potent-potables/gin.svg",
+      "image": "/images/drinks/potent-potables/premium/martini.svg",
       "route": "/drinks/recipe/martini"
     },
     "manhattan": {
@@ -5015,7 +5015,7 @@
       "slug": "manhattan",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/manhattan"
     },
     "negroni": {
@@ -5031,7 +5031,7 @@
       "slug": "whiskey-sour",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/whiskey-sour"
     },
     "daiquiri": {
@@ -5039,7 +5039,7 @@
       "slug": "daiquiri",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/daiquiri.svg",
       "route": "/drinks/recipe/daiquiri"
     },
     "sazerac": {
@@ -5047,7 +5047,7 @@
       "slug": "sazerac",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/sazerac"
     },
     "mint-julep": {
@@ -5055,7 +5055,7 @@
       "slug": "mint-julep",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/mint-julep"
     },
     "sidecar": {
@@ -5159,7 +5159,7 @@
       "slug": "classic-daiquiri",
       "sourceRoute": "/drinks/potent-potables/daiquiri",
       "sourceTitle": "Daiquiri",
-      "image": "/images/drinks/potent-potables/daiquiri.svg",
+      "image": "/images/drinks/potent-potables/premium/daiquiri.svg",
       "route": "/drinks/recipe/classic-daiquiri"
     },
     "hemingway-daiquiri": {
@@ -5639,7 +5639,7 @@
       "slug": "classic-gin-martini",
       "sourceRoute": "/drinks/potent-potables/martinis",
       "sourceTitle": "Martinis",
-      "image": "/images/drinks/potent-potables/martinis.svg",
+      "image": "/images/drinks/potent-potables/premium/martini.svg",
       "route": "/drinks/recipe/classic-gin-martini"
     },
     "vodka-martini": {
@@ -5719,7 +5719,7 @@
       "slug": "cucumber-cooler",
       "sourceRoute": "/drinks/potent-potables/mocktails",
       "sourceTitle": "Mocktails",
-      "image": "/images/drinks/potent-potables/mocktails.svg",
+      "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg",
       "route": "/drinks/recipe/cucumber-cooler"
     },
     "tropical-sunrise": {
@@ -5735,7 +5735,7 @@
       "slug": "lavender-lemonade-fizz",
       "sourceRoute": "/drinks/potent-potables/mocktails",
       "sourceTitle": "Mocktails",
-      "image": "/images/drinks/potent-potables/mocktails.svg",
+      "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg",
       "route": "/drinks/recipe/lavender-lemonade-fizz"
     },
     "watermelon-mint-smash": {
@@ -5743,7 +5743,7 @@
       "slug": "watermelon-mint-smash",
       "sourceRoute": "/drinks/potent-potables/mocktails",
       "sourceTitle": "Mocktails",
-      "image": "/images/drinks/potent-potables/mocktails.svg",
+      "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg",
       "route": "/drinks/recipe/watermelon-mint-smash"
     },
     "ginger-spice-mule": {
@@ -5751,7 +5751,7 @@
       "slug": "ginger-spice-mule",
       "sourceRoute": "/drinks/potent-potables/mocktails",
       "sourceTitle": "Mocktails",
-      "image": "/images/drinks/potent-potables/mocktails.svg",
+      "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg",
       "route": "/drinks/recipe/ginger-spice-mule"
     },
     "berry-basil-smash": {
@@ -5759,7 +5759,7 @@
       "slug": "berry-basil-smash",
       "sourceRoute": "/drinks/potent-potables/mocktails",
       "sourceTitle": "Mocktails",
-      "image": "/images/drinks/potent-potables/mocktails.svg",
+      "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg",
       "route": "/drinks/recipe/berry-basil-smash"
     },
     "pomegranate-sparkler": {
@@ -5767,7 +5767,7 @@
       "slug": "pomegranate-sparkler",
       "sourceRoute": "/drinks/potent-potables/mocktails",
       "sourceTitle": "Mocktails",
-      "image": "/images/drinks/potent-potables/mocktails.svg",
+      "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg",
       "route": "/drinks/recipe/pomegranate-sparkler"
     },
     "mango-chili-margarita": {
@@ -5775,7 +5775,7 @@
       "slug": "mango-chili-margarita",
       "sourceRoute": "/drinks/potent-potables/mocktails",
       "sourceTitle": "Mocktails",
-      "image": "/images/drinks/potent-potables/mocktails.svg",
+      "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg",
       "route": "/drinks/recipe/mango-chili-margarita"
     },
     "pineapple-cilantro-refresher": {
@@ -5783,7 +5783,7 @@
       "slug": "pineapple-cilantro-refresher",
       "sourceRoute": "/drinks/potent-potables/mocktails",
       "sourceTitle": "Mocktails",
-      "image": "/images/drinks/potent-potables/mocktails.svg",
+      "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg",
       "route": "/drinks/recipe/pineapple-cilantro-refresher"
     },
     "espresso-martini-mocktail": {
@@ -5791,7 +5791,7 @@
       "slug": "espresso-martini-mocktail",
       "sourceRoute": "/drinks/potent-potables/mocktails",
       "sourceTitle": "Mocktails",
-      "image": "/images/drinks/potent-potables/mocktails.svg",
+      "image": "/images/drinks/potent-potables/premium/mocktails-rich.svg",
       "route": "/drinks/recipe/espresso-martini-mocktail"
     },
     "mojito": {
@@ -5799,7 +5799,7 @@
       "slug": "mojito",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/mojito.svg",
       "route": "/drinks/recipe/mojito"
     },
     "pia-colada": {
@@ -5807,7 +5807,7 @@
       "slug": "pia-colada",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/pia-colada"
     },
     "mai-tai": {
@@ -5815,7 +5815,7 @@
       "slug": "mai-tai",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/mai-tai"
     },
     "dark-and-stormy": {
@@ -5823,7 +5823,7 @@
       "slug": "dark-and-stormy",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/dark-and-stormy"
     },
     "zombie": {
@@ -5831,7 +5831,7 @@
       "slug": "zombie",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/zombie"
     },
     "cuba-libre": {
@@ -5839,7 +5839,7 @@
       "slug": "cuba-libre",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/cuba-libre"
     },
     "hurricane": {
@@ -5847,7 +5847,7 @@
       "slug": "hurricane",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/hurricane"
     },
     "ti-punch": {
@@ -5855,7 +5855,7 @@
       "slug": "ti-punch",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/ti-punch"
     },
     "painkiller": {
@@ -5863,7 +5863,7 @@
       "slug": "painkiller",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/painkiller"
     },
     "jungle-bird": {
@@ -5871,7 +5871,7 @@
       "slug": "jungle-bird",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/jungle-bird"
     },
     "rum-old-fashioned": {
@@ -5879,7 +5879,7 @@
       "slug": "rum-old-fashioned",
       "sourceRoute": "/drinks/potent-potables/rum",
       "sourceTitle": "Rum",
-      "image": "/images/drinks/potent-potables/rum.svg",
+      "image": "/images/drinks/potent-potables/premium/rum-rich.svg",
       "route": "/drinks/recipe/rum-old-fashioned"
     },
     "penicillin": {
@@ -6119,7 +6119,7 @@
       "slug": "classic-margarita",
       "sourceRoute": "/drinks/potent-potables/tequila-mezcal",
       "sourceTitle": "Tequila & Mezcal",
-      "image": "/images/drinks/potent-potables/tequila-mezcal.svg",
+      "image": "/images/drinks/potent-potables/premium/margarita.svg",
       "route": "/drinks/recipe/classic-margarita"
     },
     "paloma": {
@@ -6343,7 +6343,7 @@
       "slug": "boulevardier",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/boulevardier"
     },
     "whiskey-highball": {
@@ -6351,7 +6351,7 @@
       "slug": "whiskey-highball",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/whiskey-highball"
     },
     "gold-rush": {
@@ -6359,7 +6359,7 @@
       "slug": "gold-rush",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/gold-rush"
     },
     "new-york-sour": {
@@ -6367,7 +6367,7 @@
       "slug": "new-york-sour",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/new-york-sour"
     },
     "whiskey-smash": {
@@ -6375,7 +6375,7 @@
       "slug": "whiskey-smash",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/whiskey-smash"
     },
     "paper-plane": {
@@ -6383,7 +6383,7 @@
       "slug": "paper-plane",
       "sourceRoute": "/drinks/potent-potables/whiskey-bourbon",
       "sourceTitle": "Whiskey & Bourbon",
-      "image": "/images/drinks/potent-potables/whiskey-bourbon.svg",
+      "image": "/images/drinks/potent-potables/premium/whiskey-bourbon-rich.svg",
       "route": "/drinks/recipe/paper-plane"
     }
   },
@@ -6721,5 +6721,5 @@
       "duplicateRoute": "/drinks/potent-potables/whiskey-bourbon"
     }
   ],
-  "generatedAt": "2026-05-09T12:49:49.355Z"
+  "generatedAt": "2026-05-09T16:43:22.570Z"
 }


### PR DESCRIPTION
### Motivation
- Improve visual quality for a small set of high-value Potent Potables recipes and categories by adding owned local imagery while keeping the stabilized fallback hierarchy intact.
- Prevent reliance on inconsistent external images and low-richness visuals for flagship recipes without changing page layouts or removing existing SVG fallbacks.

### Description
- Added 8 owned SVG assets under `client/public/images/drinks/potent-potables/premium/` for recipe-level artwork (`old-fashioned.svg`, `mojito.svg`, `margarita.svg`, `martini.svg`, `daiquiri.svg`) and richer category artwork (`rum-rich.svg`, `whiskey-bourbon-rich.svg`, `mocktails-rich.svg`), and exposed new constants `POTENT_POTABLES_RECIPE_ASSET_PATHS` and `POTENT_POTABLES_RICH_CATEGORY_ASSET_PATHS` in `client/src/constants/drink-images.ts`.
- Wired premium recipe images into the canonical recipe data for Old Fashioned, Mojito, Margarita, Martini, and Daiquiri and updated Rum/Whiskey/Bourbon/Mocktails category cards to reference richer owned category imagery while preserving the original SVG as a fallback.
- Updated `scripts/generate-drink-index.ts` to prefer explicit recipe images first, then route/category richer assets, then existing category SVG fallbacks, and adjusted recipe detail rendering in `client/src/pages/drinks/recipe/[slug].tsx` to preserve the explicit-image-first → richer-route → category-SVG → generic-cocktail fallback sequence.
- Files changed include the new SVGs and these code files: `client/src/constants/drink-images.ts`, `scripts/generate-drink-index.ts`, `client/src/data/drinks/potent-potables/{daiquiri,gin,martinis,rum,tequila-mezcal,whiskey-bourbon}.ts`, `client/src/pages/drinks/potent-potables/index.tsx`, `client/src/pages/drinks/recipe/[slug].tsx`, plus regenerated outputs `client/src/generated/drink-canonical.json` and `server/generated/drink-index.json`.

### Testing
- Ran `npm run generate:drink-index` and it completed successfully with updated index entries reflecting premium asset paths; the change to generated indexes was intentional for this imagery update. 
- Ran `npm run verify:drink-index` and it reported generated files present and recipe counts (report printed, indexes exist). 
- Ran `npm run build:client` and `npm run build:server` and both builds completed successfully (Vite emitted chunk-size warnings only). 
- Performed a filesystem existence check for all premium and fallback SVG paths and all required assets were present. 
- `git diff --check` returned no issues; changes are additive and safe to merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff6350deac8325a6b835551bd8e118)