### PR TITLE
Add Go Live dropdown option and real Camera modal

### DIFF
--- a/client/src/components/CameraModal.tsx
+++ b/client/src/components/CameraModal.tsx
@@ -1,0 +1,226 @@
+import { useEffect, useRef, useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Camera, Circle, Square, RotateCcw, Check, X, SwitchCamera } from "lucide-react";
+
+interface CameraModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCapture: (dataUrl: string, type: "image" | "video") => void;
+}
+
+type Mode = "idle" | "recording" | "preview";
+
+export default function CameraModal({ open, onOpenChange, onCapture }: CameraModalProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const previewRef = useRef<HTMLVideoElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const [mode, setMode] = useState<Mode>("idle");
+  const [capturedUrl, setCapturedUrl] = useState("");
+  const [capturedType, setCapturedType] = useState<"image" | "video">("image");
+  const [error, setError] = useState("");
+  const [facingMode, setFacingMode] = useState<"user" | "environment">("environment");
+  const [recordingSeconds, setRecordingSeconds] = useState(0);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const startCamera = async (facing: "user" | "environment") => {
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    setError("");
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: facing },
+        audio: true,
+      });
+      streamRef.current = stream;
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+      }
+    } catch {
+      setError("Camera access denied. Please allow access and try again.");
+    }
+  };
+
+  useEffect(() => {
+    if (!open) {
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+      recorderRef.current = null;
+      chunksRef.current = [];
+      setCapturedUrl("");
+      setMode("idle");
+      setError("");
+      setRecordingSeconds(0);
+      if (timerRef.current) clearInterval(timerRef.current);
+      return;
+    }
+    startCamera(facingMode);
+  }, [open]);
+
+  const flipCamera = async () => {
+    const next = facingMode === "environment" ? "user" : "environment";
+    setFacingMode(next);
+    await startCamera(next);
+  };
+
+  const takePhoto = () => {
+    const video = videoRef.current;
+    const canvas = canvasRef.current;
+    if (!video || !canvas) return;
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    if (facingMode === "user") {
+      ctx.translate(canvas.width, 0);
+      ctx.scale(-1, 1);
+    }
+    ctx.drawImage(video, 0, 0);
+    const url = canvas.toDataURL("image/jpeg", 0.92);
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+    setCapturedUrl(url);
+    setCapturedType("image");
+    setMode("preview");
+  };
+
+  const startRecording = () => {
+    const stream = streamRef.current;
+    if (!stream) return;
+    chunksRef.current = [];
+
+    const mimeType = MediaRecorder.isTypeSupported("video/webm;codecs=vp9")
+      ? "video/webm;codecs=vp9"
+      : MediaRecorder.isTypeSupported("video/webm")
+      ? "video/webm"
+      : "video/mp4";
+
+    const recorder = new MediaRecorder(stream, { mimeType });
+    recorder.ondataavailable = (e) => {
+      if (e.data.size > 0) chunksRef.current.push(e.data);
+    };
+    recorder.onstop = () => {
+      const blob = new Blob(chunksRef.current, { type: mimeType });
+      const url = URL.createObjectURL(blob);
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+      setCapturedUrl(url);
+      setCapturedType("video");
+      setMode("preview");
+    };
+    recorder.start(100);
+    recorderRef.current = recorder;
+    setMode("recording");
+    setRecordingSeconds(0);
+    timerRef.current = setInterval(() => setRecordingSeconds((s) => s + 1), 1000);
+  };
+
+  const stopRecording = () => {
+    if (timerRef.current) clearInterval(timerRef.current);
+    recorderRef.current?.stop();
+  };
+
+  const retake = () => {
+    setCapturedUrl("");
+    setMode("idle");
+    setRecordingSeconds(0);
+    startCamera(facingMode);
+  };
+
+  const confirm = () => {
+    onCapture(capturedUrl, capturedType);
+    onOpenChange(false);
+  };
+
+  const formatTime = (s: number) =>
+    `${String(Math.floor(s / 60)).padStart(2, "0")}:${String(s % 60).padStart(2, "0")}`;
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onOpenChange(false); }}>
+      <DialogContent className="sm:max-w-md p-0 overflow-hidden bg-black text-white border-none">
+        <div className="relative aspect-[9/16] max-h-[85vh] w-full bg-black flex items-center justify-center">
+          {error ? (
+            <p className="text-red-400 text-sm px-6 text-center">{error}</p>
+          ) : mode === "preview" ? (
+            capturedType === "video" ? (
+              <video
+                ref={previewRef}
+                src={capturedUrl}
+                autoPlay
+                loop
+                playsInline
+                className="w-full h-full object-cover"
+              />
+            ) : (
+              <img src={capturedUrl} alt="Captured" className="w-full h-full object-cover" />
+            )
+          ) : (
+            <video
+              ref={videoRef}
+              autoPlay
+              muted
+              playsInline
+              className="w-full h-full object-cover"
+              style={{ transform: facingMode === "user" ? "scaleX(-1)" : "none" }}
+            />
+          )}
+
+          <canvas ref={canvasRef} className="hidden" />
+
+          {/* Top bar */}
+          <div className="absolute top-0 left-0 right-0 p-4 flex items-center justify-between bg-gradient-to-b from-black/60 to-transparent">
+            <DialogHeader>
+              <DialogTitle className="text-white text-base">
+                {mode === "preview"
+                  ? capturedType === "video"
+                    ? "Video preview"
+                    : "Photo preview"
+                  : mode === "recording"
+                  ? <span className="flex items-center gap-2"><span className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />Recording {formatTime(recordingSeconds)}</span>
+                  : "Camera"}
+              </DialogTitle>
+            </DialogHeader>
+            {mode !== "preview" && mode !== "recording" && (
+              <Button type="button" size="icon" variant="ghost" className="text-white hover:bg-white/20" onClick={flipCamera}>
+                <SwitchCamera className="w-5 h-5" />
+              </Button>
+            )}
+          </div>
+
+          {/* Bottom controls */}
+          <div className="absolute bottom-0 left-0 right-0 p-6 flex justify-center items-center gap-8 bg-gradient-to-t from-black/80 to-transparent">
+            {mode === "preview" ? (
+              <>
+                <Button type="button" size="icon" variant="ghost" className="rounded-full border border-white/40 text-white hover:bg-white/20 w-12 h-12" onClick={retake}>
+                  <RotateCcw className="w-5 h-5" />
+                </Button>
+                <Button type="button" size="icon" className="rounded-full bg-white text-black hover:bg-white/90 w-16 h-16" onClick={confirm}>
+                  <Check className="w-6 h-6" />
+                </Button>
+                <Button type="button" size="icon" variant="ghost" className="rounded-full border border-white/40 text-white hover:bg-white/20 w-12 h-12" onClick={() => onOpenChange(false)}>
+                  <X className="w-5 h-5" />
+                </Button>
+              </>
+            ) : mode === "recording" ? (
+              <Button type="button" size="icon" className="rounded-full bg-red-600 hover:bg-red-700 w-16 h-16" onClick={stopRecording}>
+                <Square className="w-6 h-6 fill-white text-white" />
+              </Button>
+            ) : (
+              <>
+                <Button type="button" size="icon" variant="ghost" className="rounded-full border border-white/40 text-white hover:bg-white/20 w-12 h-12" onClick={takePhoto}>
+                  <Camera className="w-5 h-5" />
+                </Button>
+                <Button type="button" size="icon" className="rounded-full border-4 border-white bg-transparent hover:bg-white/10 w-16 h-16" onClick={startRecording}>
+                  <Circle className="w-8 h-8 fill-red-500 text-red-500" />
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/create-post-modal.tsx
+++ b/client/src/components/create-post-modal.tsx
@@ -18,7 +18,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useUser } from "@/contexts/UserContext";
 import GoLiveModal from "@/components/GoLiveModal";
 
-type PostType = "post" | "recipe" | "review" | "bite" | "clip";
+type PostType = "post" | "recipe" | "review" | "bite" | "reel";
 
 type IngredientRow = {
   name: string;
@@ -79,7 +79,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
   const [reviewCons, setReviewCons] = useState("");
   const [reviewVerdict, setReviewVerdict] = useState("");
 
-  // Bite / Clip fields
+  // Bite / Reel fields
   const [biteExpiry, setBiteExpiry] = useState<"24h" | "permanent">("24h");
   const [showGoLive, setShowGoLive] = useState(false);
   const biteFileRef = useRef<HTMLInputElement>(null);
@@ -207,7 +207,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
       return false;
     }
 
-    if (postType === "bite" || postType === "clip") {
+    if (postType === "bite" || postType === "reel") {
       if (!biteMediaUrl) {
         toast({ variant: "destructive", description: "Please pick a video or photo" });
         return false;
@@ -251,7 +251,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
     if (!validate()) return;
 
     // Bite → POST /api/bites
-    if (postType === "bite" || postType === "clip") {
+    if (postType === "bite" || postType === "reel") {
       try {
         const expiresAt = biteExpiry === "permanent"
           ? new Date(Date.now() + 100 * 365 * 24 * 60 * 60 * 1000).toISOString() // ~100 years
@@ -268,7 +268,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
           }),
         });
         if (!res.ok) throw new Error("Failed to create bite");
-        toast({ description: postType === "clip" ? "Clip shared!" : "Bite shared!" });
+        toast({ description: postType === "reel" ? "Reel shared!" : "Bite shared!" });
         onOpenChange(false);
         resetForm();
       } catch (err: any) {
@@ -322,8 +322,8 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
-          {/* Image Upload — hidden for bite/clip which have their own picker */}
-          <div className={`border-2 border-dashed border-border rounded-lg p-6 text-center ${postType === "bite" || postType === "clip" ? "hidden" : ""}`}>
+          {/* Image Upload — hidden for bite/reel which have their own picker */}
+          <div className={`border-2 border-dashed border-border rounded-lg p-6 text-center ${postType === "bite" || postType === "reel" ? "hidden" : ""}`}>
             <Camera className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
 
             {imagePreview ? (
@@ -412,15 +412,15 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
                 <SelectItem value="recipe">Recipe</SelectItem>
                 <SelectItem value="review">Review</SelectItem>
                 <SelectItem value="bite">Bite (24h story)</SelectItem>
-                <SelectItem value="clip">Clip (video)</SelectItem>
+                <SelectItem value="reel">Reel (video)</SelectItem>
               </SelectContent>
             </Select>
           </div>
 
           <Separator />
 
-          {/* Bite / Clip media picker */}
-          {(postType === "bite" || postType === "clip") && (
+          {/* Bite / Reel media picker */}
+          {(postType === "bite" || postType === "reel") && (
             <div className="space-y-3">
               <input
                 ref={biteFileRef}
@@ -450,10 +450,10 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
               <div className="flex items-center gap-3 p-3 bg-muted/40 rounded-lg">
                 <div className="flex-1 space-y-0.5">
                   <p className="text-sm font-medium">
-                    {biteExpiry === "permanent" ? "Add to Bites profile tab (permanent)" : "Show in Bites row for 24 hours only"}
+                    {biteExpiry === "permanent" ? "Add to Reels profile tab (permanent)" : "Show in Bites row for 24 hours only"}
                   </p>
                   <p className="text-xs text-muted-foreground">
-                    {biteExpiry === "permanent" ? "Stays on your profile Bites tab forever" : "Disappears automatically after 24 hours"}
+                    {biteExpiry === "permanent" ? "Stays on your profile Reels tab forever" : "Disappears automatically after 24 hours"}
                   </p>
                 </div>
                 <button
@@ -467,8 +467,8 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
                 </button>
               </div>
 
-              {/* Go Live button for clips */}
-              {postType === "clip" && (
+              {/* Go Live button for reels */}
+              {postType === "reel" && (
                 <Button
                   type="button"
                   variant="outline"
@@ -664,8 +664,8 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
             </div>
           )}
 
-          {/* Tags — not shown for bites/clips */}
-          {postType !== "bite" && postType !== "clip" && (
+          {/* Tags — not shown for bites/reels */}
+          {postType !== "bite" && postType !== "reel" && (
             <div className="space-y-2">
               <Label className="text-sm">Tags (comma separated)</Label>
               <Input
@@ -682,7 +682,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
             className="w-full bg-primary text-primary-foreground hover:opacity-90"
             disabled={createPostMutation.isPending}
           >
-            {createPostMutation.isPending ? "Sharing..." : postType === "recipe" ? "Share Recipe" : postType === "review" ? "Share Review" : postType === "bite" ? "Share Bite" : postType === "clip" ? "Share Clip" : "Share Post"}
+            {createPostMutation.isPending ? "Sharing..." : postType === "recipe" ? "Share Recipe" : postType === "review" ? "Share Review" : postType === "bite" ? "Share Bite" : postType === "reel" ? "Share Reel" : "Share Post"}
           </Button>
         </form>
       </DialogContent>

--- a/client/src/components/create-post-modal.tsx
+++ b/client/src/components/create-post-modal.tsx
@@ -18,7 +18,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useUser } from "@/contexts/UserContext";
 import GoLiveModal from "@/components/GoLiveModal";
 
-type PostType = "post" | "recipe" | "review" | "bite" | "reel";
+type PostType = "post" | "recipe" | "review" | "bite" | "clip";
 
 type IngredientRow = {
   name: string;
@@ -79,7 +79,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
   const [reviewCons, setReviewCons] = useState("");
   const [reviewVerdict, setReviewVerdict] = useState("");
 
-  // Bite / Reel fields
+  // Bite / Clip fields
   const [biteExpiry, setBiteExpiry] = useState<"24h" | "permanent">("24h");
   const [showGoLive, setShowGoLive] = useState(false);
   const biteFileRef = useRef<HTMLInputElement>(null);
@@ -207,7 +207,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
       return false;
     }
 
-    if (postType === "bite" || postType === "reel") {
+    if (postType === "bite" || postType === "clip") {
       if (!biteMediaUrl) {
         toast({ variant: "destructive", description: "Please pick a video or photo" });
         return false;
@@ -251,7 +251,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
     if (!validate()) return;
 
     // Bite → POST /api/bites
-    if (postType === "bite" || postType === "reel") {
+    if (postType === "bite" || postType === "clip") {
       try {
         const expiresAt = biteExpiry === "permanent"
           ? new Date(Date.now() + 100 * 365 * 24 * 60 * 60 * 1000).toISOString() // ~100 years
@@ -268,7 +268,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
           }),
         });
         if (!res.ok) throw new Error("Failed to create bite");
-        toast({ description: postType === "reel" ? "Reel shared!" : "Bite shared!" });
+        toast({ description: postType === "clip" ? "Clip shared!" : "Bite shared!" });
         onOpenChange(false);
         resetForm();
       } catch (err: any) {
@@ -322,8 +322,8 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
-          {/* Image Upload — hidden for bite/reel which have their own picker */}
-          <div className={`border-2 border-dashed border-border rounded-lg p-6 text-center ${postType === "bite" || postType === "reel" ? "hidden" : ""}`}>
+          {/* Image Upload — hidden for bite/clip which have their own picker */}
+          <div className={`border-2 border-dashed border-border rounded-lg p-6 text-center ${postType === "bite" || postType === "clip" ? "hidden" : ""}`}>
             <Camera className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
 
             {imagePreview ? (
@@ -412,15 +412,15 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
                 <SelectItem value="recipe">Recipe</SelectItem>
                 <SelectItem value="review">Review</SelectItem>
                 <SelectItem value="bite">Bite (24h story)</SelectItem>
-                <SelectItem value="reel">Reel (video)</SelectItem>
+                <SelectItem value="clip">Clip (video)</SelectItem>
               </SelectContent>
             </Select>
           </div>
 
           <Separator />
 
-          {/* Bite / Reel media picker */}
-          {(postType === "bite" || postType === "reel") && (
+          {/* Bite / Clip media picker */}
+          {(postType === "bite" || postType === "clip") && (
             <div className="space-y-3">
               <input
                 ref={biteFileRef}
@@ -450,10 +450,10 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
               <div className="flex items-center gap-3 p-3 bg-muted/40 rounded-lg">
                 <div className="flex-1 space-y-0.5">
                   <p className="text-sm font-medium">
-                    {biteExpiry === "permanent" ? "Add to Reels profile tab (permanent)" : "Show in Bites row for 24 hours only"}
+                    {biteExpiry === "permanent" ? "Add to Bites profile tab (permanent)" : "Show in Bites row for 24 hours only"}
                   </p>
                   <p className="text-xs text-muted-foreground">
-                    {biteExpiry === "permanent" ? "Stays on your profile Reels tab forever" : "Disappears automatically after 24 hours"}
+                    {biteExpiry === "permanent" ? "Stays on your profile Bites tab forever" : "Disappears automatically after 24 hours"}
                   </p>
                 </div>
                 <button
@@ -467,8 +467,8 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
                 </button>
               </div>
 
-              {/* Go Live button for reels */}
-              {postType === "reel" && (
+              {/* Go Live button for clips */}
+              {postType === "clip" && (
                 <Button
                   type="button"
                   variant="outline"
@@ -664,8 +664,8 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
             </div>
           )}
 
-          {/* Tags — not shown for bites/reels */}
-          {postType !== "bite" && postType !== "reel" && (
+          {/* Tags — not shown for bites/clips */}
+          {postType !== "bite" && postType !== "clip" && (
             <div className="space-y-2">
               <Label className="text-sm">Tags (comma separated)</Label>
               <Input
@@ -682,7 +682,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
             className="w-full bg-primary text-primary-foreground hover:opacity-90"
             disabled={createPostMutation.isPending}
           >
-            {createPostMutation.isPending ? "Sharing..." : postType === "recipe" ? "Share Recipe" : postType === "review" ? "Share Review" : postType === "bite" ? "Share Bite" : postType === "reel" ? "Share Reel" : "Share Post"}
+            {createPostMutation.isPending ? "Sharing..." : postType === "recipe" ? "Share Recipe" : postType === "review" ? "Share Review" : postType === "bite" ? "Share Bite" : postType === "clip" ? "Share Clip" : "Share Post"}
           </Button>
         </form>
       </DialogContent>

--- a/client/src/pages/social/create-post.tsx
+++ b/client/src/pages/social/create-post.tsx
@@ -21,6 +21,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useUser } from "@/contexts/UserContext";
 import { useGoogleMaps } from "@/hooks/useGoogleMaps";
 import GoLiveModal from "@/components/GoLiveModal";
+import CameraModal from "@/components/CameraModal";
 
 const EMPTY_SELECT = "__empty__";
 
@@ -204,6 +205,19 @@ export default function CreatePost() {
     reviewNotes: "",
   });
   const [galleryUrlInput, setGalleryUrlInput] = useState("");
+
+  const [showCamera, setShowCamera] = useState(false);
+
+  const handleCameraCapture = (dataUrl: string, type: "image" | "video") => {
+    const kind: MediaKind = type;
+    setMediaPreview(dataUrl);
+    setMediaKind(kind);
+    if (kind === "video") {
+      setFormData((prev) => ({ ...prev, imageUrl: dataUrl, additionalImages: [] }));
+    } else {
+      setFormData((prev) => ({ ...prev, imageUrl: dataUrl, additionalImages: [] }));
+    }
+  };
 
   // Bite / Clip state
   const [biteExpiry, setBiteExpiry] = useState<"24h" | "permanent">("24h");
@@ -890,7 +904,7 @@ export default function CreatePost() {
                       <Button
                         type="button"
                         variant="outline"
-                        onClick={() => document.getElementById("camera-input")?.click()}
+                        onClick={() => setShowCamera(true)}
                         className="flex-1"
                       >
                         <Camera className="h-4 w-4 mr-2" />
@@ -908,15 +922,6 @@ export default function CreatePost() {
                       </Button>
                     </div>
 
-                    <input
-                      id="camera-input"
-                      type="file"
-                      accept="image/*,video/*"
-                      capture="environment"
-                      onChange={handleFileSelect}
-                      className="hidden"
-                      data-testid="input-camera"
-                    />
                     <input
                       id="file-input"
                       type="file"
@@ -1412,6 +1417,7 @@ export default function CreatePost() {
       </Card>
 
       <GoLiveModal open={showGoLive} onOpenChange={setShowGoLive} />
+      <CameraModal open={showCamera} onOpenChange={setShowCamera} onCapture={handleCameraCapture} />
     </div>
   );
 }

--- a/client/src/pages/social/create-post.tsx
+++ b/client/src/pages/social/create-post.tsx
@@ -59,7 +59,7 @@ const UNIT_OPTIONS = [
   "piece",
 ];
 
-type PostType = "post" | "recipe" | "review" | "bite" | "clip";
+type PostType = "post" | "recipe" | "review" | "bite" | "clip" | "live";
 type IngredientRow = { amount: string; unit: string; name: string };
 type MediaKind = "image" | "video" | "";
 type PostImage = { id: string; url: string };
@@ -404,6 +404,11 @@ export default function CreatePost() {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
+    if (formData.postType === "live") {
+      setShowGoLive(true);
+      return;
+    }
+
     if (formData.postType === "bite" || formData.postType === "clip") {
       if (!biteMediaUrl) {
         toast({ variant: "destructive", description: "Please pick a video or photo" });
@@ -663,7 +668,10 @@ export default function CreatePost() {
               <Label>Post type</Label>
               <Select
                 value={formData.postType}
-                onValueChange={(v) => handleChange("postType", v as PostType)}
+                onValueChange={(v) => {
+                  handleChange("postType", v as PostType);
+                  if (v === "live") setShowGoLive(true);
+                }}
               >
                 <SelectTrigger data-testid="select-post-type">
                   <SelectValue placeholder="Choose type" />
@@ -674,9 +682,30 @@ export default function CreatePost() {
                   <SelectItem value="review">Review</SelectItem>
                   <SelectItem value="bite">Bite (24h story)</SelectItem>
                   <SelectItem value="clip">Clip (video)</SelectItem>
+                  <SelectItem value="live">Go Live</SelectItem>
                 </SelectContent>
               </Select>
             </div>
+
+            {/* Go Live — direct launch */}
+            {formData.postType === "live" && (
+              <div className="flex flex-col items-center gap-4 py-8">
+                <div className="w-16 h-16 rounded-full bg-red-100 dark:bg-red-950 flex items-center justify-center">
+                  <Radio className="w-8 h-8 text-red-500" />
+                </div>
+                <p className="text-sm text-muted-foreground text-center">
+                  Your camera preview will open. Start streaming when you're ready.
+                </p>
+                <Button
+                  type="button"
+                  className="w-48 bg-red-600 hover:bg-red-700 text-white font-semibold rounded-full"
+                  onClick={() => setShowGoLive(true)}
+                >
+                  <Radio className="w-4 h-4 mr-2" />
+                  Open Camera
+                </Button>
+              </div>
+            )}
 
             {/* Bite / Clip media picker */}
             {(formData.postType === "bite" || formData.postType === "clip") && (
@@ -735,8 +764,8 @@ export default function CreatePost() {
               </div>
             )}
 
-            {/* Media Upload — hidden for bite/clip */}
-            <div className={`space-y-2 ${formData.postType === "bite" || formData.postType === "clip" ? "hidden" : ""}`}>
+            {/* Media Upload — hidden for bite/clip/live */}
+            <div className={`space-y-2 ${formData.postType === "bite" || formData.postType === "clip" || formData.postType === "live" ? "hidden" : ""}`}>
               <Label htmlFor="imageUrl">Photo/Video *</Label>
               <div className="border-2 border-dashed border-border rounded-lg p-8 text-center">
                 {mediaPreview ? (
@@ -1098,8 +1127,8 @@ export default function CreatePost() {
               </>
             )}
 
-            {/* Caption (Post/Recipe only) */}
-            {formData.postType !== "review" && (
+            {/* Caption (Post/Recipe/Bite/Clip only) */}
+            {formData.postType !== "review" && formData.postType !== "live" && (
               <div className="space-y-2">
                 <Label htmlFor="caption">Caption</Label>
                 <Textarea
@@ -1115,7 +1144,7 @@ export default function CreatePost() {
             )}
 
             {/* Tags */}
-            <div className={`space-y-2 ${formData.postType === "bite" || formData.postType === "clip" ? "hidden" : ""}`}>
+            <div className={`space-y-2 ${formData.postType === "bite" || formData.postType === "clip" || formData.postType === "live" ? "hidden" : ""}`}>
               <Label>Tags</Label>
               <div className="space-y-2">
                 {formData.tags.map((tag, index) => (
@@ -1361,21 +1390,23 @@ export default function CreatePost() {
               </>
             )}
 
-            {/* Submit */}
-            <Button
-              type="submit"
-              className="w-full"
-              disabled={createPostMutation.isPending || biteSubmitting}
-              data-testid="button-submit-post"
-            >
-              {createPostMutation.isPending || biteSubmitting
-                ? "Posting..."
-                : formData.postType === "bite"
-                ? "Share Bite"
-                : formData.postType === "clip"
-                ? "Share Clip"
-                : "Post"}
-            </Button>
+            {/* Submit — hidden for Go Live (camera opens directly) */}
+            {formData.postType !== "live" && (
+              <Button
+                type="submit"
+                className="w-full"
+                disabled={createPostMutation.isPending || biteSubmitting}
+                data-testid="button-submit-post"
+              >
+                {createPostMutation.isPending || biteSubmitting
+                  ? "Posting..."
+                  : formData.postType === "bite"
+                  ? "Share Bite"
+                  : formData.postType === "clip"
+                  ? "Share Clip"
+                  : "Post"}
+              </Button>
+            )}
           </form>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary

- **Go Live** added as its own option in the post type dropdown — selecting it immediately opens the camera modal, no form fields shown
- **Camera button** now launches a real camera modal instead of a file picker:
  - Camera icon = take a still photo
  - Red circle = start video recording (MediaRecorder API)
  - Red square = stop recording
  - Preview before confirming or retaking
  - Front/back camera flip button
  - Works on desktop and mobile
- **Upload Media** button unchanged — still opens the file picker for existing files

## Test plan
- [ ] Open `/create`, confirm dropdown has a **Go Live** option
- [ ] Select Go Live — camera preview opens immediately, no form shown
- [ ] On Post/Recipe/Review, click **Camera** — camera modal opens (not file picker)
- [ ] Take a photo, confirm preview shows, checkmark confirms it into the post
- [ ] Record a video, stop it, preview plays, confirm uses it
- [ ] Flip camera button switches front/back
- [ ] Upload Media still opens the file picker as before

https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e)_