### PR TITLE
Allow user unmute for Bite videos

### DIFF
--- a/client/src/components/BitesRow.tsx
+++ b/client/src/components/BitesRow.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Heart,
@@ -130,6 +130,16 @@ export function BitesRow({ className = "" }: BitesRowProps) {
   const [createError, setCreateError] = useState("");
   const [showCamera, setShowCamera] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const biteVideoMutedRef = useRef(true);
+
+  const initializeBiteVideoAudio = useCallback(
+    (video: HTMLVideoElement | null) => {
+      if (!video) return;
+      video.defaultMuted = true;
+      video.muted = biteVideoMutedRef.current;
+    },
+    [],
+  );
 
   const handleCameraCapture = (dataUrl: string, type: "image" | "video") => {
     setCreateMediaType(type);
@@ -222,6 +232,7 @@ export function BitesRow({ className = "" }: BitesRowProps) {
     );
     setCurrentUserIndex(userIndex);
     setCurrentBiteIndex(0);
+    biteVideoMutedRef.current = true;
     setIsViewing(true);
     setProgress(0);
 
@@ -624,24 +635,26 @@ export function BitesRow({ className = "" }: BitesRowProps) {
                   key={currentBite.id}
                   src={currentBite.content.url}
                   className="w-full h-full min-h-[300px] object-contain rounded-lg bg-black"
+                  ref={initializeBiteVideoAudio}
                   controls
                   autoPlay
-                  muted
                   playsInline
                   preload="metadata"
                   onLoadedMetadata={(event) => {
                     logVideoLoadedMetadata("modal-viewer", event.currentTarget);
                     event.currentTarget.play().catch(() => undefined);
                   }}
-                  onCanPlay={(event) => {
-                    logVideoCanPlay("modal-viewer", event.currentTarget);
-                    event.currentTarget.play().catch(() => undefined);
-                  }}
+                  onCanPlay={(event) =>
+                    logVideoCanPlay("modal-viewer", event.currentTarget)
+                  }
                   onError={(event) =>
                     logVideoError("modal-viewer", event.currentTarget)
                   }
                   onPlay={() => setIsPaused(false)}
                   onPause={() => setIsPaused(true)}
+                  onVolumeChange={(event) => {
+                    biteVideoMutedRef.current = event.currentTarget.muted;
+                  }}
                 />
               ) : (
                 <img


### PR DESCRIPTION
### Motivation
- Keep Bite videos autoplaying muted by default while allowing the user to unmute and have that choice persist during playback and across re-renders.

### Description
- Add a `biteVideoMutedRef` and `initializeBiteVideoAudio` ref callback to set `video.defaultMuted = true` and apply the current muted state on mount instead of binding a controlled `muted` prop. 
- Use `ref={initializeBiteVideoAudio}` on the Bite viewer `<video>` element and remove the permanent `muted` binding and the aggressive autoplay retry inside `onCanPlay`.
- Track native user volume changes with `onVolumeChange` and update `biteVideoMutedRef.current` so the native speaker/unmute control is respected and preserved.
- Reset the ref to muted when opening the Bite viewer via `biteVideoMutedRef.current = true` to preserve initial autoplay-muted behavior.

### Testing
- Ran `git diff --check` with no issues related to the change.
- Ran `npm run check` which failed due to unrelated TypeScript errors elsewhere in the repo, and observed that there were no `BitesRow.tsx` errors reported from the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06042305b8832582032f553b4cf125)