### PR TITLE
Make store customization actually work end-to-end

### DIFF
--- a/client/src/components/store/StoreHeader.tsx
+++ b/client/src/components/store/StoreHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Store, MapPin, Clock, Star, ExternalLink } from 'lucide-react';
+import { Store, MapPin, Clock, Star } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 
@@ -7,29 +7,44 @@ export interface StoreHeaderProps {
   store: {
     name: string;
     handle: string;
-    bio?: string;
-    logo_url?: string;
-    banner_url?: string;
-    location?: string;
-    rating?: number;
-    review_count?: number;
-    hours?: string;
+    bio?: string | null;
+    logo_url?: string | null;
+    banner_url?: string | null;
+    location?: string | null;
+    rating?: number | null;
+    review_count?: number | null;
+    hours?: string | null;
     published?: boolean;
   };
   isOwner?: boolean;
   onEdit?: () => void;
+  themeColors?: {
+    primary: string;
+    secondary: string;
+    accent: string;
+  };
 }
 
-export const StoreHeader: React.FC<StoreHeaderProps> = ({ store, isOwner, onEdit }) => {
+export const StoreHeader: React.FC<StoreHeaderProps> = ({ store, isOwner, onEdit, themeColors }) => {
+  const primary = themeColors?.primary ?? "#FF6B35";
+  const secondary = themeColors?.secondary ?? "#2C3E50";
+
   return (
     <div className="w-full">
       {/* Banner */}
-      <div className="relative h-48 md:h-64 bg-gradient-to-r from-orange-400 to-red-500 overflow-hidden">
+      <div
+        className="relative h-48 md:h-64 overflow-hidden"
+        style={
+          store.banner_url
+            ? undefined
+            : { background: `linear-gradient(135deg, ${primary} 0%, ${secondary} 100%)` }
+        }
+      >
         {store.banner_url ? (
           <img src={store.banner_url} alt="Store banner" className="w-full h-full object-cover" />
         ) : (
           <div className="w-full h-full flex items-center justify-center">
-            <Store size={64} className="text-white opacity-50" />
+            <Store size={64} className="text-white opacity-40" />
           </div>
         )}
         {isOwner && (
@@ -41,27 +56,29 @@ export const StoreHeader: React.FC<StoreHeaderProps> = ({ store, isOwner, onEdit
         )}
       </div>
 
-      {/* Store Info */}
+      {/* Store Info card */}
       <div className="max-w-6xl mx-auto px-4 -mt-12 relative z-10">
         <div className="bg-white rounded-lg shadow-lg p-6">
           <div className="flex items-start gap-4">
             {/* Logo */}
-            <div className="w-24 h-24 rounded-lg bg-gray-200 flex-shrink-0 overflow-hidden border-4 border-white shadow">
+            <div className="w-24 h-24 rounded-lg bg-gray-100 flex-shrink-0 overflow-hidden border-4 border-white shadow"
+              style={!store.logo_url ? { backgroundColor: primary + "22" } : undefined}
+            >
               {store.logo_url ? (
                 <img src={store.logo_url} alt={store.name} className="w-full h-full object-cover" />
               ) : (
                 <div className="w-full h-full flex items-center justify-center">
-                  <Store size={32} className="text-gray-400" />
+                  <Store size={32} style={{ color: primary }} />
                 </div>
               )}
             </div>
 
             {/* Info */}
-            <div className="flex-1">
-              <div className="flex items-start justify-between">
+            <div className="flex-1 min-w-0">
+              <div className="flex items-start justify-between gap-2">
                 <div>
-                  <h1 className="text-3xl font-bold">{store.name}</h1>
-                  <p className="text-gray-600">@{store.handle}</p>
+                  <h1 className="text-3xl font-bold" style={{ color: secondary }}>{store.name}</h1>
+                  <p className="text-gray-500">@{store.handle}</p>
                 </div>
                 {!store.published && isOwner && (
                   <Badge variant="secondary">Unpublished</Badge>
@@ -69,26 +86,28 @@ export const StoreHeader: React.FC<StoreHeaderProps> = ({ store, isOwner, onEdit
               </div>
 
               {store.bio && (
-                <p className="text-gray-700 mt-3">{store.bio}</p>
+                <p className="text-gray-700 mt-3 leading-relaxed">{store.bio}</p>
               )}
 
               <div className="flex flex-wrap gap-4 mt-4 text-sm text-gray-600">
                 {store.location && (
                   <div className="flex items-center gap-1">
-                    <MapPin size={16} />
+                    <MapPin size={15} style={{ color: primary }} />
                     <span>{store.location}</span>
                   </div>
                 )}
                 {store.hours && (
                   <div className="flex items-center gap-1">
-                    <Clock size={16} />
+                    <Clock size={15} style={{ color: primary }} />
                     <span>{store.hours}</span>
                   </div>
                 )}
-                {store.rating && (
+                {store.rating != null && (
                   <div className="flex items-center gap-1">
-                    <Star size={16} className="fill-yellow-400 text-yellow-400" />
-                    <span>{parseFloat(String(store.rating)).toFixed(1)} ({store.review_count} reviews)</span>
+                    <Star size={15} className="fill-yellow-400 text-yellow-400" />
+                    <span>{parseFloat(String(store.rating)).toFixed(1)}
+                      {store.review_count != null && ` (${store.review_count} reviews)`}
+                    </span>
                   </div>
                 )}
               </div>

--- a/client/src/pages/store/StoreDashboard.tsx
+++ b/client/src/pages/store/StoreDashboard.tsx
@@ -3,7 +3,6 @@ import { useLocation } from "wouter";
 import {
   Package,
   ShoppingCart,
-  Edit,
   Sparkles,
   Palette,
   BarChart3,
@@ -13,10 +12,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useUser } from "@/contexts/UserContext";
 import { useToast } from "@/hooks/use-toast";
 import SubscriptionPlansModal from "@/components/store/SubscriptionPlansModal";
-import StoreBuilder from "@/components/store/StoreBuilder";
 import { getSellerMarketplaceProducts } from "@/lib/store/marketplaceApi";
 import StoreDashboardStatsGrid from "./components/StoreDashboardStatsGrid";
-import StoreDashboardBuilderTab from "./components/StoreDashboardBuilderTab";
 import StoreDashboardAnalyticsTab from "./components/StoreDashboardAnalyticsTab";
 import StoreDashboardSubscriptionTab from "./components/StoreDashboardSubscriptionTab";
 import StoreDashboardQuickActions from "./components/StoreDashboardQuickActions";
@@ -54,7 +51,6 @@ export default function StoreDashboard() {
   const [publishing, setPublishing] = useState(false);
   const [selectedTheme, setSelectedTheme] = useState("modern");
   const [showPlansModal, setShowPlansModal] = useState(false);
-  const [showBuilder, setShowBuilder] = useState(false);
   const [activeTab, setActiveTab] = useState("products");
   const [customizeInitialTab, setCustomizeInitialTab] = useState("branding");
   const tabsRef = useRef<HTMLDivElement>(null);
@@ -351,22 +347,6 @@ export default function StoreDashboard() {
     }
   };
 
-  if (showBuilder && store) {
-    return (
-      <StoreBuilder
-        storeId={store.id}
-        store={store}
-        products={products}
-        productsLoaded={productsLoaded}
-        onBack={() => setShowBuilder(false)}
-        onReadinessAction={(action) => {
-          setShowBuilder(false);
-          handleReadinessAction(action);
-        }}
-      />
-    );
-  }
-
   if (loading) {
     return <StoreDashboardLoadingState />;
   }
@@ -423,10 +403,6 @@ export default function StoreDashboard() {
               <ShoppingCart className="w-4 h-4 mr-1.5" />
               Orders
             </TabsTrigger>
-            <TabsTrigger value="builder">
-              <Edit className="w-4 h-4 mr-1.5" />
-              Store Builder
-            </TabsTrigger>
             <TabsTrigger value="customize">
               <Sparkles className="w-4 h-4 mr-1.5" />
               Customize
@@ -458,13 +434,6 @@ export default function StoreDashboard() {
           {/* Orders Tab */}
           <TabsContent value="orders">
             <StoreDashboardOrdersTab recentSales={recentSales} />
-          </TabsContent>
-
-          {/* Store Builder Tab */}
-          <TabsContent value="builder">
-            <StoreDashboardBuilderTab
-              onOpenBuilder={() => setShowBuilder(true)}
-            />
           </TabsContent>
 
           {/* Customize Tab */}

--- a/client/src/pages/store/StoreViewer.tsx
+++ b/client/src/pages/store/StoreViewer.tsx
@@ -8,7 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { StoreHeader } from "@/components/store/StoreHeader";
 import { ProductCard } from "@/components/store/ProductCard";
-import { ShoppingBag, Eye, Heart } from "lucide-react";
+import { ShoppingBag, Eye, Heart, MapPin, Clock } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { useUser } from "@/contexts/UserContext";
 import { THEMES } from "@/components/store/ThemeSelector";
@@ -20,7 +20,7 @@ interface StoreData {
   name: string;
   bio: string;
   theme: string;
-  customization: any;
+  layout: Record<string, any> | null;
   published: boolean;
   subscriptionTier: string;
   createdAt: string;
@@ -60,7 +60,6 @@ export default function StoreViewer() {
 
   const fetchStore = async () => {
     if (!storeHandle) return;
-
     try {
       setLoading(true);
       const response = await fetch(`/api/stores/${storeHandle}`, {
@@ -69,13 +68,10 @@ export default function StoreViewer() {
 
       if (!response.ok) {
         if (response.status === 404) {
-          // Before giving up, check if the current user owns a store with this handle
-          // (unpublished stores return 404 to non-owners)
           try {
             const ownerRes = await fetch(`/api/stores/check-handle/${storeHandle}`);
             if (ownerRes.ok) {
               const checkData = await ownerRes.json();
-              // available=false means store EXISTS (just not published)
               if (checkData.available === false) {
                 toast({
                   title: "Store not published",
@@ -100,13 +96,8 @@ export default function StoreViewer() {
 
       const storeData = await response.json();
       const storeObj = storeData.store ?? storeData;
-      // DEBUG — log full response so we can see the shape
-      console.log('[StoreViewer] raw response:', storeData);
-      console.log('[StoreViewer] storeObj:', storeObj);
-      console.log('[StoreViewer] userId:', storeObj?.userId, '| user_id:', (storeObj as any)?.user_id);
       setStore(storeObj);
 
-      // Track store view
       if (storeObj?.id) {
         fetch(`/api/stores/${storeObj.id}/increment-view`, { method: "PATCH" }).catch(() => {});
       }
@@ -127,22 +118,11 @@ export default function StoreViewer() {
     try {
       setProductsLoading(true);
       const response = await fetch(`/api/marketplace/sellers/${sellerId}/products`);
-
-      if (!response.ok) {
-        console.error('[StoreViewer] fetchProducts failed:', response.status, sellerId);
-        throw new Error("Failed to fetch products");
-      }
-
+      if (!response.ok) throw new Error("Failed to fetch products");
       const data = await response.json();
-      console.log('[StoreViewer] products response:', { sellerId, count: data.products?.length, data });
       setProducts(data.products || []);
     } catch (error) {
       console.error("Error fetching store products:", error);
-      toast({
-        title: "Error",
-        description: "Failed to load store products.",
-        variant: "destructive",
-      });
     } finally {
       setProductsLoading(false);
     }
@@ -155,10 +135,7 @@ export default function StoreViewer() {
 
   useEffect(() => {
     const sellerId = store?.userId ?? (store as any)?.user_id;
-    console.log('[StoreViewer] useEffect store changed:', { store, sellerId });
-    if (sellerId) {
-      fetchProducts(sellerId);
-    }
+    if (sellerId) fetchProducts(sellerId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [store?.userId, (store as any)?.user_id]);
 
@@ -168,7 +145,7 @@ export default function StoreViewer() {
     return (
       <div className="min-h-screen bg-gray-50">
         <div className="max-w-6xl mx-auto px-4 py-8">
-          <Skeleton className="h-32 w-full mb-8" />
+          <Skeleton className="h-64 w-full mb-8" />
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {Array.from({ length: 6 }).map((_, i) => (
               <Card key={i}>
@@ -176,7 +153,6 @@ export default function StoreViewer() {
                   <Skeleton className="h-48 w-full mb-4" />
                   <Skeleton className="h-4 w-3/4 mb-2" />
                   <Skeleton className="h-4 w-1/2 mb-2" />
-                  <Skeleton className="h-4 w-full mb-2" />
                   <Skeleton className="h-4 w-2/3" />
                 </CardContent>
               </Card>
@@ -192,30 +168,73 @@ export default function StoreViewer() {
   const isOwner = user?.id === store.userId;
   const themeColors = THEMES.find((t) => t.id === store.theme)?.colors ?? THEMES[0].colors;
 
-  return (
-    <div
-      className="min-h-screen bg-gray-50"
-      style={{
-        "--store-primary": themeColors.primary,
-        "--store-secondary": themeColors.secondary,
-        "--store-accent": themeColors.accent,
-      } as React.CSSProperties}
-    >
-      <StoreHeader store={store} isOwner={isOwner} />
+  // Extract layout config — saved by StoreCustomization as store.layout
+  const layout: Record<string, any> =
+    store.layout && typeof store.layout === "object" && !Array.isArray(store.layout)
+      ? store.layout
+      : {};
 
+  // Map layout fields to what StoreHeader expects
+  const storeForHeader = {
+    ...store,
+    banner_url: layout.bannerImage || (store as any).banner_url || null,
+    logo_url: layout.logo || (store as any).logo_url || null,
+    bio: store.bio || layout.aboutContent || null,
+  };
+
+  // Dynamic grid columns
+  const gridCols: number = layout.layout?.gridColumns ?? 3;
+  const gridClass =
+    gridCols === 2
+      ? "grid-cols-1 md:grid-cols-2"
+      : gridCols === 4
+        ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-4"
+        : "grid-cols-1 md:grid-cols-3";
+
+  return (
+    <div className="min-h-screen" style={{ backgroundColor: themeColors.accent + "22" }}>
+
+      {/* Announcement bar */}
+      {layout.announcementEnabled && layout.announcementBar && (
+        <div
+          className="text-white text-center py-2 px-4 text-sm font-medium"
+          style={{ backgroundColor: themeColors.primary }}
+        >
+          {layout.announcementBar}
+        </div>
+      )}
+
+      <StoreHeader store={storeForHeader} isOwner={isOwner} themeColors={themeColors} />
+
+      {/* About section */}
+      {layout.aboutEnabled && layout.aboutContent && (
+        <div className="max-w-6xl mx-auto px-4 pt-10 pb-2">
+          <h2 className="text-xl font-bold mb-3" style={{ color: themeColors.secondary }}>
+            {layout.aboutTitle || "About Us"}
+          </h2>
+          <p className="text-gray-700 leading-relaxed">{layout.aboutContent}</p>
+        </div>
+      )}
+
+      {/* Products */}
       <div className="max-w-6xl mx-auto px-4 py-8">
         <div className="flex justify-between items-center mb-6">
           <div>
-            <h2 className="text-2xl font-bold mb-1">Products</h2>
+            <h2 className="text-2xl font-bold mb-1" style={{ color: themeColors.secondary }}>
+              Products
+            </h2>
             <p className="text-gray-600">{products.length} items available</p>
           </div>
-
           <div className="flex gap-3">
             <Button variant="outline" onClick={() => setLocation("/marketplace")}>
               Browse Marketplace
             </Button>
             {isOwner && (
-              <Button onClick={() => setLocation("/store/dashboard")}>
+              <Button
+                onClick={() => setLocation("/store/dashboard")}
+                style={{ backgroundColor: themeColors.primary }}
+                className="text-white hover:opacity-90"
+              >
                 Manage Store
               </Button>
             )}
@@ -223,14 +242,13 @@ export default function StoreViewer() {
         </div>
 
         {productsLoading ? (
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div className={`grid ${gridClass} gap-6`}>
             {Array.from({ length: 6 }).map((_, i) => (
               <Card key={i}>
                 <CardContent className="p-4">
                   <Skeleton className="h-48 w-full mb-4" />
                   <Skeleton className="h-4 w-3/4 mb-2" />
                   <Skeleton className="h-4 w-1/2 mb-2" />
-                  <Skeleton className="h-4 w-full mb-2" />
                   <Skeleton className="h-4 w-2/3" />
                 </CardContent>
               </Card>
@@ -254,7 +272,7 @@ export default function StoreViewer() {
             </CardContent>
           </Card>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div className={`grid ${gridClass} gap-6`}>
             {products.map((product) => (
               <div
                 key={product.id}
@@ -281,6 +299,26 @@ export default function StoreViewer() {
           </div>
         )}
       </div>
+
+      {/* Contact / hours footer */}
+      {(layout.contactInfo?.address || layout.contactInfo?.hours) && (
+        <div className="border-t mt-8">
+          <div className="max-w-6xl mx-auto px-4 py-8 flex flex-wrap gap-6 text-sm text-gray-600">
+            {layout.contactInfo?.address && (
+              <div className="flex items-center gap-2">
+                <MapPin className="w-4 h-4 flex-shrink-0" style={{ color: themeColors.primary }} />
+                <span>{layout.contactInfo.address}</span>
+              </div>
+            )}
+            {layout.contactInfo?.hours && (
+              <div className="flex items-center gap-2">
+                <Clock className="w-4 h-4 flex-shrink-0" style={{ color: themeColors.primary }} />
+                <span>{layout.contactInfo.hours}</span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What was broken

- Banner image and logo were saved as `layout.bannerImage` / `layout.logo` but StoreHeader read `banner_url` / `logo_url` — complete field mismatch so nothing ever showed
- Theme colors were set as CSS variables but nothing used them — banner was always hardcoded orange
- Announcement bar, about section, and contact info were saved but never rendered anywhere
- Product grid was hardcoded at 3 columns, ignoring the layout setting
- Store Builder tab was crashing (Invariant failed) and was redundant with Customize

## What's fixed

- **Banner/logo**: StoreViewer now maps `layout.bannerImage` → `banner_url` before passing to StoreHeader
- **Theme**: StoreHeader accepts `themeColors` prop and uses it for banner gradient, store name color, icons, and buttons
- **Announcement bar**: renders at top of page when enabled
- **About section**: renders below header when enabled with custom title
- **Contact/hours**: renders in footer
- **Grid columns**: respects the 2/3/4 column setting from Customize → Layout tab
- **Store Builder tab removed**: no more crash, dashboard is cleaner

## Test plan

- [ ] Upload a banner image in Customize → Sections → view store → banner appears
- [ ] Upload a logo → view store → logo appears in store card
- [ ] Pick a theme → view store → banner gradient and accent colors match the theme
- [ ] Enable announcement bar with text → view store → bar appears at top
- [ ] Enable about section → view store → section appears below header
- [ ] Change grid to 2 columns → view store → products show in 2 columns

https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e)_