### PR TITLE
Make Bites first-class stories

### DIFF
--- a/client/src/components/BitesRow.tsx
+++ b/client/src/components/BitesRow.tsx
@@ -1,12 +1,24 @@
-import { useState, useEffect, useRef } from 'react';
-import { Heart, MessageCircle, Share, ChevronLeft, ChevronRight, X, Plus, Video, Upload, Camera } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Badge } from '@/components/ui/badge';
-import { useUser } from '@/contexts/UserContext';
-import CameraModal from '@/components/CameraModal';
-import { uploadMediaUrl } from '@/lib/uploadMedia';
-import chefLogo from '../asset/logo.jpg'; // Add import to match layout
+import { useState, useEffect, useMemo, useRef } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Heart,
+  MessageCircle,
+  Share,
+  ChevronLeft,
+  ChevronRight,
+  X,
+  Plus,
+  Video,
+  Upload,
+  Camera,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { useUser } from "@/contexts/UserContext";
+import CameraModal from "@/components/CameraModal";
+import { uploadMediaUrl } from "@/lib/uploadMedia";
+import chefLogo from "../asset/logo.jpg"; // Add import to match layout
 
 interface Bite {
   id: string;
@@ -14,7 +26,7 @@ interface Bite {
   username: string;
   avatar: string;
   content: {
-    type: 'image' | 'video';
+    type: "image" | "video";
     url: string;
     thumbnail?: string;
   };
@@ -40,6 +52,7 @@ type ActiveBiteApiItem = {
   id: string;
   userId: string;
   imageUrl: string;
+  mediaType: "image" | "video";
   caption?: string | null;
   createdAt?: string | null;
   user?: {
@@ -49,31 +62,12 @@ type ActiveBiteApiItem = {
   } | null;
 };
 
-const SAMPLE_BITES: ActiveBiteApiItem[] = [
-  {
-    id: "sample-bite-1",
-    userId: "sample-chef-1",
-    imageUrl: "https://images.unsplash.com/photo-1555939594-58d7cb561ad1?auto=format&fit=crop&w=800&q=80",
-    caption: "Sample bite: quick plating idea for tonight's special.",
-    createdAt: new Date().toISOString(),
-    user: { username: "Chef Lina", avatar: "" },
-  },
-  {
-    id: "sample-bite-2",
-    userId: "sample-chef-2",
-    imageUrl: "https://images.unsplash.com/photo-1540189549336-e6e99c3679fe?auto=format&fit=crop&w=800&q=80",
-    caption: "Sample bite: testing a citrus glaze.",
-    createdAt: new Date().toISOString(),
-    user: { username: "Chef Mateo", avatar: "" },
-  },
-];
-
 // Custom Logo Component
 const CustomLogo = () => (
   <div className="flex items-center">
-    <img 
-      src={chefLogo} 
-      alt="Logo" 
+    <img
+      src={chefLogo}
+      alt="Logo"
       className="w-8 h-8 rounded-full object-cover"
     />
   </div>
@@ -85,24 +79,22 @@ interface BitesRowProps {
 
 export function BitesRow({ className = "" }: BitesRowProps) {
   const { user } = useUser();
-  const [userBites, setUserBites] = useState<UserBites[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState("");
-  const [usingSampleBites, setUsingSampleBites] = useState(false);
+  const queryClient = useQueryClient();
+  const [viewedUserIds, setViewedUserIds] = useState<Set<string>>(new Set());
+  const [likedBiteIds, setLikedBiteIds] = useState<Set<string>>(new Set());
   const [isViewing, setIsViewing] = useState(false);
   const [currentUserIndex, setCurrentUserIndex] = useState(0);
   const [currentBiteIndex, setCurrentBiteIndex] = useState(0);
   const [progress, setProgress] = useState(0);
   const [isPaused, setIsPaused] = useState(false);
 
-  const currentUser = userBites[currentUserIndex];
-  const currentBite = currentUser?.bites[currentBiteIndex];
-
   // Create bite state
   const [isCreating, setIsCreating] = useState(false);
   const [createCaption, setCreateCaption] = useState("");
   const [createMediaUrl, setCreateMediaUrl] = useState<string | null>(null);
-  const [createMediaType, setCreateMediaType] = useState<"image" | "video">("video");
+  const [createMediaType, setCreateMediaType] = useState<"image" | "video">(
+    "video",
+  );
   const [createSubmitting, setCreateSubmitting] = useState(false);
   const [createError, setCreateError] = useState("");
   const [showCamera, setShowCamera] = useState(false);
@@ -113,85 +105,64 @@ export function BitesRow({ className = "" }: BitesRowProps) {
     setCreateMediaUrl(dataUrl);
   };
 
-  useEffect(() => {
-    let active = true;
+  const activeBitesQueryKey = user?.id
+    ? ["/api/bites/active", user.id]
+    : ["/api/bites/active"];
 
-    const mapItemsToUserBites = (items: ActiveBiteApiItem[]) => {
-      const grouped = new Map<string, UserBites>();
-      for (const item of items) {
-        if (!item?.id || !item?.userId || !item?.imageUrl) continue;
-        const username = item.user?.username || item.user?.displayName || "Chef";
-        const avatar = item.user?.avatar || "";
-        const bite: Bite = {
-          id: item.id,
+  const activeBitesQuery = useQuery<ActiveBiteApiItem[]>({
+    queryKey: activeBitesQueryKey,
+    queryFn: async ({ queryKey }) => {
+      const endpoint = queryKey.join("/");
+      const response = await fetch(endpoint, { credentials: "include" });
+      const payload = await response.json().catch(() => null);
+      if (!response.ok)
+        throw new Error(payload?.message || "Failed to load bites");
+      return Array.isArray(payload) ? payload : [];
+    },
+  });
+
+  const userBites = useMemo(() => {
+    const grouped = new Map<string, UserBites>();
+    for (const item of activeBitesQuery.data ?? []) {
+      if (!item?.id || !item?.userId || !item?.imageUrl) continue;
+      const username = item.user?.username || item.user?.displayName || "Chef";
+      const avatar = item.user?.avatar || "";
+      const isLiked = likedBiteIds.has(item.id);
+      const bite: Bite = {
+        id: item.id,
+        userId: item.userId,
+        username,
+        avatar,
+        content: { type: item.mediaType, url: item.imageUrl },
+        caption: item.caption || "",
+        timestamp: item.createdAt ? new Date(item.createdAt) : new Date(),
+        duration: item.mediaType === "video" ? 15 : 5,
+        views: 0,
+        likes: isLiked ? 1 : 0,
+        isLiked,
+        tags: [],
+      };
+
+      const existing = grouped.get(item.userId);
+      if (existing) {
+        existing.bites.push(bite);
+      } else {
+        const isViewed = viewedUserIds.has(item.userId);
+        grouped.set(item.userId, {
           userId: item.userId,
           username,
           avatar,
-          content: { type: item.imageUrl.startsWith("data:video/") || item.imageUrl.match(/\.(mp4|webm|mov|avi)(\?|$)/i) ? "video" : "image", url: item.imageUrl },
-          caption: item.caption || "",
-          timestamp: item.createdAt ? new Date(item.createdAt) : new Date(),
-          duration: 5,
-          views: 0,
-          likes: 0,
-          isLiked: false,
-          tags: [],
-        };
-
-        const existing = grouped.get(item.userId);
-        if (existing) {
-          existing.bites.push(bite);
-        } else {
-          grouped.set(item.userId, {
-            userId: item.userId,
-            username,
-            avatar,
-            bites: [bite],
-            hasNewBites: true,
-            isViewed: false,
-          });
-        }
+          bites: [bite],
+          hasNewBites: !isViewed,
+          isViewed,
+        });
       }
-      return Array.from(grouped.values());
-    };
+    }
+    return Array.from(grouped.values());
+  }, [activeBitesQuery.data, likedBiteIds, viewedUserIds]);
 
-    const loadBites = async () => {
-      setLoading(true);
-      setLoadError("");
-      setUsingSampleBites(false);
-      try {
-        const endpoint = user?.id
-          ? `/api/bites/active/${encodeURIComponent(user.id)}`
-          : "/api/bites/active";
-        const response = await fetch(endpoint, { credentials: "include" });
-        const payload = await response.json().catch(() => null);
-        if (!response.ok) throw new Error(payload?.message || "Failed to load bites");
-
-        const items = Array.isArray(payload) ? (payload as ActiveBiteApiItem[]) : [];
-        const mapped = mapItemsToUserBites(items);
-
-        if (!active) return;
-        if (mapped.length > 0) {
-          setUserBites(mapped);
-          return;
-        }
-
-        setUserBites(mapItemsToUserBites(SAMPLE_BITES));
-        setUsingSampleBites(true);
-      } catch (error) {
-        if (!active) return;
-        setLoadError(error instanceof Error ? error.message : "Unable to load bites right now.");
-        setUserBites(mapItemsToUserBites(SAMPLE_BITES));
-        setUsingSampleBites(true);
-      } finally {
-        if (active) setLoading(false);
-      }
-    };
-
-    void loadBites();
-    return () => {
-      active = false;
-    };
-  }, [user?.id]);
+  const currentUser = userBites[currentUserIndex];
+  const currentBite = currentUser?.bites[currentBiteIndex];
 
   // Auto-advance bites
   useEffect(() => {
@@ -201,7 +172,7 @@ export function BitesRow({ className = "" }: BitesRowProps) {
       setProgress((prev) => {
         const increment = 100 / (currentBite.duration * 10);
         const newProgress = prev + increment;
-        
+
         if (newProgress >= 100) {
           handleNextBite();
           return 0;
@@ -214,12 +185,14 @@ export function BitesRow({ className = "" }: BitesRowProps) {
   }, [isViewing, currentUserIndex, currentBiteIndex, isPaused, currentBite]);
 
   const openUserBites = (userBite: UserBites) => {
-    const userIndex = userBites.findIndex(ub => ub.userId === userBite.userId);
+    const userIndex = userBites.findIndex(
+      (ub) => ub.userId === userBite.userId,
+    );
     setCurrentUserIndex(userIndex);
     setCurrentBiteIndex(0);
     setIsViewing(true);
     setProgress(0);
-    
+
     markUserAsViewed(userBite.userId);
   };
 
@@ -232,16 +205,16 @@ export function BitesRow({ className = "" }: BitesRowProps) {
 
   const handleNextBite = () => {
     if (!currentUser) return;
-    
+
     if (currentBiteIndex < currentUser.bites.length - 1) {
-      setCurrentBiteIndex(prev => prev + 1);
+      setCurrentBiteIndex((prev) => prev + 1);
       setProgress(0);
     } else if (currentUserIndex < userBites.length - 1) {
       const nextUserIndex = currentUserIndex + 1;
       setCurrentUserIndex(nextUserIndex);
       setCurrentBiteIndex(0);
       setProgress(0);
-      
+
       markUserAsViewed(userBites[nextUserIndex].userId);
     } else {
       closeBites();
@@ -250,7 +223,7 @@ export function BitesRow({ className = "" }: BitesRowProps) {
 
   const handlePrevBite = () => {
     if (currentBiteIndex > 0) {
-      setCurrentBiteIndex(prev => prev - 1);
+      setCurrentBiteIndex((prev) => prev - 1);
       setProgress(0);
     } else if (currentUserIndex > 0) {
       const prevUserIndex = currentUserIndex - 1;
@@ -262,20 +235,16 @@ export function BitesRow({ className = "" }: BitesRowProps) {
   };
 
   const markUserAsViewed = (userId: string) => {
-    setUserBites(prev => prev.map(ub => 
-      ub.userId === userId ? { ...ub, isViewed: true, hasNewBites: false } : ub
-    ));
+    setViewedUserIds((prev) => new Set(prev).add(userId));
   };
 
   const handleLike = (biteId: string) => {
-    setUserBites(prev => prev.map(user => ({
-      ...user,
-      bites: user.bites.map(bite =>
-        bite.id === biteId 
-          ? { ...bite, isLiked: !bite.isLiked, likes: bite.isLiked ? bite.likes - 1 : bite.likes + 1 }
-          : bite
-      )
-    })));
+    setLikedBiteIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(biteId)) next.delete(biteId);
+      else next.add(biteId);
+      return next;
+    });
   };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -310,15 +279,19 @@ export function BitesRow({ className = "" }: BitesRowProps) {
           userId: user.id,
           imageUrl: storedUrl,
           caption: createCaption.trim() || undefined,
+          mediaType: createMediaType,
         }),
       });
       if (!res.ok) {
         const payload = await res.json().catch(() => null);
         throw new Error(payload?.message || "Failed to create bite");
       }
+      await queryClient.invalidateQueries({ queryKey: ["/api/bites/active"] });
       resetCreate();
     } catch (err) {
-      setCreateError(err instanceof Error ? err.message : "Something went wrong");
+      setCreateError(
+        err instanceof Error ? err.message : "Something went wrong",
+      );
     } finally {
       setCreateSubmitting(false);
     }
@@ -327,7 +300,7 @@ export function BitesRow({ className = "" }: BitesRowProps) {
   const formatTimeAgo = (date: Date) => {
     const now = new Date();
     const diff = Math.floor((now.getTime() - date.getTime()) / 1000);
-    
+
     if (diff < 3600) return `${Math.floor(diff / 60)}m`;
     if (diff < 86400) return `${Math.floor(diff / 3600)}h`;
     return `${Math.floor(diff / 86400)}d`;
@@ -336,73 +309,89 @@ export function BitesRow({ className = "" }: BitesRowProps) {
   return (
     <>
       {/* Bites Row */}
-      <div className={`bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 ${className}`}>
+      <div
+        className={`bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 ${className}`}
+      >
         <div className="container mx-auto px-4 py-4">
           <h2 className="text-orange-500 text-lg font-bold mb-4 flex items-center">
             <CustomLogo />
             <span className="ml-3">Chef's Corner - Quick Bites</span>
           </h2>
-          {loading ? (
-            <p className="text-sm text-gray-500 dark:text-gray-400">Loading bites…</p>
-          ) : userBites.length === 0 ? (
-            <p className="text-sm text-gray-500 dark:text-gray-400">No bites available yet.</p>
-          ) : (
-          <>
-          {(loadError || usingSampleBites) ? (
-            <p className="mb-2 text-xs text-amber-600 dark:text-amber-400">
-              Showing sample bites while live bites are unavailable.
+          {activeBitesQuery.isLoading ? (
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Loading bites…
             </p>
-          ) : null}
-          <div className="flex items-center space-x-4 overflow-x-auto pb-2 scrollbar-hide">
-            {/* Your Bite (Create) */}
-            <div className="flex-shrink-0 cursor-pointer group" onClick={() => user ? setIsCreating(true) : null}>
-              <div className="relative">
-                <div className="w-16 h-16 bg-gray-100 dark:bg-gray-800 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-full flex items-center justify-center group-hover:border-primary transition-colors">
-                  <Plus className="w-6 h-6 text-gray-400 group-hover:text-primary" />
-                </div>
-              </div>
-              <p className="text-xs text-center mt-2 max-w-[70px] truncate text-gray-600 dark:text-gray-400">
-                Your bite
-              </p>
-            </div>
-
-            {/* Other User Bites */}
-            {userBites.map((userBite) => (
-              <div
-                key={userBite.userId}
-                className="flex-shrink-0 cursor-pointer group"
-                onClick={() => openUserBites(userBite)}
-              >
-                <div className={`relative p-0.5 rounded-full ${
-                  userBite.hasNewBites 
-                    ? 'bg-gradient-to-tr from-orange-400 via-red-500 to-pink-600' 
-                    : userBite.isViewed 
-                      ? 'bg-gray-300 dark:bg-gray-600' 
-                      : 'bg-gradient-to-tr from-orange-400 via-red-500 to-pink-600'
-                }`}>
-                  <Avatar className="w-16 h-16 border-2 border-white dark:border-gray-900">
-                    <AvatarImage 
-                      src={userBite.avatar} 
-                      alt={userBite.username}
-                      className="object-cover"
-                    />
-                    <AvatarFallback className="bg-gray-100 text-gray-600 font-medium">
-                      {userBite.username[0].toUpperCase()}
-                    </AvatarFallback>
-                  </Avatar>
-                  {userBite.hasNewBites && (
-                    <div className="absolute -top-1 -right-1 w-6 h-6 bg-red-500 rounded-full flex items-center justify-center">
-                      <span className="text-white text-xs font-bold">{userBite.bites.length}</span>
+          ) : activeBitesQuery.error ? (
+            <p className="text-sm text-red-600 dark:text-red-400">
+              {activeBitesQuery.error instanceof Error
+                ? activeBitesQuery.error.message
+                : "Unable to load bites right now."}
+            </p>
+          ) : (
+            <>
+              <div className="flex items-center space-x-4 overflow-x-auto pb-2 scrollbar-hide">
+                {/* Your Bite (Create) */}
+                <div
+                  className="flex-shrink-0 cursor-pointer group"
+                  onClick={() => (user ? setIsCreating(true) : null)}
+                >
+                  <div className="relative">
+                    <div className="w-16 h-16 bg-gray-100 dark:bg-gray-800 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-full flex items-center justify-center group-hover:border-primary transition-colors">
+                      <Plus className="w-6 h-6 text-gray-400 group-hover:text-primary" />
                     </div>
-                  )}
+                  </div>
+                  <p className="text-xs text-center mt-2 max-w-[70px] truncate text-gray-600 dark:text-gray-400">
+                    Your bite
+                  </p>
                 </div>
-                <p className="text-xs text-center mt-2 max-w-[70px] truncate text-gray-700 dark:text-gray-300">
-                  {userBite.username}
-                </p>
+
+                {userBites.length === 0 ? (
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    No bites available yet.
+                  </p>
+                ) : null}
+
+                {/* Other User Bites */}
+                {userBites.map((userBite) => (
+                  <div
+                    key={userBite.userId}
+                    className="flex-shrink-0 cursor-pointer group"
+                    onClick={() => openUserBites(userBite)}
+                  >
+                    <div
+                      className={`relative p-0.5 rounded-full ${
+                        userBite.hasNewBites
+                          ? "bg-gradient-to-tr from-orange-400 via-red-500 to-pink-600"
+                          : userBite.isViewed
+                            ? "bg-gray-300 dark:bg-gray-600"
+                            : "bg-gradient-to-tr from-orange-400 via-red-500 to-pink-600"
+                      }`}
+                    >
+                      <Avatar className="w-16 h-16 border-2 border-white dark:border-gray-900">
+                        <AvatarImage
+                          src={userBite.avatar}
+                          alt={userBite.username}
+                          className="object-cover"
+                        />
+                        <AvatarFallback className="bg-gray-100 text-gray-600 font-medium">
+                          {userBite.username[0].toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                      {userBite.hasNewBites && (
+                        <div className="absolute -top-1 -right-1 w-6 h-6 bg-red-500 rounded-full flex items-center justify-center">
+                          <span className="text-white text-xs font-bold">
+                            {userBite.bites.length}
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                    <p className="text-xs text-center mt-2 max-w-[70px] truncate text-gray-700 dark:text-gray-300">
+                      {userBite.username}
+                    </p>
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
-          </>
+            </>
           )}
         </div>
       </div>
@@ -419,22 +408,50 @@ export function BitesRow({ className = "" }: BitesRowProps) {
             </div>
 
             {/* Media picker */}
-            <input ref={fileInputRef} type="file" accept="video/*,image/*" className="hidden" onChange={handleFileChange} />
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="video/*,image/*"
+              className="hidden"
+              onChange={handleFileChange}
+            />
             <div className="w-full aspect-[9/16] max-h-64 bg-gray-100 dark:bg-gray-800 rounded-xl overflow-hidden border-2 border-dashed border-gray-300 dark:border-gray-600">
               {createMediaUrl && createMediaType === "video" ? (
-                <video src={createMediaUrl} className="w-full h-full object-cover rounded-xl" controls muted playsInline />
+                <video
+                  src={createMediaUrl}
+                  className="w-full h-full object-cover rounded-xl"
+                  controls
+                  muted
+                  playsInline
+                />
               ) : createMediaUrl ? (
-                <img src={createMediaUrl} alt="Preview" className="w-full h-full object-cover rounded-xl" />
+                <img
+                  src={createMediaUrl}
+                  alt="Preview"
+                  className="w-full h-full object-cover rounded-xl"
+                />
               ) : (
                 <div className="w-full h-full flex flex-col items-center justify-center gap-3 text-gray-400">
                   <Video className="w-8 h-8" />
-                  <span className="text-sm font-medium">Add video or photo</span>
+                  <span className="text-sm font-medium">
+                    Add video or photo
+                  </span>
                   <div className="flex gap-2">
-                    <Button type="button" size="sm" variant="outline" onClick={() => setShowCamera(true)}>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setShowCamera(true)}
+                    >
                       <Camera className="w-4 h-4 mr-1" />
                       Camera
                     </Button>
-                    <Button type="button" size="sm" variant="outline" onClick={() => fileInputRef.current?.click()}>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => fileInputRef.current?.click()}
+                    >
                       <Upload className="w-4 h-4 mr-1" />
                       Upload
                     </Button>
@@ -453,7 +470,9 @@ export function BitesRow({ className = "" }: BitesRowProps) {
               maxLength={500}
             />
 
-            {createError && <p className="text-red-500 text-sm">{createError}</p>}
+            {createError && (
+              <p className="text-red-500 text-sm">{createError}</p>
+            )}
 
             <Button
               className="w-full"
@@ -466,7 +485,11 @@ export function BitesRow({ className = "" }: BitesRowProps) {
         </div>
       )}
 
-      <CameraModal open={showCamera} onOpenChange={setShowCamera} onCapture={handleCameraCapture} />
+      <CameraModal
+        open={showCamera}
+        onOpenChange={setShowCamera}
+        onCapture={handleCameraCapture}
+      />
 
       {/* Bite Viewer Modal */}
       {isViewing && currentBite && (
@@ -474,11 +497,19 @@ export function BitesRow({ className = "" }: BitesRowProps) {
           {/* Progress bars - only for CURRENT user's bites */}
           <div className="absolute top-4 left-4 right-4 flex space-x-1 z-10">
             {currentUser.bites.map((_, index) => (
-              <div key={index} className="flex-1 h-1 bg-white/30 rounded-full overflow-hidden">
-                <div 
+              <div
+                key={index}
+                className="flex-1 h-1 bg-white/30 rounded-full overflow-hidden"
+              >
+                <div
                   className="h-full bg-white rounded-full transition-all duration-100"
                   style={{
-                    width: index === currentBiteIndex ? `${progress}%` : index < currentBiteIndex ? '100%' : '0%'
+                    width:
+                      index === currentBiteIndex
+                        ? `${progress}%`
+                        : index < currentBiteIndex
+                          ? "100%"
+                          : "0%",
                   }}
                 />
               </div>
@@ -514,8 +545,8 @@ export function BitesRow({ className = "" }: BitesRowProps) {
           {/* Navigation areas */}
           <div className="absolute inset-0 flex">
             <div className="flex-1 cursor-pointer" onClick={handlePrevBite} />
-            <div 
-              className="flex-1 cursor-pointer" 
+            <div
+              className="flex-1 cursor-pointer"
               onClick={handleNextBite}
               onMouseDown={() => setIsPaused(true)}
               onMouseUp={() => setIsPaused(false)}
@@ -534,7 +565,7 @@ export function BitesRow({ className = "" }: BitesRowProps) {
               <ChevronLeft className="w-6 h-6" />
             </Button>
           )}
-          
+
           <Button
             variant="ghost"
             size="icon"
@@ -551,10 +582,17 @@ export function BitesRow({ className = "" }: BitesRowProps) {
                 key={currentBite.id}
                 src={currentBite.content.url}
                 className="w-full h-full object-cover rounded-lg"
+                controls
                 autoPlay
-                loop
-                muted={false}
+                muted
                 playsInline
+                preload="metadata"
+                onLoadedMetadata={(event) =>
+                  event.currentTarget.play().catch(() => undefined)
+                }
+                onCanPlay={(event) =>
+                  event.currentTarget.play().catch(() => undefined)
+                }
               />
             ) : (
               <img
@@ -563,7 +601,7 @@ export function BitesRow({ className = "" }: BitesRowProps) {
                 className="w-full h-full object-cover rounded-lg"
               />
             )}
-            
+
             {/* Caption and actions */}
             <div className="absolute bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-black/80 to-transparent">
               <div className="flex items-start justify-between mb-2">
@@ -577,18 +615,18 @@ export function BitesRow({ className = "" }: BitesRowProps) {
                     className="text-white hover:bg-white/20"
                     onClick={() => handleLike(currentBite.id)}
                   >
-                    <Heart 
+                    <Heart
                       className={`w-6 h-6 ${
-                        currentBite.isLiked 
-                          ? 'fill-red-500 text-red-500' 
-                          : 'text-white'
-                      }`} 
+                        currentBite.isLiked
+                          ? "fill-red-500 text-red-500"
+                          : "text-white"
+                      }`}
                     />
                   </Button>
                   <span className="text-white text-xs">
                     {currentBite.likes}
                   </span>
-                  
+
                   <Button
                     variant="ghost"
                     size="icon"
@@ -596,7 +634,7 @@ export function BitesRow({ className = "" }: BitesRowProps) {
                   >
                     <MessageCircle className="w-6 h-6" />
                   </Button>
-                  
+
                   <Button
                     variant="ghost"
                     size="icon"
@@ -606,12 +644,16 @@ export function BitesRow({ className = "" }: BitesRowProps) {
                   </Button>
                 </div>
               </div>
-              
+
               {/* Tags */}
               {currentBite.tags.length > 0 && (
                 <div className="flex flex-wrap gap-1 mt-2">
                   {currentBite.tags.map((tag) => (
-                    <Badge key={tag} variant="secondary" className="text-xs bg-white/20 text-white border-none">
+                    <Badge
+                      key={tag}
+                      variant="secondary"
+                      className="text-xs bg-white/20 text-white border-none"
+                    >
                       #{tag}
                     </Badge>
                   ))}

--- a/client/src/components/create-post-modal.tsx
+++ b/client/src/components/create-post-modal.tsx
@@ -11,7 +11,13 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Camera, X, Plus, Star, Video, Radio } from "lucide-react";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -48,7 +54,10 @@ interface CreatePostModalProps {
   onOpenChange: (open: boolean) => void;
 }
 
-export default function CreatePostModal({ open, onOpenChange }: CreatePostModalProps) {
+export default function CreatePostModal({
+  open,
+  onOpenChange,
+}: CreatePostModalProps) {
   const { toast } = useToast();
   const { user } = useUser();
   const queryClient = useQueryClient();
@@ -84,11 +93,17 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
   const [showGoLive, setShowGoLive] = useState(false);
   const biteFileRef = useRef<HTMLInputElement>(null);
   const [biteMediaUrl, setBiteMediaUrl] = useState<string>("");
-  const [biteMediaType, setBiteMediaType] = useState<"image" | "video">("video");
+  const [biteMediaType, setBiteMediaType] = useState<"image" | "video">(
+    "video",
+  );
 
   const cleanedTags = useMemo(
-    () => tags.split(",").map((t) => t.trim()).filter(Boolean),
-    [tags]
+    () =>
+      tags
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean),
+    [tags],
   );
 
   const createPostMutation = useMutation({
@@ -190,7 +205,9 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
 
   const buildReviewCaption = () => {
     const rating = Number(reviewRating || "0");
-    const stars = "★★★★★".slice(0, Math.max(0, Math.min(5, rating))) + "☆☆☆☆☆".slice(0, 5 - Math.max(0, Math.min(5, rating)));
+    const stars =
+      "★★★★★".slice(0, Math.max(0, Math.min(5, rating))) +
+      "☆☆☆☆☆".slice(0, 5 - Math.max(0, Math.min(5, rating)));
     const parts: string[] = [];
     parts.push(`REVIEW • ${reviewSubject.trim() || "Untitled"}`);
     parts.push(`${stars} (${rating}/5)`);
@@ -203,42 +220,63 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
 
   const validate = () => {
     if (!user?.id) {
-      toast({ variant: "destructive", description: "You must be logged in to create a post" });
+      toast({
+        variant: "destructive",
+        description: "You must be logged in to create a post",
+      });
       return false;
     }
 
     if (postType === "bite" || postType === "clip") {
       if (!biteMediaUrl) {
-        toast({ variant: "destructive", description: "Please pick a video or photo" });
+        toast({
+          variant: "destructive",
+          description: "Please pick a video or photo",
+        });
         return false;
       }
       return true;
     }
 
     if (!imageUrl) {
-      toast({ variant: "destructive", description: "Please add an image (upload or paste URL)" });
+      toast({
+        variant: "destructive",
+        description: "Please add an image (upload or paste URL)",
+      });
       return false;
     }
 
     if (postType === "recipe") {
       if (!recipeTitle.trim()) {
-        toast({ variant: "destructive", description: "Please add a recipe title" });
+        toast({
+          variant: "destructive",
+          description: "Please add a recipe title",
+        });
         return false;
       }
       const payload = buildRecipePayload();
       if (!payload.ingredients.length) {
-        toast({ variant: "destructive", description: "Please add at least 1 ingredient" });
+        toast({
+          variant: "destructive",
+          description: "Please add at least 1 ingredient",
+        });
         return false;
       }
       if (!payload.instructions.length) {
-        toast({ variant: "destructive", description: "Please add at least 1 instruction step" });
+        toast({
+          variant: "destructive",
+          description: "Please add at least 1 instruction step",
+        });
         return false;
       }
     }
 
     if (postType === "review") {
       if (!reviewSubject.trim()) {
-        toast({ variant: "destructive", description: "Please add what you're reviewing (subject)" });
+        toast({
+          variant: "destructive",
+          description: "Please add what you're reviewing (subject)",
+        });
         return false;
       }
     }
@@ -253,9 +291,12 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
     // Bite → POST /api/bites
     if (postType === "bite" || postType === "clip") {
       try {
-        const expiresAt = biteExpiry === "permanent"
-          ? new Date(Date.now() + 100 * 365 * 24 * 60 * 60 * 1000).toISOString() // ~100 years
-          : undefined;
+        const expiresAt =
+          biteExpiry === "permanent"
+            ? new Date(
+                Date.now() + 100 * 365 * 24 * 60 * 60 * 1000,
+              ).toISOString() // ~100 years
+            : undefined;
         const res = await fetch("/api/bites", {
           method: "POST",
           credentials: "include",
@@ -263,12 +304,18 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
           body: JSON.stringify({
             userId: user!.id,
             imageUrl: biteMediaUrl,
+            mediaType: biteMediaType,
             caption: caption.trim() || undefined,
             expiresAt,
           }),
         });
         if (!res.ok) throw new Error("Failed to create bite");
-        toast({ description: postType === "clip" ? "Clip shared!" : "Bite shared!" });
+        await queryClient.invalidateQueries({
+          queryKey: ["/api/bites/active"],
+        });
+        toast({
+          description: postType === "clip" ? "Clip shared!" : "Bite shared!",
+        });
         onOpenChange(false);
         resetForm();
       } catch (err: any) {
@@ -300,19 +347,26 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
   };
 
   const updateIngredient = (idx: number, patch: Partial<IngredientRow>) => {
-    setIngredients((prev) => prev.map((row, i) => (i === idx ? { ...row, ...patch } : row)));
+    setIngredients((prev) =>
+      prev.map((row, i) => (i === idx ? { ...row, ...patch } : row)),
+    );
   };
 
-  const addIngredient = () => setIngredients((prev) => [...prev, { name: "", amount: "", unit: "tbsp" }]);
+  const addIngredient = () =>
+    setIngredients((prev) => [...prev, { name: "", amount: "", unit: "tbsp" }]);
   const removeIngredient = (idx: number) =>
-    setIngredients((prev) => (prev.length <= 1 ? prev : prev.filter((_, i) => i !== idx)));
+    setIngredients((prev) =>
+      prev.length <= 1 ? prev : prev.filter((_, i) => i !== idx),
+    );
 
   const updateInstruction = (idx: number, value: string) => {
     setInstructions((prev) => prev.map((s, i) => (i === idx ? value : s)));
   };
   const addInstruction = () => setInstructions((prev) => [...prev, ""]);
   const removeInstruction = (idx: number) =>
-    setInstructions((prev) => (prev.length <= 1 ? prev : prev.filter((_, i) => i !== idx)));
+    setInstructions((prev) =>
+      prev.length <= 1 ? prev : prev.filter((_, i) => i !== idx),
+    );
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -323,7 +377,9 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
 
         <form onSubmit={handleSubmit} className="space-y-4">
           {/* Image Upload — hidden for bite/clip which have their own picker */}
-          <div className={`border-2 border-dashed border-border rounded-lg p-6 text-center ${postType === "bite" || postType === "clip" ? "hidden" : ""}`}>
+          <div
+            className={`border-2 border-dashed border-border rounded-lg p-6 text-center ${postType === "bite" || postType === "clip" ? "hidden" : ""}`}
+          >
             <Camera className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
 
             {imagePreview ? (
@@ -349,12 +405,16 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
               </div>
             ) : (
               <div className="space-y-3">
-                <p className="text-sm text-muted-foreground">Take a photo or choose from library</p>
+                <p className="text-sm text-muted-foreground">
+                  Take a photo or choose from library
+                </p>
                 <div className="flex flex-col sm:flex-row gap-2">
                   <Button
                     type="button"
                     variant="outline"
-                    onClick={() => document.getElementById("camera-input")?.click()}
+                    onClick={() =>
+                      document.getElementById("camera-input")?.click()
+                    }
                     className="flex-1"
                   >
                     <Camera className="h-4 w-4 mr-2" />
@@ -363,7 +423,9 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
                   <Button
                     type="button"
                     variant="outline"
-                    onClick={() => document.getElementById("file-input")?.click()}
+                    onClick={() =>
+                      document.getElementById("file-input")?.click()
+                    }
                     className="flex-1"
                   >
                     Upload
@@ -403,7 +465,10 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
           {/* Post Type */}
           <div className="space-y-2">
             <Label className="text-sm">Post Type</Label>
-            <Select value={postType} onValueChange={(v) => setPostType(v as PostType)}>
+            <Select
+              value={postType}
+              onValueChange={(v) => setPostType(v as PostType)}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Choose type" />
               </SelectTrigger>
@@ -434,14 +499,28 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
                 onClick={() => biteFileRef.current?.click()}
               >
                 {biteMediaUrl && biteMediaType === "video" ? (
-                  <video src={biteMediaUrl} className="w-full h-full object-cover rounded-xl" controls muted playsInline />
+                  <video
+                    src={biteMediaUrl}
+                    className="w-full h-full object-cover rounded-xl"
+                    controls
+                    muted
+                    playsInline
+                  />
                 ) : biteMediaUrl ? (
-                  <img src={biteMediaUrl} alt="Preview" className="w-full h-full object-cover rounded-xl" />
+                  <img
+                    src={biteMediaUrl}
+                    alt="Preview"
+                    className="w-full h-full object-cover rounded-xl"
+                  />
                 ) : (
                   <div className="flex flex-col items-center gap-2 text-gray-400">
                     <Video className="w-8 h-8" />
-                    <span className="text-sm font-medium">Tap to pick video or photo</span>
-                    <span className="text-xs text-gray-400">Video recommended</span>
+                    <span className="text-sm font-medium">
+                      Tap to pick video or photo
+                    </span>
+                    <span className="text-xs text-gray-400">
+                      Video recommended
+                    </span>
                   </div>
                 )}
               </div>
@@ -450,20 +529,28 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
               <div className="flex items-center gap-3 p-3 bg-muted/40 rounded-lg">
                 <div className="flex-1 space-y-0.5">
                   <p className="text-sm font-medium">
-                    {biteExpiry === "permanent" ? "Add to Bites profile tab (permanent)" : "Show in Bites row for 24 hours only"}
+                    {biteExpiry === "permanent"
+                      ? "Add to Bites profile tab (permanent)"
+                      : "Show in Bites row for 24 hours only"}
                   </p>
                   <p className="text-xs text-muted-foreground">
-                    {biteExpiry === "permanent" ? "Stays on your profile Bites tab forever" : "Disappears automatically after 24 hours"}
+                    {biteExpiry === "permanent"
+                      ? "Stays on your profile Bites tab forever"
+                      : "Disappears automatically after 24 hours"}
                   </p>
                 </div>
                 <button
                   type="button"
                   role="switch"
                   aria-checked={biteExpiry === "permanent"}
-                  onClick={() => setBiteExpiry(biteExpiry === "24h" ? "permanent" : "24h")}
+                  onClick={() =>
+                    setBiteExpiry(biteExpiry === "24h" ? "permanent" : "24h")
+                  }
                   className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none ${biteExpiry === "permanent" ? "bg-primary" : "bg-input"}`}
                 >
-                  <span className={`pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform ${biteExpiry === "permanent" ? "translate-x-5" : "translate-x-0"}`} />
+                  <span
+                    className={`pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform ${biteExpiry === "permanent" ? "translate-x-5" : "translate-x-0"}`}
+                  />
                 </button>
               </div>
 
@@ -485,10 +572,18 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
           {/* Caption / Notes */}
           <div className="space-y-2">
             <Label className="text-sm">
-              {postType === "review" ? "Notes (optional)" : postType === "recipe" ? "Story / Notes (optional)" : "Caption (optional)"}
+              {postType === "review"
+                ? "Notes (optional)"
+                : postType === "recipe"
+                  ? "Story / Notes (optional)"
+                  : "Caption (optional)"}
             </Label>
             <Textarea
-              placeholder={postType === "review" ? "Add any details you'd like to include..." : "Write something..."}
+              placeholder={
+                postType === "review"
+                  ? "Add any details you'd like to include..."
+                  : "Write something..."
+              }
               value={caption}
               onChange={(e) => setCaption(e.target.value)}
               rows={3}
@@ -501,17 +596,31 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
             <div className="space-y-4 p-4 bg-muted/30 rounded-xl border">
               <div className="space-y-2">
                 <Label className="text-sm">Recipe Title</Label>
-                <Input value={recipeTitle} onChange={(e) => setRecipeTitle(e.target.value)} placeholder="e.g., Lemon Garlic Pasta" />
+                <Input
+                  value={recipeTitle}
+                  onChange={(e) => setRecipeTitle(e.target.value)}
+                  placeholder="e.g., Lemon Garlic Pasta"
+                />
               </div>
 
               <div className="grid grid-cols-2 gap-2">
                 <div className="space-y-2">
                   <Label className="text-sm">Cook Time (min)</Label>
-                  <Input type="number" value={cookTime} onChange={(e) => setCookTime(e.target.value)} placeholder="30" />
+                  <Input
+                    type="number"
+                    value={cookTime}
+                    onChange={(e) => setCookTime(e.target.value)}
+                    placeholder="30"
+                  />
                 </div>
                 <div className="space-y-2">
                   <Label className="text-sm">Servings</Label>
-                  <Input type="number" value={servings} onChange={(e) => setServings(e.target.value)} placeholder="4" />
+                  <Input
+                    type="number"
+                    value={servings}
+                    onChange={(e) => setServings(e.target.value)}
+                    placeholder="4"
+                  />
                 </div>
               </div>
 
@@ -532,7 +641,12 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
               <div className="space-y-2">
                 <div className="flex items-center justify-between gap-2">
                   <Label className="text-sm">Ingredients</Label>
-                  <Button type="button" variant="outline" size="sm" onClick={addIngredient}>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={addIngredient}
+                  >
                     <Plus className="h-4 w-4 mr-1" />
                     Add
                   </Button>
@@ -540,21 +654,33 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
 
                 <div className="space-y-2">
                   {ingredients.map((row, idx) => (
-                    <div key={idx} className="grid grid-cols-12 gap-2 items-center">
+                    <div
+                      key={idx}
+                      className="grid grid-cols-12 gap-2 items-center"
+                    >
                       <Input
                         className="col-span-6"
                         placeholder="Ingredient"
                         value={row.name}
-                        onChange={(e) => updateIngredient(idx, { name: e.target.value })}
+                        onChange={(e) =>
+                          updateIngredient(idx, { name: e.target.value })
+                        }
                       />
                       <Input
                         className="col-span-3"
                         placeholder="Amt"
                         value={row.amount}
-                        onChange={(e) => updateIngredient(idx, { amount: e.target.value })}
+                        onChange={(e) =>
+                          updateIngredient(idx, { amount: e.target.value })
+                        }
                       />
                       <div className="col-span-3 flex items-center gap-2">
-                        <Select value={row.unit} onValueChange={(v) => updateIngredient(idx, { unit: v })}>
+                        <Select
+                          value={row.unit}
+                          onValueChange={(v) =>
+                            updateIngredient(idx, { unit: v })
+                          }
+                        >
                           <SelectTrigger className="w-full">
                             <SelectValue placeholder="Unit" />
                           </SelectTrigger>
@@ -585,7 +711,12 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
               <div className="space-y-2">
                 <div className="flex items-center justify-between gap-2">
                   <Label className="text-sm">Instructions</Label>
-                  <Button type="button" variant="outline" size="sm" onClick={addInstruction}>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={addInstruction}
+                  >
                     <Plus className="h-4 w-4 mr-1" />
                     Add step
                   </Button>
@@ -625,7 +756,11 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
             <div className="space-y-4 p-4 bg-muted/30 rounded-xl border">
               <div className="space-y-2">
                 <Label className="text-sm">What are you reviewing?</Label>
-                <Input value={reviewSubject} onChange={(e) => setReviewSubject(e.target.value)} placeholder="e.g., Mario's Pizza (NYC)" />
+                <Input
+                  value={reviewSubject}
+                  onChange={(e) => setReviewSubject(e.target.value)}
+                  placeholder="e.g., Mario's Pizza (NYC)"
+                />
               </div>
 
               <div className="space-y-2">
@@ -650,15 +785,30 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
               <div className="grid grid-cols-1 gap-2">
                 <div className="space-y-2">
                   <Label className="text-sm">Pros</Label>
-                  <Textarea value={reviewPros} onChange={(e) => setReviewPros(e.target.value)} rows={2} placeholder="What did you like?" />
+                  <Textarea
+                    value={reviewPros}
+                    onChange={(e) => setReviewPros(e.target.value)}
+                    rows={2}
+                    placeholder="What did you like?"
+                  />
                 </div>
                 <div className="space-y-2">
                   <Label className="text-sm">Cons</Label>
-                  <Textarea value={reviewCons} onChange={(e) => setReviewCons(e.target.value)} rows={2} placeholder="What could be better?" />
+                  <Textarea
+                    value={reviewCons}
+                    onChange={(e) => setReviewCons(e.target.value)}
+                    rows={2}
+                    placeholder="What could be better?"
+                  />
                 </div>
                 <div className="space-y-2">
                   <Label className="text-sm">Verdict</Label>
-                  <Textarea value={reviewVerdict} onChange={(e) => setReviewVerdict(e.target.value)} rows={2} placeholder="Would you recommend it?" />
+                  <Textarea
+                    value={reviewVerdict}
+                    onChange={(e) => setReviewVerdict(e.target.value)}
+                    rows={2}
+                    placeholder="Would you recommend it?"
+                  />
                 </div>
               </div>
             </div>
@@ -682,7 +832,17 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
             className="w-full bg-primary text-primary-foreground hover:opacity-90"
             disabled={createPostMutation.isPending}
           >
-            {createPostMutation.isPending ? "Sharing..." : postType === "recipe" ? "Share Recipe" : postType === "review" ? "Share Review" : postType === "bite" ? "Share Bite" : postType === "clip" ? "Share Clip" : "Share Post"}
+            {createPostMutation.isPending
+              ? "Sharing..."
+              : postType === "recipe"
+                ? "Share Recipe"
+                : postType === "review"
+                  ? "Share Review"
+                  : postType === "bite"
+                    ? "Share Bite"
+                    : postType === "clip"
+                      ? "Share Clip"
+                      : "Share Post"}
           </Button>
         </form>
       </DialogContent>

--- a/client/src/pages/social/create-post.tsx
+++ b/client/src/pages/social/create-post.tsx
@@ -15,7 +15,18 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
-import { Camera, Upload, Plus, Minus, X, Video, GripVertical, ChevronLeft, ChevronRight, Radio } from "lucide-react";
+import {
+  Camera,
+  Upload,
+  Plus,
+  Minus,
+  X,
+  Video,
+  GripVertical,
+  ChevronLeft,
+  ChevronRight,
+  Radio,
+} from "lucide-react";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { useUser } from "@/contexts/UserContext";
@@ -66,9 +77,15 @@ type IngredientRow = { amount: string; unit: string; name: string };
 type MediaKind = "image" | "video" | "";
 type PostImage = { id: string; url: string };
 
-function buildPostImages(imageUrl: string, additionalImages: string[] = []): PostImage[] {
+function buildPostImages(
+  imageUrl: string,
+  additionalImages: string[] = [],
+): PostImage[] {
   return [imageUrl, ...additionalImages]
-    .map((url, index) => ({ id: `${index}-${url}`, url: String(url ?? "").trim() }))
+    .map((url, index) => ({
+      id: `${index}-${url}`,
+      url: String(url ?? "").trim(),
+    }))
     .filter((image) => image.url);
 }
 
@@ -87,7 +104,7 @@ function ingredientRowsToStrings(rows: IngredientRow[]): string[] {
         .map((x) => String(x ?? "").trim())
         .filter(Boolean)
         .join(" ")
-        .trim()
+        .trim(),
     )
     .filter(Boolean);
 }
@@ -108,10 +125,10 @@ function isVideoUrl(url: string) {
   );
 }
 
-function getCityStateLabelFromPlace(place: google.maps.places.PlaceResult) {
+function getCityStateLabelFromPlace(place: any) {
   const comps = place.address_components || [];
   const find = (type: string) =>
-    comps.find((c) => c.types?.includes(type))?.long_name || "";
+    comps.find((c: any) => c.types?.includes(type))?.long_name || "";
   const city =
     find("locality") ||
     find("sublocality") ||
@@ -219,7 +236,11 @@ export default function CreatePost() {
     }
     setMediaPreview(dataUrl);
     setMediaKind(kind);
-    setFormData((prev) => ({ ...prev, imageUrl: dataUrl, additionalImages: [] }));
+    setFormData((prev) => ({
+      ...prev,
+      imageUrl: dataUrl,
+      additionalImages: [],
+    }));
   };
 
   // Bite / Clip state
@@ -227,7 +248,9 @@ export default function CreatePost() {
   const [showGoLive, setShowGoLive] = useState(false);
   const biteFileRef = useRef<HTMLInputElement>(null);
   const [biteMediaUrl, setBiteMediaUrl] = useState("");
-  const [biteMediaType, setBiteMediaType] = useState<"image" | "video">("video");
+  const [biteMediaType, setBiteMediaType] = useState<"image" | "video">(
+    "video",
+  );
   const [biteSubmitting, setBiteSubmitting] = useState(false);
 
   const handleBiteFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -245,17 +268,28 @@ export default function CreatePost() {
     try {
       toast({ description: "Uploading media…" });
       const storedUrl = await uploadMediaUrl(biteMediaUrl);
-      const expiresAt = biteExpiry === "permanent"
-        ? new Date(Date.now() + 100 * 365 * 24 * 60 * 60 * 1000).toISOString()
-        : undefined;
+      const expiresAt =
+        biteExpiry === "permanent"
+          ? new Date(Date.now() + 100 * 365 * 24 * 60 * 60 * 1000).toISOString()
+          : undefined;
       const res = await fetch("/api/bites", {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userId: user.id, imageUrl: storedUrl, caption: formData.caption || undefined, expiresAt }),
+        body: JSON.stringify({
+          userId: user.id,
+          imageUrl: storedUrl,
+          mediaType: biteMediaType,
+          caption: formData.caption || undefined,
+          expiresAt,
+        }),
       });
       if (!res.ok) throw new Error("Failed to create bite");
-      toast({ description: formData.postType === "clip" ? "Clip shared!" : "Bite shared!" });
+      await queryClient.invalidateQueries({ queryKey: ["/api/bites/active"] });
+      toast({
+        description:
+          formData.postType === "clip" ? "Clip shared!" : "Bite shared!",
+      });
       setLocation("/feed");
     } catch (err: any) {
       toast({ variant: "destructive", description: err.message });
@@ -311,10 +345,18 @@ export default function CreatePost() {
 
     // Location autocomplete (cities / regions)
     if (locationInputRef.current) {
-      const lac = new google.maps.places.Autocomplete(locationInputRef.current, {
-        types: ["(cities)"],
-        fields: ["name", "formatted_address", "address_components", "geometry"],
-      });
+      const lac = new google.maps.places.Autocomplete(
+        locationInputRef.current,
+        {
+          types: ["(cities)"],
+          fields: [
+            "name",
+            "formatted_address",
+            "address_components",
+            "geometry",
+          ],
+        },
+      );
 
       lac.addListener("place_changed", () => {
         const place = lac.getPlace();
@@ -407,8 +449,8 @@ export default function CreatePost() {
           formData.postType === "recipe"
             ? "Recipe shared successfully!"
             : formData.postType === "review"
-            ? "Review posted successfully!"
-            : "Post created successfully!",
+              ? "Review posted successfully!"
+              : "Post created successfully!",
       });
       setLocation("/feed");
     },
@@ -430,7 +472,10 @@ export default function CreatePost() {
 
     if (formData.postType === "bite" || formData.postType === "clip") {
       if (!biteMediaUrl) {
-        toast({ variant: "destructive", description: "Please pick a video or photo" });
+        toast({
+          variant: "destructive",
+          description: "Please pick a video or photo",
+        });
         return;
       }
       handleBiteSubmit();
@@ -447,7 +492,10 @@ export default function CreatePost() {
 
     if (formData.postType === "recipe") {
       if (!formData.recipeTitle.trim()) {
-        toast({ variant: "destructive", description: "Please add a recipe title" });
+        toast({
+          variant: "destructive",
+          description: "Please add a recipe title",
+        });
         return;
       }
 
@@ -455,22 +503,34 @@ export default function CreatePost() {
       const instructions = normalizeSteps(formData.instructions);
 
       if (ingredients.length === 0) {
-        toast({ variant: "destructive", description: "Please add at least one ingredient" });
+        toast({
+          variant: "destructive",
+          description: "Please add at least one ingredient",
+        });
         return;
       }
       if (instructions.length === 0) {
-        toast({ variant: "destructive", description: "Please add at least one instruction step" });
+        toast({
+          variant: "destructive",
+          description: "Please add at least one instruction step",
+        });
         return;
       }
     }
 
     if (formData.postType === "review") {
       if (!formData.reviewBusinessName.trim()) {
-        toast({ variant: "destructive", description: "Please choose a business" });
+        toast({
+          variant: "destructive",
+          description: "Please choose a business",
+        });
         return;
       }
       if (!formData.reviewRating.trim()) {
-        toast({ variant: "destructive", description: "Please select a rating" });
+        toast({
+          variant: "destructive",
+          description: "Please select a rating",
+        });
         return;
       }
     }
@@ -487,10 +547,14 @@ export default function CreatePost() {
     if (!files.length) return;
 
     const invalidFile = files.find(
-      (file) => !file.type.startsWith("image/") && !file.type.startsWith("video/")
+      (file) =>
+        !file.type.startsWith("image/") && !file.type.startsWith("video/"),
     );
     if (invalidFile) {
-      toast({ variant: "destructive", description: "Please select image or video files only" });
+      toast({
+        variant: "destructive",
+        description: "Please select image or video files only",
+      });
       return;
     }
 
@@ -498,7 +562,8 @@ export default function CreatePost() {
     if (containsVideo && files.length > 1) {
       toast({
         variant: "destructive",
-        description: "Videos can only be uploaded one at a time. Use images for multi-photo posts.",
+        description:
+          "Videos can only be uploaded one at a time. Use images for multi-photo posts.",
       });
       return;
     }
@@ -514,7 +579,9 @@ export default function CreatePost() {
     Promise.all(files.map(readFileAsDataUrl))
       .then((results) => {
         const firstFile = files[0];
-        const kind: MediaKind = firstFile.type.startsWith("video/") ? "video" : "image";
+        const kind: MediaKind = firstFile.type.startsWith("video/")
+          ? "video"
+          : "image";
 
         setMediaFile(firstFile);
         setMediaPreview(results[0] ?? "");
@@ -529,9 +596,11 @@ export default function CreatePost() {
           return;
         }
 
-        const [{ imageUrl, additionalImages }] = [splitPostImages(
-          results.map((url, index) => ({ id: `${index}-${url}`, url }))
-        )];
+        const [{ imageUrl, additionalImages }] = [
+          splitPostImages(
+            results.map((url, index) => ({ id: `${index}-${url}`, url })),
+          ),
+        ];
 
         setFormData((prev) => ({
           ...prev,
@@ -559,7 +628,10 @@ export default function CreatePost() {
     handleChange("additionalImages", []);
   };
 
-  const orderedImages = buildPostImages(formData.imageUrl, formData.additionalImages);
+  const orderedImages = buildPostImages(
+    formData.imageUrl,
+    formData.additionalImages,
+  );
 
   const syncImages = (images: PostImage[]) => {
     const { imageUrl, additionalImages } = splitPostImages(images);
@@ -589,7 +661,10 @@ export default function CreatePost() {
     if (nextIndex < 0 || nextIndex >= orderedImages.length) return;
 
     const nextImages = [...orderedImages];
-    [nextImages[index], nextImages[nextIndex]] = [nextImages[nextIndex], nextImages[index]];
+    [nextImages[index], nextImages[nextIndex]] = [
+      nextImages[nextIndex],
+      nextImages[index],
+    ];
     syncImages(nextImages);
   };
 
@@ -604,11 +679,15 @@ export default function CreatePost() {
       return;
     }
 
-    syncImages([...orderedImages, { id: `${Date.now()}-${nextUrl}`, url: nextUrl }]);
+    syncImages([
+      ...orderedImages,
+      { id: `${Date.now()}-${nextUrl}`, url: nextUrl },
+    ]);
     setGalleryUrlInput("");
   };
 
-  const addTag = () => setFormData((prev) => ({ ...prev, tags: [...prev.tags, ""] }));
+  const addTag = () =>
+    setFormData((prev) => ({ ...prev, tags: [...prev.tags, ""] }));
 
   const removeTag = (index: number) => {
     setFormData((prev) => ({
@@ -645,13 +724,16 @@ export default function CreatePost() {
     setFormData((prev) => ({
       ...prev,
       ingredients: prev.ingredients.map((row, i) =>
-        i === index ? { ...row, ...patch } : row
+        i === index ? { ...row, ...patch } : row,
       ),
     }));
   };
 
   const addInstruction = () => {
-    setFormData((prev) => ({ ...prev, instructions: [...prev.instructions, ""] }));
+    setFormData((prev) => ({
+      ...prev,
+      instructions: [...prev.instructions, ""],
+    }));
   };
 
   const removeInstruction = (index: number) => {
@@ -668,7 +750,7 @@ export default function CreatePost() {
     setFormData((prev) => ({
       ...prev,
       instructions: prev.instructions.map((instruction, i) =>
-        i === index ? value : instruction
+        i === index ? value : instruction,
       ),
     }));
   };
@@ -713,7 +795,8 @@ export default function CreatePost() {
                   <Radio className="w-8 h-8 text-red-500" />
                 </div>
                 <p className="text-sm text-muted-foreground text-center">
-                  Your camera preview will open. Start streaming when you're ready.
+                  Your camera preview will open. Start streaming when you're
+                  ready.
                 </p>
                 <Button
                   type="button"
@@ -729,22 +812,50 @@ export default function CreatePost() {
             {/* Bite / Clip media picker */}
             {(formData.postType === "bite" || formData.postType === "clip") && (
               <div className="space-y-3">
-                <input ref={biteFileRef} type="file" accept="video/*,image/*" className="hidden" onChange={handleBiteFileSelect} />
+                <input
+                  ref={biteFileRef}
+                  type="file"
+                  accept="video/*,image/*"
+                  className="hidden"
+                  onChange={handleBiteFileSelect}
+                />
                 <div className="w-full aspect-video bg-muted rounded-xl overflow-hidden border-2 border-dashed border-border">
                   {biteMediaUrl && biteMediaType === "video" ? (
-                    <video src={biteMediaUrl} className="w-full h-full object-cover" controls muted playsInline />
+                    <video
+                      src={biteMediaUrl}
+                      className="w-full h-full object-cover"
+                      controls
+                      muted
+                      playsInline
+                    />
                   ) : biteMediaUrl ? (
-                    <img src={biteMediaUrl} alt="Preview" className="w-full h-full object-cover" />
+                    <img
+                      src={biteMediaUrl}
+                      alt="Preview"
+                      className="w-full h-full object-cover"
+                    />
                   ) : (
                     <div className="w-full h-full flex flex-col items-center justify-center gap-3 text-muted-foreground">
                       <Video className="w-10 h-10" />
-                      <span className="text-sm font-medium">Add video or photo</span>
+                      <span className="text-sm font-medium">
+                        Add video or photo
+                      </span>
                       <div className="flex gap-2">
-                        <Button type="button" size="sm" variant="outline" onClick={() => setShowCamera(true)}>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          onClick={() => setShowCamera(true)}
+                        >
                           <Camera className="w-4 h-4 mr-1" />
                           Camera
                         </Button>
-                        <Button type="button" size="sm" variant="outline" onClick={() => biteFileRef.current?.click()}>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          onClick={() => biteFileRef.current?.click()}
+                        >
                           <Upload className="w-4 h-4 mr-1" />
                           Upload
                         </Button>
@@ -757,20 +868,28 @@ export default function CreatePost() {
                 <div className="flex items-center gap-3 p-3 bg-muted/40 rounded-lg">
                   <div className="flex-1">
                     <p className="text-sm font-medium">
-                      {biteExpiry === "permanent" ? "Add to Bites profile tab (permanent)" : "Show in Bites row for 24 hours only"}
+                      {biteExpiry === "permanent"
+                        ? "Add to Bites profile tab (permanent)"
+                        : "Show in Bites row for 24 hours only"}
                     </p>
                     <p className="text-xs text-muted-foreground">
-                      {biteExpiry === "permanent" ? "Stays on your profile Bites tab forever" : "Disappears after 24 hours"}
+                      {biteExpiry === "permanent"
+                        ? "Stays on your profile Bites tab forever"
+                        : "Disappears after 24 hours"}
                     </p>
                   </div>
                   <button
                     type="button"
                     role="switch"
                     aria-checked={biteExpiry === "permanent"}
-                    onClick={() => setBiteExpiry(biteExpiry === "24h" ? "permanent" : "24h")}
+                    onClick={() =>
+                      setBiteExpiry(biteExpiry === "24h" ? "permanent" : "24h")
+                    }
                     className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${biteExpiry === "permanent" ? "bg-primary" : "bg-input"}`}
                   >
-                    <span className={`block h-5 w-5 rounded-full bg-white shadow-lg transition-transform ${biteExpiry === "permanent" ? "translate-x-5" : "translate-x-0"}`} />
+                    <span
+                      className={`block h-5 w-5 rounded-full bg-white shadow-lg transition-transform ${biteExpiry === "permanent" ? "translate-x-5" : "translate-x-0"}`}
+                    />
                   </button>
                 </div>
 
@@ -790,7 +909,9 @@ export default function CreatePost() {
             )}
 
             {/* Media Upload — hidden for bite/clip/live */}
-            <div className={`space-y-2 ${formData.postType === "bite" || formData.postType === "clip" || formData.postType === "live" ? "hidden" : ""}`}>
+            <div
+              className={`space-y-2 ${formData.postType === "bite" || formData.postType === "clip" || formData.postType === "live" ? "hidden" : ""}`}
+            >
               <Label htmlFor="imageUrl">Photo/Video *</Label>
               <div className="border-2 border-dashed border-border rounded-lg p-8 text-center">
                 {mediaPreview ? (
@@ -817,7 +938,8 @@ export default function CreatePost() {
                         <div className="flex items-center justify-between">
                           <p className="text-sm font-medium">Photo order</p>
                           <p className="text-xs text-muted-foreground">
-                            The first image is the cover photo shown in the feed.
+                            The first image is the cover photo shown in the
+                            feed.
                           </p>
                         </div>
 
@@ -835,7 +957,9 @@ export default function CreatePost() {
                               />
                               <div className="min-w-0 flex-1">
                                 <p className="text-sm font-medium">
-                                  {index === 0 ? "Cover image" : `Image ${index + 1}`}
+                                  {index === 0
+                                    ? "Cover image"
+                                    : `Image ${index + 1}`}
                                 </p>
                                 <p className="truncate text-xs text-muted-foreground">
                                   {image.url}
@@ -883,7 +1007,11 @@ export default function CreatePost() {
                             value={galleryUrlInput}
                             onChange={(e) => setGalleryUrlInput(e.target.value)}
                           />
-                          <Button type="button" variant="outline" onClick={addImageUrlToGallery}>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            onClick={addImageUrlToGallery}
+                          >
                             <Plus className="mr-2 h-4 w-4" />
                             Add image
                           </Button>
@@ -925,7 +1053,9 @@ export default function CreatePost() {
                       <Button
                         type="button"
                         variant="outline"
-                        onClick={() => document.getElementById("file-input")?.click()}
+                        onClick={() =>
+                          document.getElementById("file-input")?.click()
+                        }
                         className="flex-1"
                       >
                         <Upload className="h-4 w-4 mr-2" />
@@ -985,7 +1115,9 @@ export default function CreatePost() {
                       ref={businessInputRef}
                       placeholder="Search a business (Google Places)…"
                       value={formData.reviewBusinessName}
-                      onChange={(e) => handleChange("reviewBusinessName", e.target.value)}
+                      onChange={(e) =>
+                        handleChange("reviewBusinessName", e.target.value)
+                      }
                     />
                     <p className="text-xs text-muted-foreground">
                       Start typing to use Google Places suggestions.
@@ -999,18 +1131,24 @@ export default function CreatePost() {
                         id="reviewFullAddress"
                         placeholder="Auto-filled from selection"
                         value={formData.reviewFullAddress}
-                        onChange={(e) => handleChange("reviewFullAddress", e.target.value)}
+                        onChange={(e) =>
+                          handleChange("reviewFullAddress", e.target.value)
+                        }
                       />
                     </div>
 
                     <div className="space-y-2">
-                      <Label htmlFor="reviewLocationLabel">Location (City/State)</Label>
+                      <Label htmlFor="reviewLocationLabel">
+                        Location (City/State)
+                      </Label>
                       <Input
                         id="reviewLocationLabel"
                         ref={locationInputRef}
                         placeholder="City, State (Google Places)…"
                         value={formData.reviewLocationLabel}
-                        onChange={(e) => handleChange("reviewLocationLabel", e.target.value)}
+                        onChange={(e) =>
+                          handleChange("reviewLocationLabel", e.target.value)
+                        }
                       />
                     </div>
                   </div>
@@ -1051,7 +1189,9 @@ export default function CreatePost() {
                             onClick={() =>
                               handleChange(
                                 "reviewPriceLevel",
-                                formData.reviewPriceLevel === value ? "" : value
+                                formData.reviewPriceLevel === value
+                                  ? ""
+                                  : value,
                               )
                             }
                             className={`px-3 py-1.5 rounded border text-sm font-semibold transition-colors ${
@@ -1074,7 +1214,9 @@ export default function CreatePost() {
                       id="reviewVerdict"
                       placeholder="e.g., Def recommend"
                       value={formData.reviewVerdict}
-                      onChange={(e) => handleChange("reviewVerdict", e.target.value)}
+                      onChange={(e) =>
+                        handleChange("reviewVerdict", e.target.value)
+                      }
                     />
                   </div>
 
@@ -1085,7 +1227,9 @@ export default function CreatePost() {
                         id="reviewPros"
                         placeholder="e.g., Great flavor; friendly staff"
                         value={formData.reviewPros}
-                        onChange={(e) => handleChange("reviewPros", e.target.value)}
+                        onChange={(e) =>
+                          handleChange("reviewPros", e.target.value)
+                        }
                       />
                       <p className="text-xs text-muted-foreground">
                         Separate multiple with a semicolon (;)
@@ -1097,7 +1241,9 @@ export default function CreatePost() {
                         id="reviewCons"
                         placeholder="e.g., Parking; long wait"
                         value={formData.reviewCons}
-                        onChange={(e) => handleChange("reviewCons", e.target.value)}
+                        onChange={(e) =>
+                          handleChange("reviewCons", e.target.value)
+                        }
                       />
                       <p className="text-xs text-muted-foreground">
                         Separate multiple with a semicolon (;)
@@ -1111,7 +1257,9 @@ export default function CreatePost() {
                       id="reviewNotes"
                       placeholder="e.g., Try the stewed chicken"
                       value={formData.reviewNotes}
-                      onChange={(e) => handleChange("reviewNotes", e.target.value)}
+                      onChange={(e) =>
+                        handleChange("reviewNotes", e.target.value)
+                      }
                     />
                   </div>
 
@@ -1160,7 +1308,9 @@ export default function CreatePost() {
             )}
 
             {/* Tags */}
-            <div className={`space-y-2 ${formData.postType === "bite" || formData.postType === "clip" || formData.postType === "live" ? "hidden" : ""}`}>
+            <div
+              className={`space-y-2 ${formData.postType === "bite" || formData.postType === "clip" || formData.postType === "live" ? "hidden" : ""}`}
+            >
               <Label>Tags</Label>
               <div className="space-y-2">
                 {formData.tags.map((tag, index) => (
@@ -1212,7 +1362,9 @@ export default function CreatePost() {
                       id="recipeTitle"
                       placeholder="Enter the recipe name"
                       value={formData.recipeTitle}
-                      onChange={(e) => handleChange("recipeTitle", e.target.value)}
+                      onChange={(e) =>
+                        handleChange("recipeTitle", e.target.value)
+                      }
                       data-testid="input-recipe-title"
                     />
                   </div>
@@ -1226,7 +1378,9 @@ export default function CreatePost() {
                         inputMode="numeric"
                         placeholder="30"
                         value={formData.cookTime}
-                        onChange={(e) => handleChange("cookTime", e.target.value)}
+                        onChange={(e) =>
+                          handleChange("cookTime", e.target.value)
+                        }
                         data-testid="input-cook-time"
                       />
                     </div>
@@ -1238,7 +1392,9 @@ export default function CreatePost() {
                         inputMode="numeric"
                         placeholder="4"
                         value={formData.servings}
-                        onChange={(e) => handleChange("servings", e.target.value)}
+                        onChange={(e) =>
+                          handleChange("servings", e.target.value)
+                        }
                         data-testid="input-servings"
                       />
                     </div>
@@ -1246,7 +1402,9 @@ export default function CreatePost() {
                       <Label htmlFor="difficulty">Difficulty</Label>
                       <Select
                         value={formData.difficulty}
-                        onValueChange={(value) => handleChange("difficulty", value)}
+                        onValueChange={(value) =>
+                          handleChange("difficulty", value)
+                        }
                       >
                         <SelectTrigger data-testid="select-difficulty">
                           <SelectValue />
@@ -1338,7 +1496,9 @@ export default function CreatePost() {
                               placeholder="Ingredient"
                               value={row.name}
                               onChange={(e) =>
-                                updateIngredient(index, { name: e.target.value })
+                                updateIngredient(index, {
+                                  name: e.target.value,
+                                })
                               }
                               className="h-9"
                               data-testid={`input-ingredient-name-${index}`}
@@ -1379,7 +1539,10 @@ export default function CreatePost() {
 
                     <div className="space-y-2">
                       {formData.instructions.map((instruction, index) => (
-                        <div key={index} className="flex items-center space-x-2">
+                        <div
+                          key={index}
+                          className="flex items-center space-x-2"
+                        >
                           <Input
                             placeholder={`Step ${index + 1}`}
                             value={instruction}
@@ -1417,10 +1580,10 @@ export default function CreatePost() {
                 {createPostMutation.isPending || biteSubmitting
                   ? "Posting..."
                   : formData.postType === "bite"
-                  ? "Share Bite"
-                  : formData.postType === "clip"
-                  ? "Share Clip"
-                  : "Post"}
+                    ? "Share Bite"
+                    : formData.postType === "clip"
+                      ? "Share Clip"
+                      : "Post"}
               </Button>
             )}
           </form>
@@ -1428,7 +1591,11 @@ export default function CreatePost() {
       </Card>
 
       <GoLiveModal open={showGoLive} onOpenChange={setShowGoLive} />
-      <CameraModal open={showCamera} onOpenChange={setShowCamera} onCapture={handleCameraCapture} />
+      <CameraModal
+        open={showCamera}
+        onOpenChange={setShowCamera}
+        onCapture={handleCameraCapture}
+      />
     </div>
   );
 }

--- a/server/migrations/20260513_stories_media_type.sql
+++ b/server/migrations/20260513_stories_media_type.sql
@@ -1,0 +1,8 @@
+ALTER TABLE stories
+  ADD COLUMN IF NOT EXISTS media_type text NOT NULL DEFAULT 'image';
+
+ALTER TABLE stories
+  DROP CONSTRAINT IF EXISTS stories_media_type_check;
+
+ALTER TABLE stories
+  ADD CONSTRAINT stories_media_type_check CHECK (media_type IN ('image', 'video'));

--- a/server/routes/bites.ts
+++ b/server/routes/bites.ts
@@ -45,6 +45,7 @@ type ActiveBitePayload = {
   id: string;
   userId: string;
   imageUrl: string;
+  mediaType: "image" | "video";
   caption: string | null;
   createdAt: string | null;
   expiresAt: string | null;
@@ -57,15 +58,19 @@ type ActiveBitePayload = {
 
 async function fetchActiveBites(): Promise<ActiveBitePayload[]> {
   if (!db) {
-    throw Object.assign(new Error("Database not configured (set DATABASE_URL)."), {
-      status: 503,
-    });
+    throw Object.assign(
+      new Error("Database not configured (set DATABASE_URL)."),
+      {
+        status: 503,
+      },
+    );
   }
   const rows = await db
     .select({
       id: stories.id,
       userId: stories.userId,
       imageUrl: stories.imageUrl,
+      mediaType: stories.mediaType,
       caption: stories.caption,
       createdAt: stories.createdAt,
       expiresAt: stories.expiresAt,
@@ -78,19 +83,33 @@ async function fetchActiveBites(): Promise<ActiveBitePayload[]> {
     .where(sql`${stories.expiresAt} > NOW()`)
     .orderBy(desc(stories.createdAt));
 
-  return rows.map((row) => ({
-    id: row.id,
-    userId: row.userId,
-    imageUrl: row.imageUrl,
-    caption: row.caption ?? null,
-    createdAt: row.createdAt ? new Date(row.createdAt).toISOString() : null,
-    expiresAt: row.expiresAt ? new Date(row.expiresAt).toISOString() : null,
-    user: {
-      username: row.username ?? "Chef",
-      displayName: row.displayName ?? null,
-      avatar: row.avatar ?? null,
-    },
-  }));
+  return rows.map(
+    (row: {
+      id: string;
+      userId: string;
+      imageUrl: string;
+      mediaType: "image" | "video";
+      caption: string | null;
+      createdAt: Date | string | null;
+      expiresAt: Date | string | null;
+      username: string | null;
+      displayName: string | null;
+      avatar: string | null;
+    }) => ({
+      id: row.id,
+      userId: row.userId,
+      imageUrl: row.imageUrl,
+      mediaType: row.mediaType,
+      caption: row.caption ?? null,
+      createdAt: row.createdAt ? new Date(row.createdAt).toISOString() : null,
+      expiresAt: row.expiresAt ? new Date(row.expiresAt).toISOString() : null,
+      user: {
+        username: row.username ?? "Chef",
+        displayName: row.displayName ?? null,
+        avatar: row.avatar ?? null,
+      },
+    }),
+  );
 }
 
 // List currently-active bites across network (optionally scoped by viewer)
@@ -139,6 +158,7 @@ r.post("/", async (req, res) => {
     const schema = z.object({
       userId: z.string(),
       imageUrl: z.string().min(1),
+      mediaType: z.enum(["image", "video"]),
       caption: z.string().max(500).optional(),
       expiresAt: z.string().datetime().optional(),
     });
@@ -151,6 +171,7 @@ r.post("/", async (req, res) => {
     const created = await storage.createStory({
       userId: data.userId,
       imageUrl: data.imageUrl,
+      mediaType: data.mediaType,
       caption: data.caption ?? null,
       expiresAt,
     } as any);
@@ -162,7 +183,9 @@ r.post("/", async (req, res) => {
   } catch (e: any) {
     if (e?.issues) {
       console.warn("[bites] POST / validation failed", e.issues);
-      return res.status(400).json({ message: "Invalid bite", errors: e.issues });
+      return res
+        .status(400)
+        .json({ message: "Invalid bite", errors: e.issues });
     }
     console.error("[bites] POST / error", e);
     res.status(500).json({ message: "Failed to create bite" });

--- a/shared/schema/domains/social-content.ts
+++ b/shared/schema/domains/social-content.ts
@@ -22,25 +22,42 @@ type RecipeNutrition = Record<string, unknown> & {
   fiber?: number;
 };
 
-export const posts = pgTable("posts", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  userId: varchar("user_id").references(() => users.id).notNull(),
-  caption: text("caption"),
-  imageUrl: text("image_url").notNull(),
-  additionalImages: jsonb("additional_images").$type<string[]>().default(sql`'[]'::jsonb`).notNull(),
-  tags: jsonb("tags").$type<string[]>().default(sql`'[]'::jsonb`),
-  likesCount: integer("likes_count").default(0),
-  commentsCount: integer("comments_count").default(0),
-  isRecipe: boolean("is_recipe").default(false),
-  createdAt: timestamp("created_at").defaultNow(),
-}, (t) => ({
-  createdAtIdx: index("posts_created_at_idx").on(t.createdAt),
-  userIdIdx: index("posts_user_id_idx").on(t.userId),
-}));
+export const posts = pgTable(
+  "posts",
+  {
+    id: varchar("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    userId: varchar("user_id")
+      .references(() => users.id)
+      .notNull(),
+    caption: text("caption"),
+    imageUrl: text("image_url").notNull(),
+    additionalImages: jsonb("additional_images")
+      .$type<string[]>()
+      .default(sql`'[]'::jsonb`)
+      .notNull(),
+    tags: jsonb("tags")
+      .$type<string[]>()
+      .default(sql`'[]'::jsonb`),
+    likesCount: integer("likes_count").default(0),
+    commentsCount: integer("comments_count").default(0),
+    isRecipe: boolean("is_recipe").default(false),
+    createdAt: timestamp("created_at").defaultNow(),
+  },
+  (t) => ({
+    createdAtIdx: index("posts_created_at_idx").on(t.createdAt),
+    userIdIdx: index("posts_user_id_idx").on(t.userId),
+  }),
+);
 
 export const recipes = pgTable("recipes", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  postId: varchar("post_id").references(() => posts.id).unique(),
+  id: varchar("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()`),
+  postId: varchar("post_id")
+    .references(() => posts.id)
+    .unique(),
   title: text("title").notNull(),
   imageUrl: text("image_url"),
   ingredients: jsonb("ingredients").$type<string[]>().notNull(),
@@ -54,7 +71,9 @@ export const recipes = pgTable("recipes", {
   carbs: decimal("carbs", { precision: 5, scale: 2 }),
   fat: decimal("fat", { precision: 5, scale: 2 }),
   fiber: decimal("fiber", { precision: 5, scale: 2 }),
-  averageRating: decimal("average_rating", { precision: 3, scale: 2 }).default("0"),
+  averageRating: decimal("average_rating", { precision: 3, scale: 2 }).default(
+    "0",
+  ),
   reviewCount: integer("review_count").default(0),
   externalSource: text("external_source"),
   externalId: text("external_id"),
@@ -64,9 +83,15 @@ export const recipes = pgTable("recipes", {
 });
 
 export const recipeReviews = pgTable("recipe_reviews", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  recipeId: varchar("recipe_id").references(() => recipes.id).notNull(),
-  userId: varchar("user_id").references(() => users.id).notNull(),
+  id: varchar("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()`),
+  recipeId: varchar("recipe_id")
+    .references(() => recipes.id)
+    .notNull(),
+  userId: varchar("user_id")
+    .references(() => users.id)
+    .notNull(),
   rating: integer("rating").notNull(),
   reviewText: text("review_text"),
   helpfulCount: integer("helpful_count").notNull().default(0),
@@ -75,46 +100,81 @@ export const recipeReviews = pgTable("recipe_reviews", {
 });
 
 export const recipeReviewPhotos = pgTable("recipe_review_photos", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  reviewId: varchar("review_id").references(() => recipeReviews.id).notNull(),
+  id: varchar("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()`),
+  reviewId: varchar("review_id")
+    .references(() => recipeReviews.id)
+    .notNull(),
   photoUrl: text("photo_url").notNull(),
   caption: text("caption"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 
 export const reviewHelpful = pgTable("review_helpful", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  reviewId: varchar("review_id").references(() => recipeReviews.id).notNull(),
-  userId: varchar("user_id").references(() => users.id).notNull(),
+  id: varchar("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()`),
+  reviewId: varchar("review_id")
+    .references(() => recipeReviews.id)
+    .notNull(),
+  userId: varchar("user_id")
+    .references(() => users.id)
+    .notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 
 export const stories = pgTable("stories", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  userId: varchar("user_id").references(() => users.id).notNull(),
+  id: varchar("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()`),
+  userId: varchar("user_id")
+    .references(() => users.id)
+    .notNull(),
   imageUrl: text("image_url").notNull(),
+  mediaType: text("media_type", { enum: ["image", "video"] })
+    .notNull()
+    .default("image"),
   caption: text("caption"),
   expiresAt: timestamp("expires_at").notNull(),
   createdAt: timestamp("created_at").defaultNow(),
 });
 
-export const likes = pgTable("likes", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  userId: varchar("user_id").references(() => users.id).notNull(),
-  postId: varchar("post_id").references(() => posts.id).notNull(),
-  createdAt: timestamp("created_at").defaultNow(),
-}, (t) => ({
-  postIdIdx: index("likes_post_id_idx").on(t.postId),
-  userPostIdx: uniqueIndex("likes_user_post_idx").on(t.userId, t.postId),
-}));
+export const likes = pgTable(
+  "likes",
+  {
+    id: varchar("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    userId: varchar("user_id")
+      .references(() => users.id)
+      .notNull(),
+    postId: varchar("post_id")
+      .references(() => posts.id)
+      .notNull(),
+    createdAt: timestamp("created_at").defaultNow(),
+  },
+  (t) => ({
+    postIdIdx: index("likes_post_id_idx").on(t.postId),
+    userPostIdx: uniqueIndex("likes_user_post_idx").on(t.userId, t.postId),
+  }),
+);
 
 export const comments = pgTable(
   "comments",
   {
-    id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-    userId: varchar("user_id").references(() => users.id).notNull(),
-    postId: varchar("post_id").references(() => posts.id).notNull(),
-    parentId: varchar("parent_id").references((): AnyPgColumn => comments.id, { onDelete: "cascade" }),
+    id: varchar("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    userId: varchar("user_id")
+      .references(() => users.id)
+      .notNull(),
+    postId: varchar("post_id")
+      .references(() => posts.id)
+      .notNull(),
+    parentId: varchar("parent_id").references((): AnyPgColumn => comments.id, {
+      onDelete: "cascade",
+    }),
     content: text("content").notNull(),
     createdAt: timestamp("created_at").defaultNow(),
   },
@@ -122,55 +182,90 @@ export const comments = pgTable(
     postIdIdx: index("comments_post_id_idx").on(t.postId),
     userIdIdx: index("comments_user_id_idx").on(t.userId),
     parentIdIdx: index("comments_parent_id_idx").on(t.parentId),
-  })
+  }),
 );
 
 export const commentLikes = pgTable(
   "comment_likes",
   {
-    id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-    userId: varchar("user_id").references(() => users.id).notNull(),
-    commentId: varchar("comment_id").references(() => comments.id, { onDelete: "cascade" }).notNull(),
+    id: varchar("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    userId: varchar("user_id")
+      .references(() => users.id)
+      .notNull(),
+    commentId: varchar("comment_id")
+      .references(() => comments.id, { onDelete: "cascade" })
+      .notNull(),
     createdAt: timestamp("created_at").defaultNow(),
   },
   (table) => ({
-    userCommentIdx: uniqueIndex("comment_likes_user_comment_idx").on(table.userId, table.commentId),
-  })
+    userCommentIdx: uniqueIndex("comment_likes_user_comment_idx").on(
+      table.userId,
+      table.commentId,
+    ),
+  }),
 );
 
 export const follows = pgTable(
   "follows",
   {
-    id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-    followerId: varchar("follower_id").references(() => users.id).notNull(),
-    followingId: varchar("following_id").references(() => users.id).notNull(),
+    id: varchar("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    followerId: varchar("follower_id")
+      .references(() => users.id)
+      .notNull(),
+    followingId: varchar("following_id")
+      .references(() => users.id)
+      .notNull(),
     createdAt: timestamp("created_at").defaultNow(),
   },
   (table) => ({
     followerIdx: index("follows_follower_id_idx").on(table.followerId),
     followingIdx: index("follows_following_id_idx").on(table.followingId),
-    followerCreatedAtIdx: index("follows_follower_created_at_idx").on(table.followerId, table.createdAt),
-    followingCreatedAtIdx: index("follows_following_created_at_idx").on(table.followingId, table.createdAt),
-  })
+    followerCreatedAtIdx: index("follows_follower_created_at_idx").on(
+      table.followerId,
+      table.createdAt,
+    ),
+    followingCreatedAtIdx: index("follows_following_created_at_idx").on(
+      table.followingId,
+      table.createdAt,
+    ),
+  }),
 );
 
 export const followRequests = pgTable("follow_requests", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  requesterId: varchar("requester_id").references(() => users.id).notNull(),
-  targetId: varchar("target_id").references(() => users.id).notNull(),
+  id: varchar("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()`),
+  requesterId: varchar("requester_id")
+    .references(() => users.id)
+    .notNull(),
+  targetId: varchar("target_id")
+    .references(() => users.id)
+    .notNull(),
   status: text("status").notNull().default("pending"),
   createdAt: timestamp("created_at").defaultNow(),
   respondedAt: timestamp("responded_at"),
 });
 
 export const cateringInquiries = pgTable("catering_inquiries", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  customerId: varchar("customer_id").references(() => users.id).notNull(),
-  chefId: varchar("chef_id").references(() => users.id).notNull(),
+  id: varchar("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()`),
+  customerId: varchar("customer_id")
+    .references(() => users.id)
+    .notNull(),
+  chefId: varchar("chef_id")
+    .references(() => users.id)
+    .notNull(),
   eventDate: timestamp("event_date").notNull(),
   guestCount: integer("guest_count"),
   eventType: text("event_type"),
-  cuisinePreferences: jsonb("cuisine_preferences").$type<string[]>().default(sql`'[]'::jsonb`),
+  cuisinePreferences: jsonb("cuisine_preferences")
+    .$type<string[]>()
+    .default(sql`'[]'::jsonb`),
   budget: decimal("budget", { precision: 10, scale: 2 }),
   message: text("message"),
   status: text("status").default("pending"),


### PR DESCRIPTION
### Motivation
- Treat bites/clips as their own story resource instead of regular feed posts so they appear and refresh independently and carry explicit media metadata.
- Replace fragile local fetch/fallback logic with React Query to make the BitesRow reliable and immediately refreshable after creation.

### Description
- Route bite/clip creation exclusively through `POST /api/bites`, include `mediaType: "image" | "video"` in the request payload, and invalidate the active bites query after success (`/api/bites/active`).
- Convert `BitesRow` to use React Query (`useQuery`) for `/api/bites/active`, remove the sample-bites fallback when the API returns an empty array, map returned items into the UI, and invalidate/refetch `/api/bites/active` after creating a bite from the row create flow. (`client/src/components/BitesRow.tsx`)
- Update `CreatePost` page and `CreatePostModal` to POST bites to `/api/bites` for `postType === 'bite' | 'clip'`, send `mediaType`, and invalidate `/api/bites/active` rather than creating a `/api/posts` entry. (`client/src/pages/social/create-post.tsx`, `client/src/components/create-post-modal.tsx`)
- Add `media_type` column to the `stories` table and the corresponding Drizzle schema, add a migration `server/migrations/20260513_stories_media_type.sql`, validate `mediaType` in the bites API, persist it via `storage.createStory`, and return `mediaType` from `/api/bites/active`. (`shared/schema/domains/social-content.ts`, `server/routes/bites.ts`)
- Improve video playback in the Bites viewer: use `<video>` with `controls`, `autoPlay`, `muted`, `playsInline`, `preload="metadata"`, and `onLoadedMetadata`/`onCanPlay` play retry handlers so controls remain visible and autoplay behaves robustly. (`client/src/components/BitesRow.tsx`)

### Testing
- Built the client bundle with `npm run build:client` which completed successfully. 
- Built the server bundle with `npm run build:server` which completed successfully.
- Ran type checks with `npm run check` (repo-wide `tsc`); this surfaced unrelated, pre-existing TypeScript errors elsewhere in the monorepo, and no new type errors were reported for the modified bites-related files after filtering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03da98636c832596097b241135cefa)