### PR TITLE
Integrate recipes into Meal Planner (import, persist, display)

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -85,6 +85,11 @@ const createInitialMealForm = () => ({
   servingSize: '',
   servingQty: 1,
   mealItems: [createMealItemRow()],
+  sourceRecipeId: undefined,
+  sourceRecipeTitle: undefined,
+  sourceRecipeImageUrl: undefined,
+  sourceRecipeServings: undefined,
+  sourceRecipeUrl: undefined,
 });
 
 const INITIAL_MEAL_FORM = createInitialMealForm();
@@ -1279,6 +1284,11 @@ const NutritionMealPlanner = () => {
           mealItems: mealData.mealItems || null,
           source: mealData.source || null,
           recipeId: mealData.recipeId || null,
+          sourceRecipeId: mealData.sourceRecipeId || null,
+          sourceRecipeTitle: mealData.sourceRecipeTitle || null,
+          sourceRecipeImageUrl: mealData.sourceRecipeImageUrl || null,
+          sourceRecipeServings: mealData.sourceRecipeServings || null,
+          sourceRecipeUrl: mealData.sourceRecipeUrl || null,
         }),
       });
 
@@ -2001,16 +2011,29 @@ const NutritionMealPlanner = () => {
       carbs: acc.carbs + item.carbs,
       fat: acc.fat + item.fat,
     }), { calories: 0, protein: 0, carbs: 0, fat: 0 });
+    const hasRecipeNutrition = Boolean(mealForm.sourceRecipeId) && (Number(mealForm.calories) > 0 || Number(mealForm.protein) > 0 || Number(mealForm.carbs) > 0 || Number(mealForm.fat) > 0);
+    const mealTotals = hasRecipeNutrition ? {
+      calories: Number(mealForm.calories) || 0,
+      protein: Number(mealForm.protein) || 0,
+      carbs: Number(mealForm.carbs) || 0,
+      fat: Number(mealForm.fat) || 0,
+    } : itemTotals;
 
     saveMealToSlot({
       name: mealForm.name.trim(),
-      calories: itemTotals.calories,
-      protein: itemTotals.protein,
-      carbs: itemTotals.carbs,
-      fat: itemTotals.fat,
+      calories: mealTotals.calories,
+      protein: mealTotals.protein,
+      carbs: mealTotals.carbs,
+      fat: mealTotals.fat,
       fiber: Number(mealForm.fiber) || 0,
       servingSize: normalizedMealItems.length === 1 ? (normalizedMealItems[0].quantity || mealForm.servingSize || '1 serving') : `${normalizedMealItems.length} items`,
       mealItems: normalizedMealItems,
+      source: mealForm.sourceRecipeId ? 'recipe' : null,
+      sourceRecipeId: mealForm.sourceRecipeId,
+      sourceRecipeTitle: mealForm.sourceRecipeTitle,
+      sourceRecipeImageUrl: mealForm.sourceRecipeImageUrl,
+      sourceRecipeServings: mealForm.sourceRecipeServings,
+      sourceRecipeUrl: mealForm.sourceRecipeUrl,
     });
     resetAddMealModalState();
   };

--- a/client/src/components/meal-planner/modals/AddMealModal.tsx
+++ b/client/src/components/meal-planner/modals/AddMealModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Plus, Sparkles, Trash2 } from 'lucide-react';
+import { ChefHat, Image as ImageIcon, Plus, Search, Sparkles, Trash2, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 
@@ -24,6 +24,11 @@ type MealForm = {
   servingSize: string;
   servingQty: number;
   mealItems: MealItemFormRow[];
+  sourceRecipeId?: string | number;
+  sourceRecipeTitle?: string;
+  sourceRecipeImageUrl?: string;
+  sourceRecipeServings?: number;
+  sourceRecipeUrl?: string;
 };
 
 type BaseNutrition = {
@@ -33,6 +38,40 @@ type BaseNutrition = {
   fat: number;
   fiber: number;
   servingSize: string;
+};
+
+
+type PlannerRecipeSearchItem = {
+  id: string | number;
+  title: string;
+  image?: string | null;
+  imageUrl?: string | null;
+  thumbnail?: string | null;
+  servings?: number | null;
+  calories?: number | string | null;
+  protein?: number | string | null;
+  carbs?: number | string | null;
+  fat?: number | string | null;
+  fiber?: number | string | null;
+  nutrition?: {
+    calories?: number | string | null;
+    protein?: number | string | null;
+    carbs?: number | string | null;
+    fat?: number | string | null;
+    fiber?: number | string | null;
+  } | null;
+  ingredients?: any[] | string | null;
+  sourceUrl?: string | null;
+  sourceURL?: string | null;
+  source_link?: string | null;
+  url?: string | null;
+  source?: string | null;
+};
+
+type RecipeSearchResponse = {
+  ok?: boolean;
+  items?: PlannerRecipeSearchItem[];
+  results?: PlannerRecipeSearchItem[];
 };
 
 type MealHistoryItem = {
@@ -80,6 +119,66 @@ const createMealItemRow = (overrides: Partial<MealItemFormRow> = {}): MealItemFo
 
 const toNumber = (value: string | number | undefined) => Number(value) || 0;
 
+const toOptionalNumber = (value: unknown): number | undefined => {
+  const num = Number(value);
+  return Number.isFinite(num) && num > 0 ? num : undefined;
+};
+
+const getRecipeImageUrl = (recipe: PlannerRecipeSearchItem | null) => (
+  recipe?.imageUrl || recipe?.image || recipe?.thumbnail || ''
+);
+
+const getRecipeUrl = (recipe: PlannerRecipeSearchItem | null) => (
+  recipe?.sourceUrl || recipe?.sourceURL || recipe?.source_link || recipe?.url || undefined
+);
+
+const getRecipeNutrition = (recipe: PlannerRecipeSearchItem | null) => ({
+  calories: toOptionalNumber(recipe?.calories ?? recipe?.nutrition?.calories),
+  protein: toOptionalNumber(recipe?.protein ?? recipe?.nutrition?.protein),
+  carbs: toOptionalNumber(recipe?.carbs ?? recipe?.nutrition?.carbs),
+  fat: toOptionalNumber(recipe?.fat ?? recipe?.nutrition?.fat),
+  fiber: toOptionalNumber(recipe?.fiber ?? recipe?.nutrition?.fiber),
+});
+
+const getRecipeIngredients = (recipe: PlannerRecipeSearchItem | null): any[] => {
+  const ingredients = recipe?.ingredients;
+  if (!ingredients) return [];
+  if (Array.isArray(ingredients)) return ingredients.filter(Boolean);
+  if (typeof ingredients === 'string') {
+    return ingredients
+      .split(/\n|,/)
+      .map((ingredient) => ingredient.trim())
+      .filter(Boolean);
+  }
+  return [];
+};
+
+const firstString = (...values: unknown[]) => (
+  values.find((value) => typeof value === 'string' && value.trim()) as string | undefined
+)?.trim();
+
+const ingredientToMealItem = (ingredient: any): MealItemFormRow => {
+  if (typeof ingredient === 'string') {
+    return createMealItemRow({ name: ingredient.trim() });
+  }
+
+  const name = firstString(ingredient?.name, ingredient?.ingredient, ingredient?.item, ingredient?.food, ingredient?.title) || 'Ingredient';
+  const amount = firstString(ingredient?.amount, ingredient?.quantity, ingredient?.qty, ingredient?.measure);
+  const unit = firstString(ingredient?.unit, ingredient?.unitName, ingredient?.unitShort);
+  const quantity = [amount, unit].filter(Boolean).join(' ').trim();
+  const notes = firstString(ingredient?.notes, ingredient?.note, ingredient?.preparation, ingredient?.aisle, ingredient?.original, ingredient?.originalString);
+
+  return createMealItemRow({
+    name,
+    quantity,
+    notes: notes && notes !== name && notes !== quantity ? notes : '',
+    calories: String(ingredient?.calories || ''),
+    protein: String(ingredient?.protein || ''),
+    carbs: String(ingredient?.carbs || ''),
+    fat: String(ingredient?.fat || ''),
+  });
+};
+
 const AddMealModal = ({
   open,
   selectedMealSlot,
@@ -104,6 +203,16 @@ const AddMealModal = ({
     carbs: acc.carbs + toNumber(item.carbs),
     fat: acc.fat + toNumber(item.fat),
   }), { calories: 0, protein: 0, carbs: 0, fat: 0 });
+
+  const [recipeSearchTerm, setRecipeSearchTerm] = React.useState('');
+  const [recipeResults, setRecipeResults] = React.useState<PlannerRecipeSearchItem[]>([]);
+  const [selectedRecipe, setSelectedRecipe] = React.useState<PlannerRecipeSearchItem | null>(null);
+  const [isSearchingRecipes, setIsSearchingRecipes] = React.useState(false);
+  const [recipeSearchError, setRecipeSearchError] = React.useState('');
+  const selectedRecipeNutrition = getRecipeNutrition(selectedRecipe);
+  const selectedRecipeIngredients = getRecipeIngredients(selectedRecipe);
+  const selectedRecipeImageUrl = getRecipeImageUrl(selectedRecipe);
+  const linkedRecipeId = mealForm.sourceRecipeId;
 
   const updateMealItem = (id: string, updates: Partial<MealItemFormRow>) => {
     onMealFormChange((prev) => ({
@@ -172,6 +281,91 @@ const AddMealModal = ({
       });
     }
   }, [mealForm.calories, mealForm.protein, mealForm.carbs, mealForm.fat]);
+
+
+  React.useEffect(() => {
+    if (!open) {
+      setRecipeSearchTerm('');
+      setRecipeResults([]);
+      setSelectedRecipe(null);
+      setRecipeSearchError('');
+    }
+  }, [open]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const trimmed = recipeSearchTerm.trim();
+    if (trimmed.length < 2) {
+      setRecipeResults([]);
+      setRecipeSearchError('');
+      return;
+    }
+
+    const controller = new AbortController();
+    const timeout = window.setTimeout(async () => {
+      setIsSearchingRecipes(true);
+      setRecipeSearchError('');
+      try {
+        const params = new URLSearchParams({ q: trimmed, pageSize: '8', source: 'all' });
+        const response = await fetch(`/api/recipes/search?${params.toString()}`, {
+          credentials: 'include',
+          signal: controller.signal,
+        });
+        if (!response.ok) throw new Error('Recipe search failed');
+        const data: RecipeSearchResponse = await response.json();
+        setRecipeResults((data.items || data.results || []).filter((recipe) => recipe?.id && recipe?.title));
+      } catch (error: any) {
+        if (error?.name !== 'AbortError') {
+          setRecipeSearchError('Unable to search recipes right now. You can still enter the meal manually.');
+          setRecipeResults([]);
+        }
+      } finally {
+        if (!controller.signal.aborted) setIsSearchingRecipes(false);
+      }
+    }, 250);
+
+    return () => {
+      window.clearTimeout(timeout);
+      controller.abort();
+    };
+  }, [open, recipeSearchTerm]);
+
+  const useSelectedRecipe = () => {
+    if (!selectedRecipe) return;
+    const nutrition = getRecipeNutrition(selectedRecipe);
+    const ingredients = getRecipeIngredients(selectedRecipe);
+    const mappedItems = ingredients.map(ingredientToMealItem).filter((item) => item.name.trim());
+
+    onMealFormChange((prev) => ({
+      ...prev,
+      name: selectedRecipe.title,
+      calories: nutrition.calories ? String(nutrition.calories) : '',
+      protein: nutrition.protein ? String(nutrition.protein) : '',
+      carbs: nutrition.carbs ? String(nutrition.carbs) : '',
+      fat: nutrition.fat ? String(nutrition.fat) : '',
+      fiber: nutrition.fiber ? String(nutrition.fiber) : '',
+      servingSize: selectedRecipe.servings ? `${selectedRecipe.servings} serving${selectedRecipe.servings === 1 ? '' : 's'}` : prev.servingSize,
+      servingQty: selectedRecipe.servings || prev.servingQty || 1,
+      mealItems: mappedItems.length ? mappedItems : [createMealItemRow({ name: selectedRecipe.title, quantity: selectedRecipe.servings ? `${selectedRecipe.servings} serving${selectedRecipe.servings === 1 ? '' : 's'}` : '1 serving' })],
+      sourceRecipeId: selectedRecipe.id,
+      sourceRecipeTitle: selectedRecipe.title,
+      sourceRecipeImageUrl: getRecipeImageUrl(selectedRecipe) || undefined,
+      sourceRecipeServings: selectedRecipe.servings || undefined,
+      sourceRecipeUrl: getRecipeUrl(selectedRecipe),
+    }));
+  };
+
+  const clearLinkedRecipe = () => {
+    setSelectedRecipe(null);
+    onMealFormChange((prev) => ({
+      ...prev,
+      sourceRecipeId: undefined,
+      sourceRecipeTitle: undefined,
+      sourceRecipeImageUrl: undefined,
+      sourceRecipeServings: undefined,
+      sourceRecipeUrl: undefined,
+    }));
+  };
 
   if (!open) return null;
 
@@ -256,6 +450,93 @@ const AddMealModal = ({
                     </div>
                   ))}
                 </div>
+              </div>
+            )}
+          </div>
+
+
+          <div className="border rounded-lg p-4 bg-gradient-to-r from-amber-50 to-orange-50 border-orange-100">
+            <div className="flex items-start justify-between gap-3 mb-3">
+              <div>
+                <h4 className="text-sm font-semibold text-gray-900 flex items-center gap-2"><ChefHat className="w-4 h-4 text-orange-500" /> From recipe <span className="text-xs font-normal text-gray-500">optional</span></h4>
+                <p className="text-xs text-gray-500">Search an existing recipe, preview it, then import its ingredients as editable meal items.</p>
+              </div>
+              {linkedRecipeId && (
+                <Button type="button" size="sm" variant="outline" className="shrink-0" onClick={clearLinkedRecipe}>
+                  <X className="w-3.5 h-3.5 mr-1" /> Clear link
+                </Button>
+              )}
+            </div>
+
+            <div className="relative">
+              <Search className="w-4 h-4 text-gray-400 absolute left-3 top-2.5" />
+              <input
+                type="text"
+                className="w-full border rounded px-9 py-2 text-sm bg-white"
+                placeholder="Search recipes by title or ingredient…"
+                value={recipeSearchTerm}
+                onChange={(event) => setRecipeSearchTerm(event.target.value)}
+              />
+            </div>
+            {recipeSearchError && <p className="text-xs text-red-500 mt-2">{recipeSearchError}</p>}
+
+            {recipeSearchTerm.trim().length >= 2 && (
+              <div className="mt-2 rounded-lg border bg-white divide-y max-h-48 overflow-y-auto">
+                {isSearchingRecipes && <div className="px-3 py-2 text-xs text-gray-500">Searching recipes…</div>}
+                {!isSearchingRecipes && recipeResults.length === 0 && <div className="px-3 py-2 text-xs text-gray-500">No recipes found.</div>}
+                {!isSearchingRecipes && recipeResults.map((recipe) => (
+                  <button
+                    key={recipe.id}
+                    type="button"
+                    className={`w-full text-left px-3 py-2 hover:bg-orange-50 flex items-center gap-3 ${selectedRecipe?.id === recipe.id ? 'bg-orange-50' : ''}`}
+                    onClick={() => setSelectedRecipe(recipe)}
+                  >
+                    {getRecipeImageUrl(recipe) ? (
+                      <img src={getRecipeImageUrl(recipe)} alt="" className="w-10 h-10 rounded object-cover border" />
+                    ) : (
+                      <div className="w-10 h-10 rounded border bg-gray-50 flex items-center justify-center"><ImageIcon className="w-4 h-4 text-gray-300" /></div>
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm font-medium text-gray-900 truncate">{recipe.title}</div>
+                      <div className="text-xs text-gray-500">
+                        {recipe.servings ? `${recipe.servings} servings · ` : ''}{getRecipeIngredients(recipe).length} ingredients
+                      </div>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {selectedRecipe && (
+              <div className="mt-3 rounded-lg border bg-white p-3 flex gap-3">
+                {selectedRecipeImageUrl ? (
+                  <img src={selectedRecipeImageUrl} alt="" className="w-20 h-20 rounded-lg object-cover border shrink-0" />
+                ) : (
+                  <div className="w-20 h-20 rounded-lg border bg-gray-50 flex items-center justify-center shrink-0"><ImageIcon className="w-6 h-6 text-gray-300" /></div>
+                )}
+                <div className="min-w-0 flex-1 space-y-2">
+                  <div>
+                    <div className="font-semibold text-gray-900 truncate">{selectedRecipe.title}</div>
+                    <div className="text-xs text-gray-500">
+                      {selectedRecipe.servings ? `${selectedRecipe.servings} serving${selectedRecipe.servings === 1 ? '' : 's'} · ` : ''}{selectedRecipeIngredients.length} ingredient{selectedRecipeIngredients.length === 1 ? '' : 's'}
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-1.5 text-xs">
+                    <Badge variant="secondary">{selectedRecipeNutrition.calories ?? 0} cal</Badge>
+                    <Badge variant="secondary">P {selectedRecipeNutrition.protein ?? 0}g</Badge>
+                    <Badge variant="secondary">C {selectedRecipeNutrition.carbs ?? 0}g</Badge>
+                    <Badge variant="secondary">F {selectedRecipeNutrition.fat ?? 0}g</Badge>
+                  </div>
+                  <Button type="button" size="sm" className="bg-orange-500 hover:bg-orange-600 text-white" onClick={useSelectedRecipe}>
+                    Use this recipe
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {linkedRecipeId && (
+              <div className="mt-3 text-xs text-orange-700 flex items-center gap-1">
+                <ChefHat className="w-3.5 h-3.5" /> Linked to {mealForm.sourceRecipeTitle || 'selected recipe'}; item rows remain editable.
               </div>
             )}
           </div>

--- a/client/src/components/meal-planner/nutritionMealPlannerUtils.ts
+++ b/client/src/components/meal-planner/nutritionMealPlannerUtils.ts
@@ -34,12 +34,15 @@ export const getMealItems = (meal: any): CalendarMealItem[] => (
 export const getMealNutritionTotals = (meal: any) => {
   const mealItems = getMealItems(meal);
   if (mealItems.length > 0) {
-    return mealItems.reduce((acc, item) => ({
+    const itemTotals = mealItems.reduce((acc, item) => ({
       calories: acc.calories + (Number(item?.calories) || 0),
       protein: acc.protein + (Number(item?.protein) || 0),
       carbs: acc.carbs + (Number(item?.carbs) || 0),
       fat: acc.fat + (Number(item?.fat) || 0),
     }), { calories: 0, protein: 0, carbs: 0, fat: 0 });
+    const hasItemNutrition = itemTotals.calories > 0 || itemTotals.protein > 0 || itemTotals.carbs > 0 || itemTotals.fat > 0;
+    const hasMealNutrition = Number(meal?.calories) > 0 || Number(meal?.protein) > 0 || Number(meal?.carbs) > 0 || Number(meal?.fat) > 0;
+    if (hasItemNutrition || !hasMealNutrition) return itemTotals;
   }
 
   return {

--- a/client/src/components/meal-planner/sections/PlannerTabSection.tsx
+++ b/client/src/components/meal-planner/sections/PlannerTabSection.tsx
@@ -189,12 +189,15 @@ const PlannerTabSection = ({
   const getMealTotals = (meal: any) => {
     const components = getMealComponents(meal);
     if (components.length > 0) {
-      return components.reduce((acc: any, component: any) => ({
+      const itemTotals = components.reduce((acc: any, component: any) => ({
         calories: acc.calories + (Number(component.calories) || 0),
         protein: acc.protein + (Number(component.protein) || 0),
         carbs: acc.carbs + (Number(component.carbs) || 0),
         fat: acc.fat + (Number(component.fat) || 0),
       }), { calories: 0, protein: 0, carbs: 0, fat: 0 });
+      const hasItemNutrition = itemTotals.calories > 0 || itemTotals.protein > 0 || itemTotals.carbs > 0 || itemTotals.fat > 0;
+      const hasMealNutrition = Number(meal?.calories) > 0 || Number(meal?.protein) > 0 || Number(meal?.carbs) > 0 || Number(meal?.fat) > 0;
+      if (hasItemNutrition || !hasMealNutrition) return itemTotals;
     }
 
     return {
@@ -533,8 +536,9 @@ const PlannerTabSection = ({
                               <div key={idx} className="flex items-start justify-between gap-1 group rounded-md bg-white/70 p-1">
                                 <div className="flex-1 min-w-0">
                                   <div className="text-xs font-medium text-gray-900 truncate flex items-center gap-1">
-                                    {item.name}
-                                    {item.source === 'recipe' && <ChefHat className="w-3 h-3 text-orange-500" />}
+                                    {item.sourceRecipeImageUrl && <img src={item.sourceRecipeImageUrl} alt="" className="w-5 h-5 rounded object-cover border shrink-0" />}
+                                    <span className="truncate">{item.name}</span>
+                                    {(item.source === 'recipe' || item.sourceRecipeId) && <Badge variant="outline" className="text-[9px] leading-3 px-1 py-0 border-orange-200 text-orange-600 shrink-0"><ChefHat className="w-2.5 h-2.5 mr-0.5" />Recipe</Badge>}
                                     <span className={`px-1.5 py-0.5 rounded text-[10px] ${gradeClass(getNutritionGrade(item, calorieGoal))}`}>{getNutritionGrade(item, calorieGoal)}</span>
                                   </div>
                                   <div className="text-xs text-gray-400">{mealTotals.calories} cal · P:{mealTotals.protein}g{componentCount > 0 ? ` · ${componentCount} items` : ''}</div>
@@ -664,7 +668,7 @@ const PlannerTabSection = ({
                               return (
                                 <div key={idx} className="flex items-start justify-between bg-gray-50 rounded-lg px-3 py-2">
                                   <div className="flex-1 min-w-0">
-                                    <div className="text-sm font-medium text-gray-900 flex items-center gap-1">{item.name} {item.source === 'recipe' && <ChefHat className="w-3.5 h-3.5 text-orange-500" />} <span className={`px-1.5 py-0.5 rounded text-[10px] ${gradeClass(getNutritionGrade(item, calorieGoal))}`}>{getNutritionGrade(item, calorieGoal)}</span></div>
+                                    <div className="text-sm font-medium text-gray-900 flex items-center gap-1">{item.sourceRecipeImageUrl && <img src={item.sourceRecipeImageUrl} alt="" className="w-7 h-7 rounded object-cover border shrink-0" />}<span className="truncate">{item.name}</span> {(item.source === 'recipe' || item.sourceRecipeId) && <Badge variant="outline" className="text-[9px] leading-3 px-1 py-0 border-orange-200 text-orange-600 shrink-0"><ChefHat className="w-2.5 h-2.5 mr-0.5" />Recipe</Badge>} <span className={`px-1.5 py-0.5 rounded text-[10px] ${gradeClass(getNutritionGrade(item, calorieGoal))}`}>{getNutritionGrade(item, calorieGoal)}</span></div>
                                     <div className="flex gap-3 mt-0.5 flex-wrap"><span className="text-xs text-gray-500">{mealTotals.calories} cal</span><span className="text-xs text-blue-500">P: {mealTotals.protein}g</span><span className="text-xs text-orange-500">C: {mealTotals.carbs}g</span><span className="text-xs text-purple-500">F: {mealTotals.fat}g</span>{componentCount > 0 && <span className="text-xs text-gray-500">{componentCount} items</span>}</div>
                                     {renderMealComponents(item, cardKey)}
                                   </div>

--- a/server/routes/meal-planner-week.ts
+++ b/server/routes/meal-planner-week.ts
@@ -1483,7 +1483,7 @@ router.post("/week/generate", requireAuth, async (req: Request, res: Response) =
 router.post("/week/entry", requireAuth, async (req: Request, res: Response) => {
   try {
     const userId = req.user!.id;
-    const { date, mealType, name, calories, protein, carbs, fat, fiber, mealItems, source, recipeId } = req.body || {};
+    const { date, mealType, name, calories, protein, carbs, fat, fiber, mealItems, source, recipeId, sourceRecipeId, sourceRecipeTitle, sourceRecipeImageUrl, sourceRecipeServings, sourceRecipeUrl } = req.body || {};
 
     const parsed = date ? new Date(date) : null;
     if (!parsed || isNaN(parsed.getTime())) {
@@ -1548,6 +1548,11 @@ router.post("/week/entry", requireAuth, async (req: Request, res: Response) => {
         customFat: toNonNegativeRoundedInt(fat),
         mealItems: Array.isArray(mealItems) ? mealItems : null,
         source: source || null,
+        sourceRecipeId: sourceRecipeId ? String(sourceRecipeId) : null,
+        sourceRecipeTitle: sourceRecipeTitle ? String(sourceRecipeTitle) : null,
+        sourceRecipeImageUrl: sourceRecipeImageUrl ? String(sourceRecipeImageUrl) : null,
+        sourceRecipeServings: sourceRecipeServings ? toNonNegativeRoundedInt(sourceRecipeServings) : null,
+        sourceRecipeUrl: sourceRecipeUrl ? String(sourceRecipeUrl) : null,
       })
       .returning();
 
@@ -1647,6 +1652,11 @@ router.post("/week/entry", requireAuth, async (req: Request, res: Response) => {
         fiber: toNonNegativeRoundedInt(fiber),
         mealItems: Array.isArray(mealItems) ? mealItems : null,
         source: source || null,
+        sourceRecipeId: sourceRecipeId ? String(sourceRecipeId) : null,
+        sourceRecipeTitle: sourceRecipeTitle ? String(sourceRecipeTitle) : null,
+        sourceRecipeImageUrl: sourceRecipeImageUrl ? String(sourceRecipeImageUrl) : null,
+        sourceRecipeServings: sourceRecipeServings ? toNonNegativeRoundedInt(sourceRecipeServings) : null,
+        sourceRecipeUrl: sourceRecipeUrl ? String(sourceRecipeUrl) : null,
       },
     });
   } catch (error) {

--- a/server/routes/meal-planner-week/schema.ts
+++ b/server/routes/meal-planner-week/schema.ts
@@ -12,6 +12,11 @@ export async function ensureMealPlannerWeekSchema() {
     await db.execute(sql`ALTER TABLE meal_plan_entries ADD COLUMN IF NOT EXISTS custom_fat INTEGER;`);
     await db.execute(sql`ALTER TABLE meal_plan_entries ADD COLUMN IF NOT EXISTS meal_items JSONB;`);
     await db.execute(sql`ALTER TABLE meal_plan_entries ADD COLUMN IF NOT EXISTS source VARCHAR(50);`);
+    await db.execute(sql`ALTER TABLE meal_plan_entries ADD COLUMN IF NOT EXISTS source_recipe_id TEXT;`);
+    await db.execute(sql`ALTER TABLE meal_plan_entries ADD COLUMN IF NOT EXISTS source_recipe_title TEXT;`);
+    await db.execute(sql`ALTER TABLE meal_plan_entries ADD COLUMN IF NOT EXISTS source_recipe_image_url TEXT;`);
+    await db.execute(sql`ALTER TABLE meal_plan_entries ADD COLUMN IF NOT EXISTS source_recipe_servings INTEGER;`);
+    await db.execute(sql`ALTER TABLE meal_plan_entries ADD COLUMN IF NOT EXISTS source_recipe_url TEXT;`);
     await db.execute(sql`
       CREATE TABLE IF NOT EXISTS meal_plan_week_shares (
         id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/server/routes/meal-planner-week/utils.ts
+++ b/server/routes/meal-planner-week/utils.ts
@@ -89,6 +89,11 @@ export function mapEntriesToWeeklyMeals(entries: any[]) {
           recipeId: e.recipe.id,
           entryId: e.id,
           source: e.source || null,
+          sourceRecipeId: e.sourceRecipeId || e.recipe.id || null,
+          sourceRecipeTitle: e.sourceRecipeTitle || e.recipe.title || null,
+          sourceRecipeImageUrl: e.sourceRecipeImageUrl || e.recipe.imageUrl || null,
+          sourceRecipeServings: e.sourceRecipeServings || e.recipe.servings || null,
+          sourceRecipeUrl: e.sourceRecipeUrl || null,
         }
       : {
           name: e.customName || "Meal",
@@ -100,6 +105,11 @@ export function mapEntriesToWeeklyMeals(entries: any[]) {
           recipeId: null,
           entryId: e.id,
           source: e.source || null,
+          sourceRecipeId: e.sourceRecipeId || null,
+          sourceRecipeTitle: e.sourceRecipeTitle || null,
+          sourceRecipeImageUrl: e.sourceRecipeImageUrl || null,
+          sourceRecipeServings: e.sourceRecipeServings || null,
+          sourceRecipeUrl: e.sourceRecipeUrl || null,
         };
 
     const existing = out[dayName][e.mealType];

--- a/server/services/recipe.service.ts
+++ b/server/services/recipe.service.ts
@@ -128,6 +128,7 @@ export class RecipeService {
         cookTime: recipe.cookTime,
         servings: recipe.servings,
         difficulty: recipe.difficulty,
+        nutrition: recipe.nutrition,
         calories: recipe.calories,
         protein: recipe.protein,
         carbs: recipe.carbs,

--- a/server/services/recipes-service.ts
+++ b/server/services/recipes-service.ts
@@ -48,6 +48,13 @@ export type RecipeItem = {
   source: "chefsire" | "external";
   externalProvider?: "mealdb";
   averageRating?: string | number | null;
+  ingredients?: any[];
+  calories?: number | null;
+  protein?: number | string | null;
+  carbs?: number | string | null;
+  fat?: number | string | null;
+  fiber?: number | string | null;
+  nutrition?: Record<string, unknown> | null;
 };
 
 const EXTERNAL_PROVIDER: "mealdb" = "mealdb";
@@ -210,6 +217,13 @@ export async function searchRecipes(params: SearchParams): Promise<{
             ratingSpoons: recipe.averageRating ? Number(recipe.averageRating) : null,
             cookTime: recipe.cookTime,
             servings: recipe.servings,
+            ingredients: Array.isArray(recipe.ingredients) ? recipe.ingredients : [],
+            calories: recipe.calories ?? null,
+            protein: recipe.protein ?? null,
+            carbs: recipe.carbs ?? null,
+            fat: recipe.fat ?? null,
+            fiber: recipe.fiber ?? null,
+            nutrition: recipe.nutrition ?? null,
             source: "chefsire",
             averageRating: recipe.averageRating,
           }));
@@ -258,6 +272,13 @@ export async function searchRecipes(params: SearchParams): Promise<{
     ratingSpoons: recipe.averageRating ? Number(recipe.averageRating) : null,
     cookTime: recipe.cookTime,
     servings: recipe.servings,
+    ingredients: Array.isArray(recipe.ingredients) ? recipe.ingredients : [],
+    calories: recipe.calories ?? null,
+    protein: recipe.protein ?? null,
+    carbs: recipe.carbs ?? null,
+    fat: recipe.fat ?? null,
+    fiber: recipe.fiber ?? null,
+    nutrition: recipe.nutrition ?? null,
     source: "chefsire",
     averageRating: recipe.averageRating,
   }));

--- a/shared/schema/domains/meal-planning.ts
+++ b/shared/schema/domains/meal-planning.ts
@@ -28,6 +28,11 @@ export const mealPlanEntries = pgTable("meal_plan_entries", {
   customFat: integer("custom_fat"),
   mealItems: jsonb("meal_items"),
   source: varchar("source", { length: 50 }),
+  sourceRecipeId: text("source_recipe_id"),
+  sourceRecipeTitle: text("source_recipe_title"),
+  sourceRecipeImageUrl: text("source_recipe_image_url"),
+  sourceRecipeServings: integer("source_recipe_servings"),
+  sourceRecipeUrl: text("source_recipe_url"),
 });
 
 export const mealStreaks = pgTable("meal_streaks", {


### PR DESCRIPTION
### Motivation

- Allow users to import an existing recipe into the Add Meal modal so the planner can auto-populate meal title, components, and macros while preserving existing manual entry and multi-item behavior.
- Persist minimal recipe identity/preview metadata on planner entries so imported meals remain linked and display a recipe badge/thumbnail without breaking legacy single-item meals.

### Description

- UI: added a new "From recipe" section to `AddMealModal` with search, selectable results, preview (title, image, servings, ingredient count, top-level nutrition badges), a `Use this recipe` action to import, and a `Clear link` action to unlink; imported ingredients become editable `mealItems`. (client/src/components/meal-planner/modals/AddMealModal.tsx)
- State/flow: extended `mealForm` with optional `sourceRecipeId`, `sourceRecipeTitle`, `sourceRecipeImageUrl`, `sourceRecipeServings`, and `sourceRecipeUrl`, and updated NutritionMealPlanner save flow to include these fields when persisting a meal. (client/src/components/NutritionMealPlanner.tsx)
- Mapping & totals: map recipe ingredients into `mealItems` (name, combined quantity string, notes, and any provided per-ingredient nutrition) and, when recipe nutrition exists, populate top-level meal macros while keeping ingredient rows editable; updated utilities so totals prefer explicit item nutrition but fall back to top-level meal macros for backwards compatibility. (client/src/components/meal-planner/nutritionMealPlannerUtils.ts, client/src/components/meal-planner/sections/PlannerTabSection.tsx)
- Calendar display: planner cards now render an optional recipe thumbnail and a compact recipe badge when `sourceRecipe*` metadata is present, while preserving component counts, totals, expand/collapse ingredient lists, and existing remove/edit flows. (client/src/components/meal-planner/sections/PlannerTabSection.tsx)
- Server/schema: added optional additive fields to `meal_plan_entries` (`source_recipe_id`, `source_recipe_title`, `source_recipe_image_url`, `source_recipe_servings`, `source_recipe_url`) in the shared schema and ensured runtime schema setup uses `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` to avoid destructive migrations. (shared/schema/domains/meal-planning.ts, server/routes/meal-planner-week/schema.ts)
- API/persistence: `POST /api/meal-planner/week/entry` accepts the optional source recipe fields and returns them in the response, and weekly loading maps these fields through `mapEntriesToWeeklyMeals` so UI displays persisted metadata. (server/routes/meal-planner-week.ts, server/routes/meal-planner-week/utils.ts)
- Recipe search: enriched local recipe search responses to include `ingredients` and `nutrition`/macro fields so the client can import ingredient lists and nutrition when available. (server/services/recipe.service.ts, server/services/recipes-service.ts)

### Testing

- Ran `npm run build:client` and the client build completed successfully.
- Ran `npm run build:server` and the server bundle completed successfully.
- Performed a focused TypeScript check for the changed meal-planner files using a temporary tsconfig and `tsc -p`, which completed for the targeted files.
- Ran the full repository TypeScript check (`npm run check`) which failed, but the failures are existing/unrelated type errors across many files and were not caused by these changes.

Note: I preserved additive-only backend/schema changes and avoided rewriting the existing NutritionMealPlanner logic as requested; the PR includes updates to UI, client state, server route handling, weekly mapping utilities, and non-destructive schema additions to persist recipe metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0933d7c24c832581e7310c88571f2b)