### PR TITLE
Add premium drink category hero imagery

### DIFF
--- a/client/src/components/drinks/DrinkCategoryHeroImage.tsx
+++ b/client/src/components/drinks/DrinkCategoryHeroImage.tsx
@@ -1,0 +1,35 @@
+import { getDrinkCategoryHeroVisual } from '@/constants/drink-images';
+
+type DrinkCategoryHeroImageProps = {
+  route: string;
+  className?: string;
+};
+
+export default function DrinkCategoryHeroImage({ route, className = '' }: DrinkCategoryHeroImageProps) {
+  const visual = getDrinkCategoryHeroVisual(route);
+
+  return (
+    <section className={`relative mb-8 min-h-[260px] overflow-hidden rounded-3xl border border-white/60 bg-slate-950 shadow-2xl ${className}`}>
+      <img
+        src={visual.image}
+        alt={visual.alt}
+        className={`absolute inset-0 h-full w-full object-cover ${visual.positionClass ?? 'object-center'}`}
+        onError={(event) => {
+          if (event.currentTarget.dataset.fallbackApplied !== 'true') {
+            event.currentTarget.dataset.fallbackApplied = 'true';
+            event.currentTarget.src = visual.fallbackImage;
+          }
+        }}
+      />
+      <div className={`absolute inset-0 ${visual.overlayClass}`} />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_75%_20%,rgba(255,255,255,0.22),transparent_28%),linear-gradient(180deg,transparent,rgba(0,0,0,0.38))]" />
+      <div className="relative flex min-h-[260px] max-w-3xl flex-col justify-end p-6 text-white sm:p-8 lg:p-10">
+        <p className="mb-3 w-fit rounded-full border border-white/30 bg-white/15 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-white/85 backdrop-blur">
+          {visual.mood}
+        </p>
+        <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">{visual.displayName}</h2>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-white/85 sm:text-base">{visual.description}</p>
+      </div>
+    </section>
+  );
+}

--- a/client/src/constants/drink-images.ts
+++ b/client/src/constants/drink-images.ts
@@ -80,6 +80,108 @@ export function getPotentPotablesAssetByRoute(route: string): string {
   return POTENT_POTABLES_ROUTE_ASSET_PATHS[route] ?? '';
 }
 
+
+export type DrinkCategoryHeroVisual = {
+  image: string;
+  fallbackImage: string;
+  alt: string;
+  displayName: string;
+  mood: string;
+  description: string;
+  overlayClass: string;
+  positionClass?: string;
+};
+
+const PREMIUM_DRINK_HERO_BASE_PARAMS = 'w=1600&h=900&fit=crop&crop=entropy&auto=format&q=85';
+
+export const NEUTRAL_PREMIUM_DRINK_HERO_IMAGE = `https://images.unsplash.com/photo-1514362545857-3bc16c4c7d1b?${PREMIUM_DRINK_HERO_BASE_PARAMS}`;
+
+export const drinkCategoryHeroVisuals: Record<string, DrinkCategoryHeroVisual> = {
+  '/drinks/potent-potables/gin': {
+    image: `https://images.unsplash.com/photo-1513558161293-cdaf765ed2fd?${PREMIUM_DRINK_HERO_BASE_PARAMS}`,
+    fallbackImage: NEUTRAL_PREMIUM_DRINK_HERO_IMAGE,
+    alt: 'Premium gin cocktail with botanical garnish in an upscale bar setting',
+    displayName: 'Gin Cocktails',
+    mood: 'Botanical clarity',
+    description: 'Crisp glassware, fresh herbs, juniper-green highlights, and an upscale cocktail-hour finish.',
+    overlayClass: 'bg-gradient-to-r from-slate-950/80 via-emerald-950/55 to-teal-700/25',
+    positionClass: 'object-center',
+  },
+  '/drinks/potent-potables/rum': {
+    image: `https://images.unsplash.com/photo-1536935338788-846bb9981813?${PREMIUM_DRINK_HERO_BASE_PARAMS}`,
+    fallbackImage: NEUTRAL_PREMIUM_DRINK_HERO_IMAGE,
+    alt: 'Premium rum cocktail with tropical warmth and bar lighting',
+    displayName: 'Rum Cocktails',
+    mood: 'Tropical warmth',
+    description: 'Golden bar light, citrus garnish, tiki energy, and a sun-warmed Caribbean cocktail mood.',
+    overlayClass: 'bg-gradient-to-r from-stone-950/80 via-amber-900/60 to-orange-500/30',
+    positionClass: 'object-center',
+  },
+  '/drinks/potent-potables/vodka': {
+    image: `https://images.unsplash.com/photo-1551024709-8f23befc6f87?${PREMIUM_DRINK_HERO_BASE_PARAMS}`,
+    fallbackImage: NEUTRAL_PREMIUM_DRINK_HERO_IMAGE,
+    alt: 'Premium vodka cocktail with crystal-clear ice and modern nightlife lighting',
+    displayName: 'Vodka Cocktails',
+    mood: 'Crystal nightlife',
+    description: 'Clean glass, cool highlights, sharp ice, and a polished late-night lounge aesthetic.',
+    overlayClass: 'bg-gradient-to-r from-slate-950/80 via-cyan-950/55 to-blue-500/25',
+    positionClass: 'object-center',
+  },
+  '/drinks/potent-potables/whiskey-bourbon': {
+    image: `https://images.unsplash.com/photo-1527281400683-1aae777175f8?${PREMIUM_DRINK_HERO_BASE_PARAMS}`,
+    fallbackImage: NEUTRAL_PREMIUM_DRINK_HERO_IMAGE,
+    alt: 'Premium whiskey glass with cinematic amber lounge lighting',
+    displayName: 'Whiskey & Bourbon',
+    mood: 'Amber lounge',
+    description: 'Deep oak tones, low cinematic light, heavy glassware, and classic bourbon-bar confidence.',
+    overlayClass: 'bg-gradient-to-r from-stone-950/85 via-amber-950/60 to-orange-700/25',
+    positionClass: 'object-center',
+  },
+  '/drinks/potent-potables/tequila-mezcal': {
+    image: `https://images.unsplash.com/photo-1556855810-ac404aa91e85?${PREMIUM_DRINK_HERO_BASE_PARAMS}`,
+    fallbackImage: NEUTRAL_PREMIUM_DRINK_HERO_IMAGE,
+    alt: 'Premium tequila cocktail with citrus and agave-inspired warmth',
+    displayName: 'Tequila & Mezcal',
+    mood: 'Agave citrus',
+    description: 'Bright lime, mineral green tones, sunlit agave warmth, and a polished cantina feel.',
+    overlayClass: 'bg-gradient-to-r from-stone-950/75 via-lime-950/55 to-emerald-500/25',
+    positionClass: 'object-center',
+  },
+  '/drinks/potent-potables/cognac-brandy': {
+    image: `https://images.unsplash.com/photo-1569529465841-dfecdab7503b?${PREMIUM_DRINK_HERO_BASE_PARAMS}`,
+    fallbackImage: NEUTRAL_PREMIUM_DRINK_HERO_IMAGE,
+    alt: 'Premium brandy and cognac glass with refined amber lighting',
+    displayName: 'Cognac & Brandy',
+    mood: 'French elegance',
+    description: 'Refined amber glow, snifter-style richness, polished wood, and after-dinner luxury.',
+    overlayClass: 'bg-gradient-to-r from-stone-950/85 via-orange-950/60 to-red-700/25',
+    positionClass: 'object-center',
+  },
+  '/drinks/potent-potables/liqueurs': {
+    image: `https://images.unsplash.com/photo-1470337458703-46ad1756a187?${PREMIUM_DRINK_HERO_BASE_PARAMS}`,
+    fallbackImage: NEUTRAL_PREMIUM_DRINK_HERO_IMAGE,
+    alt: 'Premium cocktail bar with colorful liqueur bottles and polished glassware',
+    displayName: 'Liqueurs',
+    mood: 'Sweet afterglow',
+    description: 'Jewel-tone bottles, dessert-bar polish, layered sweetness, and a sophisticated digestif mood.',
+    overlayClass: 'bg-gradient-to-r from-slate-950/80 via-purple-950/55 to-pink-600/25',
+    positionClass: 'object-center',
+  },
+};
+
+export function getDrinkCategoryHeroVisual(route: string): DrinkCategoryHeroVisual {
+  return drinkCategoryHeroVisuals[route] ?? {
+    image: NEUTRAL_PREMIUM_DRINK_HERO_IMAGE,
+    fallbackImage: POTENT_POTABLES_CATEGORY_ASSET_PATHS.cocktails,
+    alt: 'Premium cocktail in a polished bar setting',
+    displayName: 'Premium Drink Category',
+    mood: 'Premium bar',
+    description: 'A neutral upscale drink visual that keeps category hero layouts polished when specific imagery is unavailable.',
+    overlayClass: 'bg-gradient-to-r from-slate-950/80 via-slate-900/55 to-amber-700/20',
+    positionClass: 'object-center',
+  };
+}
+
 // Fallback images for when specific images are not available
 export const DRINK_FALLBACK_IMAGES = {
   default: POTENT_POTABLES_CATEGORY_ASSET_PATHS.cocktails,

--- a/client/src/pages/drinks/potent-potables/cognac-brandy/index.tsx
+++ b/client/src/pages/drinks/potent-potables/cognac-brandy/index.tsx
@@ -15,6 +15,7 @@ import {
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
 import UniversalSearch from '@/components/UniversalSearch';
+import DrinkCategoryHeroImage from '@/components/drinks/DrinkCategoryHeroImage';
 import { cognacCocktails } from "@/data/drinks/potent-potables/cognac-brandy";
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 
@@ -376,6 +377,8 @@ export default function CognacBrandyPage() {
         </div>
 
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <DrinkCategoryHeroImage route="/drinks/potent-potables/cognac-brandy" />
+
           {/* CROSS-HUB NAVIGATION */}
           <Card className="bg-gradient-to-r from-amber-50 to-orange-50 border-orange-300 mb-6">
             <CardContent className="p-4">

--- a/client/src/pages/drinks/potent-potables/gin/index.tsx
+++ b/client/src/pages/drinks/potent-potables/gin/index.tsx
@@ -16,6 +16,7 @@ import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
 import UniversalSearch from '@/components/UniversalSearch';
 import TrendingDrinksByCategory from "@/components/drinks/TrendingDrinksByCategory";
+import DrinkCategoryHeroImage from '@/components/drinks/DrinkCategoryHeroImage';
 import { ginRecipes } from "@/data/drinks/potent-potables/gin";
 import { resolveCanonicalDrinkSlug } from "@/data/drinks/canonical";
 
@@ -334,6 +335,8 @@ export default function GinCocktailsPage() {
         </div>
 
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <DrinkCategoryHeroImage route="/drinks/potent-potables/gin" />
+
           {/* CROSS-HUB NAVIGATION */}
           <Card className="bg-gradient-to-r from-blue-50 to-teal-50 border-blue-200 mb-6">
             <CardContent className="p-4">

--- a/client/src/pages/drinks/potent-potables/index.tsx
+++ b/client/src/pages/drinks/potent-potables/index.tsx
@@ -18,7 +18,7 @@ import RecipeKit from '@/components/recipes/RecipeKit';
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 import { otherDrinkHubs } from '../data/detoxes';
 import { sortByName } from '@/lib/sort-by-name';
-import { POTENT_POTABLES_CATEGORY_ASSET_PATHS, POTENT_POTABLES_RICH_CATEGORY_ASSET_PATHS } from '@/constants/drink-images';
+import { getDrinkCategoryHeroVisual, POTENT_POTABLES_CATEGORY_ASSET_PATHS, POTENT_POTABLES_RICH_CATEGORY_ASSET_PATHS } from '@/constants/drink-images';
 
 type Measured = { amount: number | string; unit: string; item: string; note?: string };
 const m = (amount: number | string, unit: string, item: string, note: string = ''): Measured => ({ amount, unit, item, note });
@@ -42,7 +42,8 @@ const potentPotablesSubcategories = [
     count: 12,
     route: '/drinks/potent-potables/vodka',
     description: 'Clean & versatile',
-    image: POTENT_POTABLES_CATEGORY_ASSET_PATHS.vodka,
+    image: getDrinkCategoryHeroVisual('/drinks/potent-potables/vodka').image,
+    fallbackImage: getDrinkCategoryHeroVisual('/drinks/potent-potables/vodka').fallbackImage,
     bgColor: 'bg-cyan-50',
     borderColor: 'border-cyan-200',
     textColor: 'text-cyan-600',
@@ -58,7 +59,8 @@ const potentPotablesSubcategories = [
     count: 10,
     route: '/drinks/potent-potables/gin',
     description: 'Botanical spirits',
-    image: POTENT_POTABLES_CATEGORY_ASSET_PATHS.gin,
+    image: getDrinkCategoryHeroVisual('/drinks/potent-potables/gin').image,
+    fallbackImage: getDrinkCategoryHeroVisual('/drinks/potent-potables/gin').fallbackImage,
     bgColor: 'bg-teal-50',
     borderColor: 'border-teal-200',
     textColor: 'text-teal-600',
@@ -74,8 +76,8 @@ const potentPotablesSubcategories = [
     count: 12,
     route: '/drinks/potent-potables/whiskey-bourbon',
     description: 'Kentucky classics',
-    image: POTENT_POTABLES_RICH_CATEGORY_ASSET_PATHS.whiskeyBourbon,
-    fallbackImage: POTENT_POTABLES_CATEGORY_ASSET_PATHS.whiskeyBourbon,
+    image: getDrinkCategoryHeroVisual('/drinks/potent-potables/whiskey-bourbon').image,
+    fallbackImage: getDrinkCategoryHeroVisual('/drinks/potent-potables/whiskey-bourbon').fallbackImage,
     bgColor: 'bg-amber-50',
     borderColor: 'border-amber-200',
     textColor: 'text-amber-600',
@@ -91,7 +93,8 @@ const potentPotablesSubcategories = [
     count: 12,
     route: '/drinks/potent-potables/tequila-mezcal',
     description: 'Agave spirits',
-    image: POTENT_POTABLES_CATEGORY_ASSET_PATHS.tequilaMezcal,
+    image: getDrinkCategoryHeroVisual('/drinks/potent-potables/tequila-mezcal').image,
+    fallbackImage: getDrinkCategoryHeroVisual('/drinks/potent-potables/tequila-mezcal').fallbackImage,
     bgColor: 'bg-lime-50',
     borderColor: 'border-lime-200',
     textColor: 'text-lime-600',
@@ -106,8 +109,8 @@ const potentPotablesSubcategories = [
     count: 12,
     route: '/drinks/potent-potables/rum',
     description: 'Caribbean vibes',
-    image: POTENT_POTABLES_RICH_CATEGORY_ASSET_PATHS.rum,
-    fallbackImage: POTENT_POTABLES_CATEGORY_ASSET_PATHS.rum,
+    image: getDrinkCategoryHeroVisual('/drinks/potent-potables/rum').image,
+    fallbackImage: getDrinkCategoryHeroVisual('/drinks/potent-potables/rum').fallbackImage,
     bgColor: 'bg-orange-50',
     borderColor: 'border-orange-200',
     textColor: 'text-orange-600',
@@ -123,7 +126,8 @@ const potentPotablesSubcategories = [
     count: 12,
     route: '/drinks/potent-potables/cognac-brandy',
     description: 'French elegance',
-    image: POTENT_POTABLES_CATEGORY_ASSET_PATHS.cognacBrandy,
+    image: getDrinkCategoryHeroVisual('/drinks/potent-potables/cognac-brandy').image,
+    fallbackImage: getDrinkCategoryHeroVisual('/drinks/potent-potables/cognac-brandy').fallbackImage,
     bgColor: 'bg-red-50',
     borderColor: 'border-red-200',
     textColor: 'text-red-600',
@@ -184,7 +188,8 @@ const potentPotablesSubcategories = [
     count: 15,
     route: '/drinks/potent-potables/liqueurs',
     description: 'Sweet spirits',
-    image: POTENT_POTABLES_CATEGORY_ASSET_PATHS.liqueurs,
+    image: getDrinkCategoryHeroVisual('/drinks/potent-potables/liqueurs').image,
+    fallbackImage: getDrinkCategoryHeroVisual('/drinks/potent-potables/liqueurs').fallbackImage,
     bgColor: 'bg-pink-50',
     borderColor: 'border-pink-200',
     textColor: 'text-pink-600',

--- a/client/src/pages/drinks/potent-potables/liqueurs/index.tsx
+++ b/client/src/pages/drinks/potent-potables/liqueurs/index.tsx
@@ -9,6 +9,7 @@ import { Wine, Clock, Heart, Target, Sparkles, Droplets, Search, Share2, ArrowLe
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
 import UniversalSearch from '@/components/UniversalSearch';
+import DrinkCategoryHeroImage from '@/components/drinks/DrinkCategoryHeroImage';
 import { liqueurCocktails } from "@/data/drinks/potent-potables/liqueurs";
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 import { redirectToCanonicalRecipe } from '@/lib/canonical-routing';
@@ -335,6 +336,8 @@ export default function LiqueursPage() {
         </div>
 
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <DrinkCategoryHeroImage route="/drinks/potent-potables/liqueurs" />
+
           {/* CROSS-HUB NAVIGATION */}
           <Card className="bg-gradient-to-r from-purple-50 to-pink-50 border-purple-200 mb-6">
             <CardContent className="p-4">

--- a/client/src/pages/drinks/potent-potables/rum/index.tsx
+++ b/client/src/pages/drinks/potent-potables/rum/index.tsx
@@ -16,6 +16,7 @@ import {
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
 import UniversalSearch from '@/components/UniversalSearch';
+import { getDrinkCategoryHeroVisual } from '@/constants/drink-images';
 import { rumCocktails } from "@/data/drinks/potent-potables/rum";
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 
@@ -258,6 +259,8 @@ export default function RumCocktailsPage() {
     setSelectedCocktail(null);
   };
 
+  const heroVisual = getDrinkCategoryHeroVisual('/drinks/potent-potables/rum');
+
   return (
     <RequireAgeGate>
       <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50">
@@ -299,8 +302,21 @@ export default function RumCocktailsPage() {
         )}
 
         {/* Hero Section */}
-        <div className="bg-gradient-to-r from-amber-600 via-orange-600 to-red-600 text-white py-16 px-4">
-          <div className="max-w-7xl mx-auto">
+        <div className="relative overflow-hidden bg-slate-950 text-white py-16 px-4">
+          <img
+            src={heroVisual.image}
+            alt={heroVisual.alt}
+            className={`absolute inset-0 h-full w-full object-cover ${heroVisual.positionClass ?? 'object-center'}`}
+            onError={(event) => {
+              if (event.currentTarget.dataset.fallbackApplied !== 'true') {
+                event.currentTarget.dataset.fallbackApplied = 'true';
+                event.currentTarget.src = heroVisual.fallbackImage;
+              }
+            }}
+          />
+          <div className={`absolute inset-0 ${heroVisual.overlayClass}`} />
+          <div className="absolute inset-0 bg-black/20" />
+          <div className="relative max-w-7xl mx-auto">
             <div className="flex items-center justify-between mb-4">
               <Link href="/drinks/potent-potables">
                 <Button

--- a/client/src/pages/drinks/potent-potables/tequila-mezcal/index.tsx
+++ b/client/src/pages/drinks/potent-potables/tequila-mezcal/index.tsx
@@ -16,6 +16,7 @@ import {
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
 import UniversalSearch from '@/components/UniversalSearch';
+import { getDrinkCategoryHeroVisual } from '@/constants/drink-images';
 import { tequilaMezcalCocktails } from "@/data/drinks/potent-potables/tequila-mezcal";
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 
@@ -258,6 +259,8 @@ export default function TequilaMezcalPage() {
     setSelectedCocktail(null);
   };
 
+  const heroVisual = getDrinkCategoryHeroVisual('/drinks/potent-potables/tequila-mezcal');
+
   return (
     <RequireAgeGate>
       <div className="min-h-screen bg-gradient-to-br from-lime-50 via-green-50 to-emerald-50">
@@ -299,8 +302,21 @@ export default function TequilaMezcalPage() {
         )}
 
         {/* Hero Section */}
-        <div className="bg-gradient-to-r from-lime-600 via-green-600 to-emerald-600 text-white py-16 px-4">
-          <div className="max-w-7xl mx-auto">
+        <div className="relative overflow-hidden bg-slate-950 text-white py-16 px-4">
+          <img
+            src={heroVisual.image}
+            alt={heroVisual.alt}
+            className={`absolute inset-0 h-full w-full object-cover ${heroVisual.positionClass ?? 'object-center'}`}
+            onError={(event) => {
+              if (event.currentTarget.dataset.fallbackApplied !== 'true') {
+                event.currentTarget.dataset.fallbackApplied = 'true';
+                event.currentTarget.src = heroVisual.fallbackImage;
+              }
+            }}
+          />
+          <div className={`absolute inset-0 ${heroVisual.overlayClass}`} />
+          <div className="absolute inset-0 bg-black/20" />
+          <div className="relative max-w-7xl mx-auto">
             <div className="flex items-center justify-between mb-4">
               <Link href="/drinks/potent-potables">
                 <Button

--- a/client/src/pages/drinks/potent-potables/vodka/index.tsx
+++ b/client/src/pages/drinks/potent-potables/vodka/index.tsx
@@ -15,6 +15,7 @@ import {
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
 import UniversalSearch from '@/components/UniversalSearch';
+import DrinkCategoryHeroImage from '@/components/drinks/DrinkCategoryHeroImage';
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 import { vodkaCocktails } from "@/data/drinks/potent-potables/vodka";
 
@@ -347,6 +348,8 @@ export default function VodkaCocktailsPage() {
         </div>
 
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <DrinkCategoryHeroImage route="/drinks/potent-potables/vodka" />
+
           {/* CROSS-HUB NAVIGATION */}
           <Card className="bg-gradient-to-r from-cyan-50 to-blue-50 border-cyan-200 mb-6">
             <CardContent className="p-4">

--- a/client/src/pages/drinks/potent-potables/whiskey-bourbon/index.tsx
+++ b/client/src/pages/drinks/potent-potables/whiskey-bourbon/index.tsx
@@ -9,6 +9,7 @@ import { Wine, Clock, Heart, Target, Sparkles, Flame, Search, Share2, ArrowLeft,
 import { useDrinks } from '@/contexts/DrinksContext';
 import RecipeKit from '@/components/recipes/RecipeKit';
 import UniversalSearch from '@/components/UniversalSearch';
+import DrinkCategoryHeroImage from '@/components/drinks/DrinkCategoryHeroImage';
 import { whiskeyCocktails } from "@/data/drinks/potent-potables/whiskey-bourbon";
 import { resolveCanonicalDrinkSlug } from '@/data/drinks/canonical';
 import { redirectToCanonicalRecipe } from '@/lib/canonical-routing';
@@ -344,6 +345,8 @@ export default function WhiskeyBourbonPage() {
         </div>
 
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <DrinkCategoryHeroImage route="/drinks/potent-potables/whiskey-bourbon" />
+
           {/* CROSS-HUB NAVIGATION */}
           <Card className="bg-gradient-to-r from-amber-50 to-orange-50 border-amber-200 mb-6">
             <CardContent className="p-4">


### PR DESCRIPTION
### Motivation
- Centralize premium hero imagery so Potent Potables category pages present a consistent, high‑end visual identity. 
- Provide a single, reusable lookup/config so category visuals are not scattered or hardcoded across pages. 
- Prepare a lightweight, additive foundation for future recipe‑level realism without changing backend logic or routing.

### Description
- Added a centralized visual config and API in `client/src/constants/drink-images.ts` (`DrinkCategoryHeroVisual`, `drinkCategoryHeroVisuals`, `getDrinkCategoryHeroVisual`) with route-keyed premium hero URLs, alt text, mood copy, overlay classes, and a neutral premium fallback. 
- Introduced a reusable presentation component `client/src/components/drinks/DrinkCategoryHeroImage.tsx` that renders the hero panel and swaps to the configured `fallbackImage` via a one-time `data-fallback-applied` guard on `onError`. 
- Wired the centralized visuals into the Potent Potables surface: category grid entries in `client/src/pages/drinks/potent-potables/index.tsx` now source `image`/`fallbackImage` from `getDrinkCategoryHeroVisual`, and the subcategory pages `gin`, `rum`, `vodka`, `whiskey-bourbon`, `tequila-mezcal`, `cognac-brandy`, and `liqueurs` render the new `DrinkCategoryHeroImage` (or use `getDrinkCategoryHeroVisual` in-place for existing hero blocks). 
- Files changed: `client/src/constants/drink-images.ts`, `client/src/components/drinks/DrinkCategoryHeroImage.tsx`, and Potent Potables pages under `client/src/pages/drinks/potent-potables/*` (gin, rum, vodka, whiskey-bourbon, tequila-mezcal, cognac-brandy, liqueurs, and the index).

### Testing
- Ran `npm run build` and the full build completed successfully. 
- Ran `npm run build:client` and `npm run build:server` and both completed successfully. 
- Restored generated artifacts after build churn (`client/src/generated/drink-canonical.json`, `server/generated/drink-index.json`, `server/generated/pet-food-index.json`) per instructions and verified `git diff --check` showed no issues. 
- No automated UI tests were added; the changes are front-end only and additive, and the build artifacts indicate the integration is stable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00c1ed4e7c8325b7e941aba5434bc6)