### PR TITLE
Fix /notifications 404 and bite inline reply/like notifications

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,6 +31,7 @@ const DuetsPage = React.lazy(() => import("@/pages/social/duets"));
 const EventsPage = React.lazy(() => import("@/pages/social/events"));
 const DMInboxPage = React.lazy(() => import("@/pages/dm/InboxPage"));
 const DMThreadPage = React.lazy(() => import("@/pages/dm/ThreadPage"));
+const NotificationsPage = React.lazy(() => import("@/pages/notifications"));
 const ExplorePage = React.lazy(() => import("@/pages/explore/ExplorePage"));
 const Pantry = React.lazy(() => import("@/pages/pantry"));
 const RecipeMatches = React.lazy(() => import("@/pages/pantry/recipe-matches"));
@@ -203,6 +204,7 @@ export default function App() {
                 {/* 🔔 DMs (NEW) */}
                 <Route path="/messages" component={DMInboxPage} />
                 <Route path="/messages/:threadId" component={DMThreadPage} />
+                <Route path="/notifications" component={NotificationsPage} />
 
                 {/* BiteMap */}
                 <Route path="/bitemap" component={BiteMapPage} />

--- a/client/src/components/BitesRow.tsx
+++ b/client/src/components/BitesRow.tsx
@@ -16,7 +16,6 @@ import {
   SmilePlus,
   Send,
 } from "lucide-react";
-import { useLocation } from "wouter";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
@@ -138,7 +137,6 @@ export function BitesRow({ className = "" }: BitesRowProps) {
   const [createSubmitting, setCreateSubmitting] = useState(false);
   const [createError, setCreateError] = useState("");
   const [showCamera, setShowCamera] = useState(false);
-  const [, setLocation] = useLocation();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const activeBiteVideoRef = useRef<HTMLVideoElement | null>(null);
   const biteVideoMutedRef = useRef(true);
@@ -337,8 +335,13 @@ export function BitesRow({ className = "" }: BitesRowProps) {
   const handleLike = (biteId: string) => {
     setLikedBiteIds((prev) => {
       const next = new Set(prev);
-      if (next.has(biteId)) next.delete(biteId);
-      else next.add(biteId);
+      const wasLiked = next.has(biteId);
+      if (wasLiked) {
+        next.delete(biteId);
+      } else {
+        next.add(biteId);
+        fetch(`/api/bites/${biteId}/like`, { method: "POST", credentials: "include" }).catch(() => undefined);
+      }
       return next;
     });
   };
@@ -378,9 +381,7 @@ export function BitesRow({ className = "" }: BitesRowProps) {
     event: React.MouseEvent<HTMLButtonElement>,
   ) => {
     event.stopPropagation();
-    if (!currentBite) return;
-    closeBites();
-    setLocation(`/messages?new=${encodeURIComponent(currentBite.username)}`);
+    replyInputRef.current?.focus();
   };
 
   const handleEmojiReact = (emoji: string) => {

--- a/server/routes/bites.ts
+++ b/server/routes/bites.ts
@@ -4,7 +4,8 @@ import { z } from "zod";
 import { eq, desc, sql } from "drizzle-orm";
 import { storage } from "../storage";
 import { db } from "../db";
-import { stories, users } from "../../shared/schema";
+import { requireAuth } from "../middleware";
+import { stories, users, notifications } from "../../shared/schema";
 
 const r = Router();
 
@@ -189,6 +190,46 @@ r.post("/", async (req, res) => {
     }
     console.error("[bites] POST / error", e);
     res.status(500).json({ message: "Failed to create bite" });
+  }
+});
+
+// Like a bite — fires a notification to the owner
+r.post("/:id/like", requireAuth, async (req, res) => {
+  try {
+    const { id } = req.params;
+    const likerId = req.user!.id;
+
+    const [bite] = await db
+      .select({ userId: stories.userId })
+      .from(stories)
+      .where(eq(stories.id, id))
+      .limit(1);
+
+    if (!bite) return res.status(404).json({ ok: false, error: "Bite not found" });
+
+    if (bite.userId !== likerId) {
+      const [liker] = await db
+        .select({ displayName: users.displayName, username: users.username })
+        .from(users)
+        .where(eq(users.id, likerId))
+        .limit(1);
+
+      const likerName = liker?.displayName || liker?.username || "Someone";
+
+      await db.insert(notifications).values({
+        userId: bite.userId,
+        type: "like",
+        title: `${likerName} liked your Bite`,
+        message: `${likerName} reacted to your Bite`,
+        linkUrl: `/feed`,
+        priority: "normal",
+      });
+    }
+
+    res.json({ ok: true });
+  } catch (e: any) {
+    console.error("[bites] POST /:id/like error", e);
+    res.status(500).json({ ok: false, error: "Failed to record like" });
   }
 });
 

--- a/server/routes/dm.ts
+++ b/server/routes/dm.ts
@@ -1,7 +1,7 @@
 // server/routes/dm.ts
 import { Router } from "express";
 import { z } from "zod";
-import { and, desc, eq, inArray, lt } from "drizzle-orm";
+import { and, desc, eq, inArray, lt, ne } from "drizzle-orm";
 import { db } from "../db";
 import { requireAuth } from "../middleware";
 import {
@@ -319,6 +319,38 @@ r.post("/threads/:id/messages", requireAuth, async (req, res) => {
     .update(dmParticipants)
     .set({ lastReadMessageId: msg.id, lastReadAt: new Date() })
     .where(and(eq(dmParticipants.threadId, id), eq(dmParticipants.userId, userId)));
+
+  // Notify other participants
+  try {
+    const { users } = await import("../../shared/schema");
+    const { notifications } = await import("../../shared/schema");
+    const [sender] = await db
+      .select({ displayName: users.displayName, username: users.username })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1);
+    const senderName = sender?.displayName || sender?.username || "Someone";
+
+    const others = await db
+      .select({ userId: dmParticipants.userId })
+      .from(dmParticipants)
+      .where(and(eq(dmParticipants.threadId, id), ne(dmParticipants.userId, userId)));
+
+    if (others.length > 0) {
+      await db.insert(notifications).values(
+        others.map((p) => ({
+          userId: p.userId,
+          type: "message",
+          title: `New message from ${senderName}`,
+          message: body.text.length > 80 ? body.text.slice(0, 80) + "…" : body.text,
+          linkUrl: `/messages`,
+          priority: "normal",
+        }))
+      );
+    }
+  } catch {
+    // never break message delivery
+  }
 
   res.json({ ok: true, message: msg });
 });


### PR DESCRIPTION
## Summary

- Fix `/notifications` page returning 404 — route was missing from App.tsx
- Bite reply button focuses inline input instead of navigating to /messages
- Like on a Bite sends notification to the owner
- DM messages notify other thread participants

## Test plan

- [ ] Visit `/notifications` — should load instead of 404
- [ ] Open someone else's Bite, tap chat bubble → reply bar appears at bottom
- [ ] Like someone's Bite → they get a notification

https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e)_