### PR TITLE
Bites: video support, create from post dropdown, expiry toggle, Go Live, rename Clip

### DIFF
--- a/client/src/components/BitesRow.tsx
+++ b/client/src/components/BitesRow.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { Heart, MessageCircle, Share, ChevronLeft, ChevronRight, X, Plus, Camera } from 'lucide-react';
+import { Heart, MessageCircle, Share, ChevronLeft, ChevronRight, X, Plus, Camera, Video } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
@@ -99,7 +99,8 @@ export function BitesRow({ className = "" }: BitesRowProps) {
   // Create bite state
   const [isCreating, setIsCreating] = useState(false);
   const [createCaption, setCreateCaption] = useState("");
-  const [createImageDataUrl, setCreateImageDataUrl] = useState<string | null>(null);
+  const [createMediaUrl, setCreateMediaUrl] = useState<string | null>(null);
+  const [createMediaType, setCreateMediaType] = useState<"image" | "video">("video");
   const [createSubmitting, setCreateSubmitting] = useState(false);
   const [createError, setCreateError] = useState("");
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -118,7 +119,7 @@ export function BitesRow({ className = "" }: BitesRowProps) {
           userId: item.userId,
           username,
           avatar,
-          content: { type: "image", url: item.imageUrl },
+          content: { type: item.imageUrl.startsWith("data:video/") || item.imageUrl.match(/\.(mp4|webm|mov|avi)(\?|$)/i) ? "video" : "image", url: item.imageUrl },
           caption: item.caption || "",
           timestamp: item.createdAt ? new Date(item.createdAt) : new Date(),
           duration: 5,
@@ -272,13 +273,23 @@ export function BitesRow({ className = "" }: BitesRowProps) {
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+    const isVideo = file.type.startsWith("video/");
+    setCreateMediaType(isVideo ? "video" : "image");
     const reader = new FileReader();
-    reader.onload = () => setCreateImageDataUrl(reader.result as string);
+    reader.onload = () => setCreateMediaUrl(reader.result as string);
     reader.readAsDataURL(file);
   };
 
+  const resetCreate = () => {
+    setIsCreating(false);
+    setCreateCaption("");
+    setCreateMediaUrl(null);
+    setCreateMediaType("video");
+    setCreateError("");
+  };
+
   const handleCreateBite = async () => {
-    if (!user?.id || !createImageDataUrl) return;
+    if (!user?.id || !createMediaUrl) return;
     setCreateSubmitting(true);
     setCreateError("");
     try {
@@ -288,7 +299,7 @@ export function BitesRow({ className = "" }: BitesRowProps) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           userId: user.id,
-          imageUrl: createImageDataUrl,
+          imageUrl: createMediaUrl,
           caption: createCaption.trim() || undefined,
         }),
       });
@@ -296,9 +307,7 @@ export function BitesRow({ className = "" }: BitesRowProps) {
         const payload = await res.json().catch(() => null);
         throw new Error(payload?.message || "Failed to create bite");
       }
-      setIsCreating(false);
-      setCreateCaption("");
-      setCreateImageDataUrl(null);
+      resetCreate();
     } catch (err) {
       setCreateError(err instanceof Error ? err.message : "Something went wrong");
     } finally {
@@ -395,23 +404,26 @@ export function BitesRow({ className = "" }: BitesRowProps) {
           <div className="bg-white dark:bg-gray-900 rounded-2xl w-full max-w-sm p-6 space-y-4">
             <div className="flex items-center justify-between">
               <h3 className="text-lg font-semibold">New Bite</h3>
-              <Button variant="ghost" size="icon" onClick={() => { setIsCreating(false); setCreateImageDataUrl(null); setCreateCaption(""); setCreateError(""); }}>
+              <Button variant="ghost" size="icon" onClick={resetCreate}>
                 <X className="w-5 h-5" />
               </Button>
             </div>
 
-            {/* Image picker */}
-            <input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={handleFileChange} />
+            {/* Media picker */}
+            <input ref={fileInputRef} type="file" accept="video/*,image/*" className="hidden" onChange={handleFileChange} />
             <div
               className="w-full aspect-[9/16] max-h-64 bg-gray-100 dark:bg-gray-800 rounded-xl flex items-center justify-center cursor-pointer overflow-hidden border-2 border-dashed border-gray-300 dark:border-gray-600 hover:border-primary transition-colors"
               onClick={() => fileInputRef.current?.click()}
             >
-              {createImageDataUrl ? (
-                <img src={createImageDataUrl} alt="Preview" className="w-full h-full object-cover rounded-xl" />
+              {createMediaUrl && createMediaType === "video" ? (
+                <video src={createMediaUrl} className="w-full h-full object-cover rounded-xl" controls muted playsInline />
+              ) : createMediaUrl ? (
+                <img src={createMediaUrl} alt="Preview" className="w-full h-full object-cover rounded-xl" />
               ) : (
                 <div className="flex flex-col items-center gap-2 text-gray-400">
-                  <Camera className="w-8 h-8" />
-                  <span className="text-sm">Tap to pick photo</span>
+                  <Video className="w-8 h-8" />
+                  <span className="text-sm font-medium">Tap to pick video or photo</span>
+                  <span className="text-xs">Video recommended</span>
                 </div>
               )}
             </div>
@@ -430,7 +442,7 @@ export function BitesRow({ className = "" }: BitesRowProps) {
 
             <Button
               className="w-full"
-              disabled={!createImageDataUrl || createSubmitting}
+              disabled={!createMediaUrl || createSubmitting}
               onClick={handleCreateBite}
             >
               {createSubmitting ? "Posting…" : "Share Bite"}
@@ -517,11 +529,23 @@ export function BitesRow({ className = "" }: BitesRowProps) {
 
           {/* Bite Content */}
           <div className="relative w-full max-w-md mx-auto aspect-[9/16]">
-            <img 
-              src={currentBite.content.url}
-              alt={currentBite.caption}
-              className="w-full h-full object-cover rounded-lg"
-            />
+            {currentBite.content.type === "video" ? (
+              <video
+                key={currentBite.id}
+                src={currentBite.content.url}
+                className="w-full h-full object-cover rounded-lg"
+                autoPlay
+                loop
+                muted={false}
+                playsInline
+              />
+            ) : (
+              <img
+                src={currentBite.content.url}
+                alt={currentBite.caption}
+                className="w-full h-full object-cover rounded-lg"
+              />
+            )}
             
             {/* Caption and actions */}
             <div className="absolute bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-black/80 to-transparent">

--- a/client/src/components/GoLiveModal.tsx
+++ b/client/src/components/GoLiveModal.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef, useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Radio, MicOff, Mic, VideoOff, Video, Users } from "lucide-react";
+
+interface GoLiveModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function GoLiveModal({ open, onOpenChange }: GoLiveModalProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const [isLive, setIsLive] = useState(false);
+  const [micOn, setMicOn] = useState(true);
+  const [camOn, setCamOn] = useState(true);
+  const [error, setError] = useState("");
+  const [viewerCount] = useState(0);
+
+  useEffect(() => {
+    if (!open) return;
+    setError("");
+    navigator.mediaDevices
+      .getUserMedia({ video: true, audio: true })
+      .then((stream) => {
+        streamRef.current = stream;
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+        }
+      })
+      .catch(() => {
+        setError("Camera/microphone access denied. Please allow access and try again.");
+      });
+
+    return () => {
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+      setIsLive(false);
+    };
+  }, [open]);
+
+  const toggleMic = () => {
+    streamRef.current?.getAudioTracks().forEach((t) => {
+      t.enabled = !micOn;
+    });
+    setMicOn((prev) => !prev);
+  };
+
+  const toggleCam = () => {
+    streamRef.current?.getVideoTracks().forEach((t) => {
+      t.enabled = !camOn;
+    });
+    setCamOn((prev) => !prev);
+  };
+
+  const endLive = () => {
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+    setIsLive(false);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) endLive(); else onOpenChange(true); }}>
+      <DialogContent className="sm:max-w-md p-0 overflow-hidden bg-black text-white border-none">
+        <div className="relative aspect-[9/16] max-h-[80vh] w-full bg-black flex items-center justify-center">
+          {error ? (
+            <p className="text-red-400 text-sm px-6 text-center">{error}</p>
+          ) : (
+            <video
+              ref={videoRef}
+              autoPlay
+              muted
+              playsInline
+              className="w-full h-full object-cover"
+              style={{ transform: "scaleX(-1)" }}
+            />
+          )}
+
+          {/* Top bar */}
+          <div className="absolute top-0 left-0 right-0 p-4 flex items-center justify-between bg-gradient-to-b from-black/60 to-transparent">
+            <DialogHeader>
+              <DialogTitle className="text-white text-base">
+                {isLive ? (
+                  <span className="flex items-center gap-2">
+                    <span className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />
+                    LIVE
+                  </span>
+                ) : "Go Live"}
+              </DialogTitle>
+            </DialogHeader>
+            {isLive && (
+              <span className="flex items-center gap-1 text-sm bg-black/40 px-2 py-1 rounded-full">
+                <Users className="w-3 h-3" />
+                {viewerCount}
+              </span>
+            )}
+          </div>
+
+          {/* Bottom controls */}
+          <div className="absolute bottom-0 left-0 right-0 p-6 flex flex-col items-center gap-4 bg-gradient-to-t from-black/80 to-transparent">
+            <div className="flex gap-4">
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                className={`rounded-full border ${micOn ? "border-white/40 text-white" : "border-red-500 text-red-500"} hover:bg-white/20`}
+                onClick={toggleMic}
+              >
+                {micOn ? <Mic className="w-5 h-5" /> : <MicOff className="w-5 h-5" />}
+              </Button>
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                className={`rounded-full border ${camOn ? "border-white/40 text-white" : "border-red-500 text-red-500"} hover:bg-white/20`}
+                onClick={toggleCam}
+              >
+                {camOn ? <Video className="w-5 h-5" /> : <VideoOff className="w-5 h-5" />}
+              </Button>
+            </div>
+
+            {!isLive ? (
+              <Button
+                type="button"
+                className="w-48 bg-red-600 hover:bg-red-700 text-white font-semibold rounded-full"
+                onClick={() => setIsLive(true)}
+                disabled={!!error}
+              >
+                <Radio className="w-4 h-4 mr-2" />
+                Start Live
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                variant="outline"
+                className="w-48 border-white text-white hover:bg-white/20 rounded-full"
+                onClick={endLive}
+              >
+                End Live
+              </Button>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/create-post-modal.tsx
+++ b/client/src/components/create-post-modal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   Dialog,
@@ -12,12 +12,13 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Camera, X, Plus, Star } from "lucide-react";
+import { Camera, X, Plus, Star, Video, Radio } from "lucide-react";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { useUser } from "@/contexts/UserContext";
+import GoLiveModal from "@/components/GoLiveModal";
 
-type PostType = "post" | "recipe" | "review";
+type PostType = "post" | "recipe" | "review" | "bite" | "reel";
 
 type IngredientRow = {
   name: string;
@@ -78,6 +79,13 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
   const [reviewCons, setReviewCons] = useState("");
   const [reviewVerdict, setReviewVerdict] = useState("");
 
+  // Bite / Reel fields
+  const [biteExpiry, setBiteExpiry] = useState<"24h" | "permanent">("24h");
+  const [showGoLive, setShowGoLive] = useState(false);
+  const biteFileRef = useRef<HTMLInputElement>(null);
+  const [biteMediaUrl, setBiteMediaUrl] = useState<string>("");
+  const [biteMediaType, setBiteMediaType] = useState<"image" | "video">("video");
+
   const cleanedTags = useMemo(
     () => tags.split(",").map((t) => t.trim()).filter(Boolean),
     [tags]
@@ -123,6 +131,10 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
 
     setImageFile(null);
     setImagePreview("");
+
+    setBiteExpiry("24h");
+    setBiteMediaUrl("");
+    setBiteMediaType("video");
   };
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -138,6 +150,16 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
       // NOTE: demo uses base64 as imageUrl; in production upload to storage/CDN
       setImageUrl(result);
     };
+    reader.readAsDataURL(file);
+  };
+
+  const handleBiteFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const isVideo = file.type.startsWith("video/");
+    setBiteMediaType(isVideo ? "video" : "image");
+    const reader = new FileReader();
+    reader.onloadend = () => setBiteMediaUrl(reader.result as string);
     reader.readAsDataURL(file);
   };
 
@@ -184,6 +206,15 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
       toast({ variant: "destructive", description: "You must be logged in to create a post" });
       return false;
     }
+
+    if (postType === "bite" || postType === "reel") {
+      if (!biteMediaUrl) {
+        toast({ variant: "destructive", description: "Please pick a video or photo" });
+        return false;
+      }
+      return true;
+    }
+
     if (!imageUrl) {
       toast({ variant: "destructive", description: "Please add an image (upload or paste URL)" });
       return false;
@@ -215,9 +246,36 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
     return true;
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!validate()) return;
+
+    // Bite → POST /api/bites
+    if (postType === "bite" || postType === "reel") {
+      try {
+        const expiresAt = biteExpiry === "permanent"
+          ? new Date(Date.now() + 100 * 365 * 24 * 60 * 60 * 1000).toISOString() // ~100 years
+          : undefined;
+        const res = await fetch("/api/bites", {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            userId: user!.id,
+            imageUrl: biteMediaUrl,
+            caption: caption.trim() || undefined,
+            expiresAt,
+          }),
+        });
+        if (!res.ok) throw new Error("Failed to create bite");
+        toast({ description: postType === "reel" ? "Reel shared!" : "Bite shared!" });
+        onOpenChange(false);
+        resetForm();
+      } catch (err: any) {
+        toast({ variant: "destructive", description: err.message });
+      }
+      return;
+    }
 
     const baseTags = [...cleanedTags];
     const payload: any = {
@@ -230,7 +288,6 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
 
     if (postType === "recipe") {
       payload.recipe = buildRecipePayload();
-      // Helpful tags
       if (!payload.tags.includes("Recipe")) payload.tags.push("Recipe");
     }
 
@@ -265,8 +322,8 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
-          {/* Image Upload */}
-          <div className="border-2 border-dashed border-border rounded-lg p-6 text-center">
+          {/* Image Upload — hidden for bite/reel which have their own picker */}
+          <div className={`border-2 border-dashed border-border rounded-lg p-6 text-center ${postType === "bite" || postType === "reel" ? "hidden" : ""}`}>
             <Camera className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
 
             {imagePreview ? (
@@ -354,11 +411,76 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
                 <SelectItem value="post">Post</SelectItem>
                 <SelectItem value="recipe">Recipe</SelectItem>
                 <SelectItem value="review">Review</SelectItem>
+                <SelectItem value="bite">Bite (24h story)</SelectItem>
+                <SelectItem value="reel">Reel (video)</SelectItem>
               </SelectContent>
             </Select>
           </div>
 
           <Separator />
+
+          {/* Bite / Reel media picker */}
+          {(postType === "bite" || postType === "reel") && (
+            <div className="space-y-3">
+              <input
+                ref={biteFileRef}
+                type="file"
+                accept="video/*,image/*"
+                className="hidden"
+                onChange={handleBiteFileSelect}
+              />
+              <div
+                className="w-full aspect-video bg-gray-100 dark:bg-gray-800 rounded-xl flex items-center justify-center cursor-pointer overflow-hidden border-2 border-dashed border-gray-300 dark:border-gray-600 hover:border-primary transition-colors"
+                onClick={() => biteFileRef.current?.click()}
+              >
+                {biteMediaUrl && biteMediaType === "video" ? (
+                  <video src={biteMediaUrl} className="w-full h-full object-cover rounded-xl" controls muted playsInline />
+                ) : biteMediaUrl ? (
+                  <img src={biteMediaUrl} alt="Preview" className="w-full h-full object-cover rounded-xl" />
+                ) : (
+                  <div className="flex flex-col items-center gap-2 text-gray-400">
+                    <Video className="w-8 h-8" />
+                    <span className="text-sm font-medium">Tap to pick video or photo</span>
+                    <span className="text-xs text-gray-400">Video recommended</span>
+                  </div>
+                )}
+              </div>
+
+              {/* Expiry / Permanent toggle */}
+              <div className="flex items-center gap-3 p-3 bg-muted/40 rounded-lg">
+                <div className="flex-1 space-y-0.5">
+                  <p className="text-sm font-medium">
+                    {biteExpiry === "permanent" ? "Add to Reels profile tab (permanent)" : "Show in Bites row for 24 hours only"}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {biteExpiry === "permanent" ? "Stays on your profile Reels tab forever" : "Disappears automatically after 24 hours"}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={biteExpiry === "permanent"}
+                  onClick={() => setBiteExpiry(biteExpiry === "24h" ? "permanent" : "24h")}
+                  className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none ${biteExpiry === "permanent" ? "bg-primary" : "bg-input"}`}
+                >
+                  <span className={`pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform ${biteExpiry === "permanent" ? "translate-x-5" : "translate-x-0"}`} />
+                </button>
+              </div>
+
+              {/* Go Live button for reels */}
+              {postType === "reel" && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full border-red-500 text-red-500 hover:bg-red-50 dark:hover:bg-red-950"
+                  onClick={() => setShowGoLive(true)}
+                >
+                  <Radio className="w-4 h-4 mr-2" />
+                  Go Live Instead
+                </Button>
+              )}
+            </div>
+          )}
 
           {/* Caption / Notes */}
           <div className="space-y-2">
@@ -542,15 +664,17 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
             </div>
           )}
 
-          {/* Tags */}
-          <div className="space-y-2">
-            <Label className="text-sm">Tags (comma separated)</Label>
-            <Input
-              placeholder="e.g., italian, pasta, homemade"
-              value={tags}
-              onChange={(e) => setTags(e.target.value)}
-            />
-          </div>
+          {/* Tags — not shown for bites/reels */}
+          {postType !== "bite" && postType !== "reel" && (
+            <div className="space-y-2">
+              <Label className="text-sm">Tags (comma separated)</Label>
+              <Input
+                placeholder="e.g., italian, pasta, homemade"
+                value={tags}
+                onChange={(e) => setTags(e.target.value)}
+              />
+            </div>
+          )}
 
           {/* Submit */}
           <Button
@@ -558,10 +682,11 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
             className="w-full bg-primary text-primary-foreground hover:opacity-90"
             disabled={createPostMutation.isPending}
           >
-            {createPostMutation.isPending ? "Sharing..." : postType === "recipe" ? "Share Recipe" : postType === "review" ? "Share Review" : "Share Post"}
+            {createPostMutation.isPending ? "Sharing..." : postType === "recipe" ? "Share Recipe" : postType === "review" ? "Share Review" : postType === "bite" ? "Share Bite" : postType === "reel" ? "Share Reel" : "Share Post"}
           </Button>
         </form>
       </DialogContent>
+      <GoLiveModal open={showGoLive} onOpenChange={setShowGoLive} />
     </Dialog>
   );
 }

--- a/client/src/components/create-post-modal.tsx
+++ b/client/src/components/create-post-modal.tsx
@@ -18,7 +18,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useUser } from "@/contexts/UserContext";
 import GoLiveModal from "@/components/GoLiveModal";
 
-type PostType = "post" | "recipe" | "review" | "bite" | "reel";
+type PostType = "post" | "recipe" | "review" | "bite" | "clip";
 
 type IngredientRow = {
   name: string;
@@ -79,7 +79,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
   const [reviewCons, setReviewCons] = useState("");
   const [reviewVerdict, setReviewVerdict] = useState("");
 
-  // Bite / Reel fields
+  // Bite / Clip fields
   const [biteExpiry, setBiteExpiry] = useState<"24h" | "permanent">("24h");
   const [showGoLive, setShowGoLive] = useState(false);
   const biteFileRef = useRef<HTMLInputElement>(null);
@@ -207,7 +207,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
       return false;
     }
 
-    if (postType === "bite" || postType === "reel") {
+    if (postType === "bite" || postType === "clip") {
       if (!biteMediaUrl) {
         toast({ variant: "destructive", description: "Please pick a video or photo" });
         return false;
@@ -251,7 +251,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
     if (!validate()) return;
 
     // Bite → POST /api/bites
-    if (postType === "bite" || postType === "reel") {
+    if (postType === "bite" || postType === "clip") {
       try {
         const expiresAt = biteExpiry === "permanent"
           ? new Date(Date.now() + 100 * 365 * 24 * 60 * 60 * 1000).toISOString() // ~100 years
@@ -268,7 +268,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
           }),
         });
         if (!res.ok) throw new Error("Failed to create bite");
-        toast({ description: postType === "reel" ? "Reel shared!" : "Bite shared!" });
+        toast({ description: postType === "clip" ? "Clip shared!" : "Bite shared!" });
         onOpenChange(false);
         resetForm();
       } catch (err: any) {
@@ -322,8 +322,8 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
-          {/* Image Upload — hidden for bite/reel which have their own picker */}
-          <div className={`border-2 border-dashed border-border rounded-lg p-6 text-center ${postType === "bite" || postType === "reel" ? "hidden" : ""}`}>
+          {/* Image Upload — hidden for bite/clip which have their own picker */}
+          <div className={`border-2 border-dashed border-border rounded-lg p-6 text-center ${postType === "bite" || postType === "clip" ? "hidden" : ""}`}>
             <Camera className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
 
             {imagePreview ? (
@@ -412,15 +412,15 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
                 <SelectItem value="recipe">Recipe</SelectItem>
                 <SelectItem value="review">Review</SelectItem>
                 <SelectItem value="bite">Bite (24h story)</SelectItem>
-                <SelectItem value="reel">Reel (video)</SelectItem>
+                <SelectItem value="clip">Clip (video)</SelectItem>
               </SelectContent>
             </Select>
           </div>
 
           <Separator />
 
-          {/* Bite / Reel media picker */}
-          {(postType === "bite" || postType === "reel") && (
+          {/* Bite / Clip media picker */}
+          {(postType === "bite" || postType === "clip") && (
             <div className="space-y-3">
               <input
                 ref={biteFileRef}
@@ -450,10 +450,10 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
               <div className="flex items-center gap-3 p-3 bg-muted/40 rounded-lg">
                 <div className="flex-1 space-y-0.5">
                   <p className="text-sm font-medium">
-                    {biteExpiry === "permanent" ? "Add to Reels profile tab (permanent)" : "Show in Bites row for 24 hours only"}
+                    {biteExpiry === "permanent" ? "Add to Bites profile tab (permanent)" : "Show in Bites row for 24 hours only"}
                   </p>
                   <p className="text-xs text-muted-foreground">
-                    {biteExpiry === "permanent" ? "Stays on your profile Reels tab forever" : "Disappears automatically after 24 hours"}
+                    {biteExpiry === "permanent" ? "Stays on your profile Bites tab forever" : "Disappears automatically after 24 hours"}
                   </p>
                 </div>
                 <button
@@ -467,8 +467,8 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
                 </button>
               </div>
 
-              {/* Go Live button for reels */}
-              {postType === "reel" && (
+              {/* Go Live button for clips */}
+              {postType === "clip" && (
                 <Button
                   type="button"
                   variant="outline"
@@ -664,8 +664,8 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
             </div>
           )}
 
-          {/* Tags — not shown for bites/reels */}
-          {postType !== "bite" && postType !== "reel" && (
+          {/* Tags — not shown for bites/clips */}
+          {postType !== "bite" && postType !== "clip" && (
             <div className="space-y-2">
               <Label className="text-sm">Tags (comma separated)</Label>
               <Input
@@ -682,7 +682,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
             className="w-full bg-primary text-primary-foreground hover:opacity-90"
             disabled={createPostMutation.isPending}
           >
-            {createPostMutation.isPending ? "Sharing..." : postType === "recipe" ? "Share Recipe" : postType === "review" ? "Share Review" : postType === "bite" ? "Share Bite" : postType === "reel" ? "Share Reel" : "Share Post"}
+            {createPostMutation.isPending ? "Sharing..." : postType === "recipe" ? "Share Recipe" : postType === "review" ? "Share Review" : postType === "bite" ? "Share Bite" : postType === "clip" ? "Share Clip" : "Share Post"}
           </Button>
         </form>
       </DialogContent>


### PR DESCRIPTION
## Summary

- **BitesRow + button**: now opens a create modal with video/photo picker (video first)
- **Post type dropdown**: added Bite and Clip options alongside Post/Recipe/Review
- **Bite expiry toggle**: switch between "24 hours in Bites row" and "Permanent Bites profile tab"
- **Go Live**: Clip type shows a Go Live button → opens camera/mic preview modal with Start/End Live controls
- **Renamed Reel → Clip**: Reel is a Meta trademark; all references updated

## After merging

```bash
git pull
npm run build
```

Then restart the app in Plesk.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e)_