### PR TITLE
Add AI Nutrition Coach: weekly insights, scoring, and UI panel

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -3,7 +3,8 @@ import {
   Calendar, Plus, Target, TrendingUp, Clock, ChefHat, Star, Lock, Crown,
   ShoppingCart, CheckCircle, BarChart3, Download, Filter, Save,
   AlertCircle, Package, Utensils, CalendarDays, Zap, ListChecks, Settings, Camera,
-  DollarSign, Sparkles, Flame, Scale, Droplets, Ruler, Users, Globe, Copy, Share2
+  DollarSign, Sparkles, Flame, Scale, Droplets, Ruler, Users, Globe, Copy, Share2,
+  Brain, Lightbulb, ShieldCheck, AlertTriangle, Activity
 } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -35,6 +36,11 @@ import {
   type PlannerGrocerySuggestion,
 } from '@/components/meal-planner/plannerGroceryUtils';
 import { derivePrepSessions } from '@/components/meal-planner/prepOrchestrationUtils';
+import {
+  deriveNutritionCoachInsights,
+  type NutritionCoachInsight,
+  type NutritionCoachScore,
+} from '@/components/meal-planner/nutritionCoachUtils';
 import {
   LineChart,
   Line,
@@ -360,6 +366,7 @@ const NutritionMealPlanner = () => {
   const [fixItDetailsQueueDone, setFixItDetailsQueueDone] = useState(false);
   const [fixItDetailsQueueSnoozedByKey, setFixItDetailsQueueSnoozedByKey] = useState<Record<string, FixItDetailsQueueSnoozeOptionId>>({});
   const [plannerGroceryState, setPlannerGroceryState] = useState<PlannerGroceryDerivationState>({});
+  const [dismissedCoachInsightIds, setDismissedCoachInsightIds] = useState<string[]>([]);
 
   // Add Meal modal — controlled fields
   const [mealForm, setMealForm] = useState(INITIAL_MEAL_FORM);
@@ -380,6 +387,7 @@ const NutritionMealPlanner = () => {
   const getPrepSessionStorageKeyForAnchor = (anchorDate: string) => `meal-planner-prep-session-v1:${user?.id || 'anon'}:${anchorDate}`;
   const getShareVisibilityStorageKey = () => `meal-planner-share-visibility-v1:${user?.id || 'anon'}`;
   const getPlannerGroceryStorageKey = () => `meal-planner-derived-grocery-v1:${user?.id || 'anon'}:${getCurrentWeekAnchor()}`;
+  const getNutritionCoachDismissalStorageKey = () => `meal-planner-nutrition-coach-dismissed-v1:${user?.id || 'anon'}:${getCurrentWeekAnchor()}`;
   const countMealEntries = (weekMeals: Record<string, any> | null | undefined) => {
     if (!weekMeals || typeof weekMeals !== 'object') return 0;
     return Object.values(weekMeals).reduce((weekTotal, dayValue) => {
@@ -656,6 +664,29 @@ const NutritionMealPlanner = () => {
       console.error('Error saving planner grocery intelligence state:', error);
     }
   }, [plannerGroceryState, user?.id, selectedDate]);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(getNutritionCoachDismissalStorageKey());
+      if (!stored) {
+        setDismissedCoachInsightIds([]);
+        return;
+      }
+      const parsed = JSON.parse(stored);
+      setDismissedCoachInsightIds(Array.isArray(parsed) ? parsed.filter((id) => typeof id === 'string') : []);
+    } catch (error) {
+      console.error('Error loading nutrition coach dismissal state:', error);
+      setDismissedCoachInsightIds([]);
+    }
+  }, [user?.id, selectedDate]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(getNutritionCoachDismissalStorageKey(), JSON.stringify(dismissedCoachInsightIds));
+    } catch (error) {
+      console.error('Error saving nutrition coach dismissal state:', error);
+    }
+  }, [dismissedCoachInsightIds, user?.id, selectedDate]);
 
 
   useEffect(() => {
@@ -3598,6 +3629,65 @@ const NutritionMealPlanner = () => {
     },
   ];
 
+  const nutritionCoachAnalysis = useMemo(() => deriveNutritionCoachInsights({
+    weeklyMeals,
+    mealTypes,
+    weekDays,
+    calorieGoal,
+    proteinGoal: macroGoals.protein || DEFAULT_NUTRITION_GOALS.macroGoals.protein,
+    water,
+    grocery: {
+      pendingCount: groceryPendingCount,
+      completedCount: groceryCompletedCount,
+      totalBuyCount: groceryBuyItemCount,
+      suggestions: activePlannerGrocerySuggestions,
+      pantryItemCount: normalizedSavingsReport?.pantryItemCount || groceryList.filter((item: any) => item?.isPantryItem).length,
+      pantrySavings: normalizedSavingsReport?.pantrySavings || 0,
+    },
+    prep: {
+      planned: prepSessionPlanned,
+      completed: prepSessionCompleted,
+      progress: blendedPrepProgress,
+      activeBlockersCount: prepActiveBlockersCount,
+      carryoverCount: prepCarryoverCount,
+      orchestration: prepOrchestration,
+    },
+    readiness: {
+      weekReadyNow,
+      prepReadyForWeek,
+    },
+    adherence: {
+      currentStreak: streak.currentStreak,
+    },
+  }), [
+    weeklyMeals,
+    mealTypes,
+    weekDays,
+    calorieGoal,
+    macroGoals.protein,
+    water,
+    groceryPendingCount,
+    groceryCompletedCount,
+    groceryBuyItemCount,
+    activePlannerGrocerySuggestions,
+    normalizedSavingsReport,
+    groceryList,
+    prepSessionPlanned,
+    prepSessionCompleted,
+    blendedPrepProgress,
+    prepActiveBlockersCount,
+    prepCarryoverCount,
+    prepOrchestration,
+    weekReadyNow,
+    prepReadyForWeek,
+    streak.currentStreak,
+  ]);
+  const visibleCoachInsights = nutritionCoachAnalysis.insights.filter((insight) => !dismissedCoachInsightIds.includes(insight.id));
+  const handleDismissCoachInsight = (insightId: string) => {
+    setDismissedCoachInsightIds((prev) => prev.includes(insightId) ? prev : [...prev, insightId]);
+  };
+  const handleRestoreCoachInsights = () => setDismissedCoachInsightIds([]);
+
   const copyWeeklyShareSummary = async () => {
     try {
       await navigator.clipboard.writeText(weeklyShareSummaryText);
@@ -5011,6 +5101,17 @@ const NutritionMealPlanner = () => {
 
           {/* Analytics Tab */}
           <TabsContent value="analytics">
+            <div className="space-y-6">
+              <NutritionCoachPanel
+                analysis={nutritionCoachAnalysis}
+                visibleInsights={visibleCoachInsights}
+                dismissedCount={dismissedCoachInsightIds.length}
+                onDismissInsight={handleDismissCoachInsight}
+                onRestoreInsights={handleRestoreCoachInsights}
+                onOpenPlanner={() => setActiveTab('planner')}
+                onOpenGrocery={() => setActiveTab('grocery')}
+                onOpenPrep={() => setActiveTab('prep')}
+              />
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
               <Card>
                 <CardHeader>
@@ -5158,6 +5259,7 @@ const NutritionMealPlanner = () => {
                 </CardContent>
               </Card>
             </div>
+            </div>
           </TabsContent>
 
           <TabsContent value="advanced">
@@ -5273,7 +5375,7 @@ const NutritionMealPlanner = () => {
 };
 
 // Helper Components
-const MacroCard = ({ label, current, goal, unit, color }) => {
+const MacroCard = ({ label, current, goal, unit, color }: { label: string; current: number; goal: number; unit: string; color: 'blue' | 'orange' | 'purple' }) => {
   const percentage = (current / goal) * 100;
   const colorClasses = {
     blue: 'text-blue-600 bg-blue-50',
@@ -5290,7 +5392,256 @@ const MacroCard = ({ label, current, goal, unit, color }) => {
   );
 };
 
-const StorageTip = ({ icon, title, tip }) => (
+const coachSeverityStyles: Record<NutritionCoachInsight['severity'], string> = {
+  positive: 'border-emerald-200 bg-emerald-50/70 text-emerald-800',
+  neutral: 'border-blue-200 bg-blue-50/70 text-blue-800',
+  warning: 'border-amber-200 bg-amber-50/80 text-amber-800',
+  'high-priority': 'border-red-200 bg-red-50/80 text-red-800',
+};
+
+const coachCategoryStyles: Record<NutritionCoachInsight['category'], string> = {
+  nutrition: 'bg-blue-100 text-blue-800',
+  prep: 'bg-purple-100 text-purple-800',
+  grocery: 'bg-emerald-100 text-emerald-800',
+  readiness: 'bg-orange-100 text-orange-800',
+  consistency: 'bg-indigo-100 text-indigo-800',
+  budget: 'bg-green-100 text-green-800',
+  recovery: 'bg-rose-100 text-rose-800',
+  scheduling: 'bg-slate-100 text-slate-800',
+  hydration: 'bg-cyan-100 text-cyan-800',
+  adherence: 'bg-yellow-100 text-yellow-800',
+};
+
+const coachScoreGradient = (value: number) => {
+  if (value >= 80) return 'from-emerald-500 to-green-500';
+  if (value >= 60) return 'from-blue-500 to-cyan-500';
+  if (value >= 40) return 'from-amber-500 to-orange-500';
+  return 'from-red-500 to-rose-500';
+};
+
+const coachTrendLabel = (trend: NutritionCoachScore['trend']) => (
+  trend === 'up' ? 'Strong' : trend === 'steady' ? 'Stable' : 'Needs attention'
+);
+
+const NutritionCoachPanel = ({
+  analysis,
+  visibleInsights,
+  dismissedCount,
+  onDismissInsight,
+  onRestoreInsights,
+  onOpenPlanner,
+  onOpenGrocery,
+  onOpenPrep,
+}: {
+  analysis: ReturnType<typeof deriveNutritionCoachInsights>;
+  visibleInsights: NutritionCoachInsight[];
+  dismissedCount: number;
+  onDismissInsight: (insightId: string) => void;
+  onRestoreInsights: () => void;
+  onOpenPlanner: () => void;
+  onOpenGrocery: () => void;
+  onOpenPrep: () => void;
+}) => {
+  const topPriority = analysis.summary.topPriority;
+  const scoreById = new Map(analysis.scores.map((score) => [score.id, score]));
+  const momentum = scoreById.get('weeklyMomentum');
+  const primaryActions = [
+    { label: 'Review planner', onClick: onOpenPlanner },
+    { label: 'Grocery readiness', onClick: onOpenGrocery },
+    { label: 'Prep plan', onClick: onOpenPrep },
+  ];
+
+  return (
+    <Card className="overflow-hidden border-orange-200 bg-gradient-to-br from-orange-50 via-white to-purple-50 shadow-sm">
+      <CardHeader className="border-b border-orange-100 bg-white/70">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge className="bg-orange-600 text-white">
+                <Brain className="w-3.5 h-3.5 mr-1" />
+                Derived Intelligence
+              </Badge>
+              <Badge variant="outline" className="border-purple-200 bg-purple-50 text-purple-800">
+                <Sparkles className="w-3.5 h-3.5 mr-1" />
+                AI Nutrition Coach
+              </Badge>
+            </div>
+            <CardTitle className="mt-3 flex items-center gap-2 text-2xl text-gray-950">
+              <Activity className="w-6 h-6 text-orange-600" />
+              AI Nutrition Coach
+            </CardTitle>
+            <CardDescription className="mt-1 max-w-3xl text-gray-700">
+              Insight-driven weekly coaching from your planner, macros, grocery readiness, pantry signals, prep orchestration, hydration, and adherence data. No external AI call is made.
+            </CardDescription>
+          </div>
+          <div className="rounded-2xl border border-orange-200 bg-white/90 p-4 text-center shadow-sm lg:min-w-[190px]">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Weekly Momentum</p>
+            <p className="mt-1 text-4xl font-bold text-orange-600">{momentum?.value ?? 0}</p>
+            <p className="text-xs text-gray-500">{momentum?.description || 'Momentum unlocks as meals are planned.'}</p>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-5 p-4 sm:p-6">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-5">
+          {analysis.scores.map((score) => (
+            <div key={score.id} className="rounded-xl border border-white/70 bg-white/90 p-3 shadow-sm">
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <p className="text-xs font-medium text-gray-500">{score.label}</p>
+                  <p className="text-2xl font-bold text-gray-950">{score.value}</p>
+                </div>
+                <Badge variant="outline" className="text-[10px]">
+                  {coachTrendLabel(score.trend)}
+                </Badge>
+              </div>
+              <Progress value={score.value} className="mt-3 h-2" />
+              <div className={`mt-2 h-1 rounded-full bg-gradient-to-r ${coachScoreGradient(score.value)}`} style={{ width: `${Math.max(8, score.value)}%` }} />
+              <p className="mt-2 text-xs text-gray-600">{score.description}</p>
+            </div>
+          ))}
+        </div>
+
+        {topPriority ? (
+          <div className="rounded-2xl border border-orange-200 bg-white/90 p-4 shadow-sm">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+              <div className="flex items-start gap-3">
+                {topPriority.severity === 'positive' ? (
+                  <ShieldCheck className="mt-1 h-5 w-5 text-emerald-600" />
+                ) : topPriority.severity === 'high-priority' ? (
+                  <AlertTriangle className="mt-1 h-5 w-5 text-red-600" />
+                ) : (
+                  <Lightbulb className="mt-1 h-5 w-5 text-orange-600" />
+                )}
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-orange-700">Top coaching signal</p>
+                  <h3 className="text-lg font-semibold text-gray-950">{topPriority.title}</h3>
+                  <p className="text-sm text-gray-600">{topPriority.description}</p>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {primaryActions.map((action) => (
+                  <Button key={action.label} type="button" size="sm" variant="outline" onClick={action.onClick}>
+                    {action.label}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)]">
+          <div className="space-y-3">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h3 className="font-semibold text-gray-950">Coaching insights</h3>
+                <p className="text-sm text-gray-600">
+                  {analysis.summary.positiveCount} positive • {analysis.summary.warningCount} warning • {analysis.summary.recommendationCount} recommendation
+                </p>
+              </div>
+              {dismissedCount > 0 ? (
+                <Button type="button" size="sm" variant="ghost" onClick={onRestoreInsights}>
+                  Restore {dismissedCount} dismissed
+                </Button>
+              ) : null}
+            </div>
+            {visibleInsights.length > 0 ? (
+              <div className="grid grid-cols-1 gap-3 xl:grid-cols-2">
+                {visibleInsights.slice(0, 8).map((insight) => (
+                  <details key={insight.id} className={`group rounded-xl border p-4 shadow-sm ${coachSeverityStyles[insight.severity]}`}>
+                    <summary className="flex cursor-pointer list-none items-start justify-between gap-3">
+                      <div>
+                        <div className="mb-2 flex flex-wrap items-center gap-2">
+                          <Badge className={coachCategoryStyles[insight.category]}>{insight.category}</Badge>
+                          <Badge variant="outline" className="bg-white/70 text-[10px] uppercase tracking-wide">{insight.kind}</Badge>
+                        </div>
+                        <h4 className="font-semibold text-gray-950">{insight.title}</h4>
+                        <p className="mt-1 text-sm text-gray-700">{insight.description}</p>
+                      </div>
+                      <span className="rounded-full bg-white/80 px-2 py-1 text-xs font-semibold text-gray-500 group-open:hidden">Details</span>
+                    </summary>
+                    <div className="mt-4 space-y-3 rounded-lg bg-white/75 p-3 text-sm text-gray-700">
+                      {insight.suggestedActions.length > 0 ? (
+                        <div>
+                          <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Suggested actions</p>
+                          <div className="mt-2 flex flex-wrap gap-2">
+                            {insight.suggestedActions.map((action) => (
+                              <span key={action} className="rounded-full bg-white px-3 py-1 text-xs font-medium text-gray-700 shadow-sm">
+                                {action}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      ) : null}
+                      {insight.relatedMeals.length > 0 ? (
+                        <p><span className="font-medium">Related meals:</span> {insight.relatedMeals.slice(0, 5).join(', ')}</p>
+                      ) : null}
+                      {insight.relatedPrepSessions.length > 0 ? (
+                        <p><span className="font-medium">Prep links:</span> {insight.relatedPrepSessions.slice(0, 4).join(', ')}</p>
+                      ) : null}
+                      {insight.evidence.length > 0 ? (
+                        <p><span className="font-medium">Evidence:</span> {insight.evidence.slice(0, 4).join(' • ')}</p>
+                      ) : null}
+                      <Button type="button" size="sm" variant="ghost" className="h-8 px-2 text-xs" onClick={() => onDismissInsight(insight.id)}>
+                        Dismiss for this week
+                      </Button>
+                    </div>
+                  </details>
+                ))}
+              </div>
+            ) : (
+              <div className="rounded-xl border border-dashed bg-white/70 p-6 text-sm text-gray-600">
+                All visible coach insights are dismissed for this week. Restore dismissed insights to review them again.
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-3">
+            <div className="rounded-xl border border-white/80 bg-white/90 p-4 shadow-sm">
+              <h3 className="flex items-center gap-2 font-semibold text-gray-950">
+                <Lightbulb className="h-4 w-4 text-orange-600" />
+                Action queue
+              </h3>
+              {analysis.recommendations.length > 0 ? (
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {analysis.recommendations.map((recommendation) => (
+                    <span key={recommendation} className="rounded-full border border-orange-200 bg-orange-50 px-3 py-1.5 text-xs font-medium text-orange-800">
+                      {recommendation}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <p className="mt-2 text-sm text-gray-600">No urgent action queue yet. Add meals and prep details to unlock more coaching.</p>
+              )}
+            </div>
+            <div className="rounded-xl border border-white/80 bg-white/90 p-4 shadow-sm">
+              <h3 className="font-semibold text-gray-950">Coach coverage</h3>
+              <div className="mt-3 grid grid-cols-2 gap-2 text-sm">
+                <div className="rounded-lg bg-gray-50 p-3">
+                  <p className="text-xs text-gray-500">Planned slots</p>
+                  <p className="font-semibold text-gray-950">{analysis.summary.plannedSlots}/{analysis.summary.totalSlots}</p>
+                </div>
+                <div className="rounded-lg bg-gray-50 p-3">
+                  <p className="text-xs text-gray-500">Active days</p>
+                  <p className="font-semibold text-gray-950">{analysis.summary.activeDays}/7</p>
+                </div>
+                <div className="rounded-lg bg-gray-50 p-3">
+                  <p className="text-xs text-gray-500">Repeated meals</p>
+                  <p className="font-semibold text-gray-950">{analysis.summary.repeatedMealCount}</p>
+                </div>
+                <div className="rounded-lg bg-gray-50 p-3">
+                  <p className="text-xs text-gray-500">Visible insights</p>
+                  <p className="font-semibold text-gray-950">{visibleInsights.length}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+const StorageTip = ({ icon, title, tip }: { icon: React.ReactNode; title: string; tip: string }) => (
   <div className="flex items-start gap-3 p-3 bg-gray-50 rounded-lg">
     {icon}
     <div>
@@ -5300,7 +5651,7 @@ const StorageTip = ({ icon, title, tip }) => (
   </div>
 );
 
-const InsightCard = ({ icon, title, description, trend }) => {
+const InsightCard = ({ icon, title, description, trend }: { icon: React.ReactNode; title: string; description: string; trend: 'positive' | 'neutral' }) => {
   const borderColor = trend === 'positive' ? 'border-green-200' : 'border-gray-200';
 
   return (
@@ -5312,7 +5663,7 @@ const InsightCard = ({ icon, title, description, trend }) => {
   );
 };
 
-const Testimonial = ({ name, text, rating }) => (
+const Testimonial = ({ name, text, rating }: { name: string; text: string; rating: number }) => (
   <div className="bg-white p-4 rounded-lg border border-purple-200">
     <div className="flex gap-1 mb-2">
       {[...Array(rating)].map((_, i) => (

--- a/client/src/components/meal-planner/nutritionCoachUtils.ts
+++ b/client/src/components/meal-planner/nutritionCoachUtils.ts
@@ -1,0 +1,711 @@
+import { MEAL_TYPES, WEEK_DAYS, getMealItems, getMealNutritionTotals, getSlotItems } from './nutritionMealPlannerUtils';
+import { aggregatePlannerGroceries, normalizeMealIngredient, type PlannerGrocerySuggestion } from './plannerGroceryUtils';
+import type { PrepOrchestration } from './prepOrchestrationUtils';
+
+export type NutritionCoachCategory =
+  | 'nutrition'
+  | 'prep'
+  | 'grocery'
+  | 'readiness'
+  | 'consistency'
+  | 'budget'
+  | 'recovery'
+  | 'scheduling'
+  | 'hydration'
+  | 'adherence';
+
+export type NutritionCoachSeverity = 'positive' | 'neutral' | 'warning' | 'high-priority';
+export type NutritionCoachKind = 'positive' | 'warning' | 'recommendation';
+
+export type NutritionCoachInsight = {
+  id: string;
+  category: NutritionCoachCategory;
+  title: string;
+  description: string;
+  severity: NutritionCoachSeverity;
+  priority: number;
+  kind: NutritionCoachKind;
+  relatedMeals: string[];
+  relatedPrepSessions: string[];
+  suggestedActions: string[];
+  evidence: string[];
+};
+
+export type NutritionCoachScore = {
+  id: 'nutritionConsistency' | 'prepEfficiency' | 'groceryReadiness' | 'weeklyMomentum' | 'planningCompleteness';
+  label: string;
+  value: number;
+  trend: 'up' | 'steady' | 'attention';
+  description: string;
+};
+
+export type NutritionCoachAnalysis = {
+  insights: NutritionCoachInsight[];
+  recommendations: string[];
+  scores: NutritionCoachScore[];
+  summary: {
+    topPriority: NutritionCoachInsight | null;
+    positiveCount: number;
+    warningCount: number;
+    recommendationCount: number;
+    plannedSlots: number;
+    totalSlots: number;
+    activeDays: number;
+    repeatedMealCount: number;
+  };
+};
+
+export type NutritionCoachInput = {
+  weeklyMeals: Record<string, any> | null | undefined;
+  mealTypes?: readonly string[];
+  weekDays?: readonly string[];
+  calorieGoal: number;
+  proteinGoal: number;
+  water?: { glassesLogged?: number; dailyTarget?: number };
+  grocery?: {
+    pendingCount: number;
+    completedCount: number;
+    totalBuyCount: number;
+    suggestions?: PlannerGrocerySuggestion[];
+    pantryItemCount?: number;
+    pantrySavings?: number;
+  };
+  prep?: {
+    planned: boolean;
+    completed: boolean;
+    progress: number;
+    activeBlockersCount: number;
+    carryoverCount?: number;
+    orchestration?: PrepOrchestration;
+  };
+  readiness?: {
+    weekReadyNow: boolean;
+    prepReadyForWeek: boolean;
+  };
+  adherence?: {
+    currentStreak?: number;
+  };
+};
+
+type PlannedMeal = {
+  id: string;
+  name: string;
+  day: string;
+  mealType: string;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  hasNutrition: boolean;
+  ingredientNames: string[];
+};
+
+type DayNutrition = {
+  day: string;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  mealsLogged: number;
+};
+
+const clampScore = (value: number) => Math.max(0, Math.min(100, Math.round(value)));
+const percent = (part: number, total: number) => Math.round((part / Math.max(1, total)) * 100);
+const unique = <T,>(values: T[]) => Array.from(new Set(values.filter(Boolean)));
+const toTitle = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
+
+const getPlannedMeals = (
+  weeklyMeals: Record<string, any> | null | undefined,
+  weekDays: readonly string[],
+  mealTypes: readonly string[],
+): PlannedMeal[] => {
+  if (!weeklyMeals || typeof weeklyMeals !== 'object') return [];
+
+  const meals: PlannedMeal[] = [];
+  weekDays.forEach((day) => {
+    mealTypes.forEach((mealType) => {
+      getSlotItems(weeklyMeals, day, mealType).forEach((meal: any, index: number) => {
+        const totals = getMealNutritionTotals(meal);
+        const ingredientNames = getMealItems(meal).map((item) => String(item?.name || '').trim()).filter(Boolean);
+        meals.push({
+          id: String(meal?.entryId || meal?.id || `${day}-${mealType}-${index}`),
+          name: String(meal?.name || meal?.title || `${toTitle(mealType)} meal`).trim(),
+          day,
+          mealType,
+          ...totals,
+          hasNutrition: totals.calories > 0 || totals.protein > 0 || totals.carbs > 0 || totals.fat > 0,
+          ingredientNames,
+        });
+      });
+    });
+  });
+
+  return meals;
+};
+
+const getDayNutrition = (meals: PlannedMeal[], weekDays: readonly string[]): DayNutrition[] => (
+  weekDays.map((day) => {
+    const dayMeals = meals.filter((meal) => meal.day === day);
+    return dayMeals.reduce((totals, meal) => ({
+      day,
+      calories: totals.calories + meal.calories,
+      protein: totals.protein + meal.protein,
+      carbs: totals.carbs + meal.carbs,
+      fat: totals.fat + meal.fat,
+      mealsLogged: totals.mealsLogged + 1,
+    }), { day, calories: 0, protein: 0, carbs: 0, fat: 0, mealsLogged: 0 });
+  })
+);
+
+export const analyzeMealConsistency = (
+  meals: PlannedMeal[],
+  dayNutrition: DayNutrition[],
+  proteinGoal: number,
+  calorieGoal: number,
+) => {
+  const activeDays = dayNutrition.filter((day) => day.mealsLogged > 0);
+  const trackedProteinDays = activeDays.filter((day) => day.protein > 0);
+  const trackedCalorieDays = activeDays.filter((day) => day.calories > 0);
+  const proteinGoalDays = trackedProteinDays.filter((day) => day.protein >= proteinGoal * 0.9).length;
+  const calorieTargetDays = trackedCalorieDays.filter((day) => day.calories >= calorieGoal * 0.85 && day.calories <= calorieGoal * 1.15).length;
+  const missingNutritionMeals = meals.filter((meal) => !meal.hasNutrition);
+  const avgProtein = trackedProteinDays.length > 0
+    ? trackedProteinDays.reduce((sum, day) => sum + day.protein, 0) / trackedProteinDays.length
+    : 0;
+  const proteinSpread = trackedProteinDays.length >= 3
+    ? Math.max(...trackedProteinDays.map((day) => day.protein)) - Math.min(...trackedProteinDays.map((day) => day.protein))
+    : 0;
+  const calorieSpread = trackedCalorieDays.length >= 3
+    ? Math.max(...trackedCalorieDays.map((day) => day.calories)) - Math.min(...trackedCalorieDays.map((day) => day.calories))
+    : 0;
+
+  return {
+    activeDays,
+    trackedProteinDays,
+    trackedCalorieDays,
+    proteinGoalDays,
+    calorieTargetDays,
+    missingNutritionMeals,
+    avgProtein,
+    proteinSpread,
+    calorieSpread,
+  };
+};
+
+export const analyzeMacroCoverage = (dayNutrition: DayNutrition[], proteinGoal: number, calorieGoal: number) => {
+  const plannedDays = dayNutrition.filter((day) => day.mealsLogged > 0);
+  const lowProteinDays = plannedDays.filter((day) => day.protein > 0 && day.protein < proteinGoal * 0.75);
+  const underFueledDays = plannedDays.filter((day) => day.calories > 0 && day.calories < calorieGoal * 0.7);
+  const highVariance = plannedDays.filter((day) => day.calories > 0).length >= 3
+    && Math.max(...plannedDays.map((day) => day.calories || calorieGoal)) - Math.min(...plannedDays.filter((day) => day.calories > 0).map((day) => day.calories)) > Math.max(700, calorieGoal * 0.35);
+
+  return { plannedDays, lowProteinDays, underFueledDays, highVariance };
+};
+
+export const analyzePrepEfficiency = (input: NutritionCoachInput['prep']) => {
+  const orchestration = input?.orchestration;
+  const generatedScore = orchestration?.summary.prepEfficiencyScore ?? 0;
+  const readinessScore = orchestration?.summary.readinessScore ?? 0;
+  const estimatedMinutes = orchestration?.summary.estimatedWeeklyPrepMinutes ?? 0;
+  const savingsMinutes = orchestration?.summary.estimatedWeeklyPrepSavingsMinutes ?? 0;
+  const batchOpportunities = orchestration?.batchOpportunities ?? [];
+  const totalGeneratedTasks = orchestration?.summary.totalGeneratedTasks ?? 0;
+  const completedGeneratedTasks = orchestration?.summary.completedGeneratedTasks ?? 0;
+
+  return {
+    generatedScore,
+    readinessScore,
+    estimatedMinutes,
+    savingsMinutes,
+    batchOpportunities,
+    totalGeneratedTasks,
+    completedGeneratedTasks,
+    completionPercent: Math.max(input?.progress ?? 0, orchestration?.summary.completionPercent ?? 0),
+  };
+};
+
+export const analyzePlannerReadiness = (input: NutritionCoachInput, plannedSlots: number, totalSlots: number) => {
+  const planningCompleteness = percent(plannedSlots, totalSlots);
+  const groceryReady = !input.grocery || input.grocery.totalBuyCount === 0 || input.grocery.pendingCount === 0;
+  const prepReady = Boolean(input.readiness?.prepReadyForWeek);
+  const weekReady = Boolean(input.readiness?.weekReadyNow);
+
+  return { planningCompleteness, groceryReady, prepReady, weekReady };
+};
+
+const getRepeatedMeals = (meals: PlannedMeal[]) => {
+  const byName = new Map<string, PlannedMeal[]>();
+  meals.forEach((meal) => {
+    const normalized = normalizeMealIngredient(meal.name);
+    if (!normalized) return;
+    byName.set(normalized, [...(byName.get(normalized) || []), meal]);
+  });
+  return Array.from(byName.values()).filter((rows) => rows.length >= 3);
+};
+
+const getRepeatedIngredients = (meals: PlannedMeal[]) => {
+  const byIngredient = new Map<string, { displayName: string; meals: PlannedMeal[] }>();
+  meals.forEach((meal) => {
+    meal.ingredientNames.forEach((name) => {
+      const normalized = normalizeMealIngredient(name);
+      if (!normalized) return;
+      const current = byIngredient.get(normalized) || { displayName: name, meals: [] };
+      current.meals.push(meal);
+      byIngredient.set(normalized, current);
+    });
+  });
+  return Array.from(byIngredient.values()).filter((row) => row.meals.length >= 3);
+};
+
+const makeInsight = (insight: NutritionCoachInsight): NutritionCoachInsight => insight;
+
+export const calculateNutritionMomentum = (scores: NutritionCoachScore[]) => (
+  clampScore(scores.reduce((sum, score) => sum + score.value, 0) / Math.max(1, scores.length))
+);
+
+export const deriveCoachingRecommendations = (insights: NutritionCoachInsight[]) => (
+  insights
+    .filter((insight) => insight.kind !== 'positive')
+    .sort((a, b) => b.priority - a.priority)
+    .flatMap((insight) => insight.suggestedActions)
+    .filter((action, index, all) => all.indexOf(action) === index)
+    .slice(0, 6)
+);
+
+export const deriveNutritionCoachInsights = (input: NutritionCoachInput): NutritionCoachAnalysis => {
+  const weekDays = input.weekDays || WEEK_DAYS;
+  const mealTypes = input.mealTypes || MEAL_TYPES;
+  const totalSlots = weekDays.length * mealTypes.length;
+  const meals = getPlannedMeals(input.weeklyMeals, weekDays, mealTypes);
+  const dayNutrition = getDayNutrition(meals, weekDays);
+  const plannedSlots = weekDays.reduce((sum, day) => (
+    sum + mealTypes.filter((mealType) => getSlotItems(input.weeklyMeals || {}, day, mealType).length > 0).length
+  ), 0);
+  const missingSlots = totalSlots - plannedSlots;
+  const missingDays = dayNutrition.filter((day) => day.mealsLogged === 0);
+  const weekendGaps = missingDays.filter((day) => day.day === 'Saturday' || day.day === 'Sunday');
+  const consistency = analyzeMealConsistency(meals, dayNutrition, input.proteinGoal, input.calorieGoal);
+  const macros = analyzeMacroCoverage(dayNutrition, input.proteinGoal, input.calorieGoal);
+  const prep = analyzePrepEfficiency(input.prep);
+  const readiness = analyzePlannerReadiness(input, plannedSlots, totalSlots);
+  const repeatedMeals = getRepeatedMeals(meals);
+  const repeatedIngredients = getRepeatedIngredients(meals);
+  const pantryIngredientRows = aggregatePlannerGroceries(input.weeklyMeals).filter((row) => (
+    input.grocery?.suggestions || []
+  ).some((suggestion) => suggestion.normalizedName === row.normalizedName && suggestion.pantryMatchStatus !== 'missing'));
+  const groceryReadinessPct = input.grocery
+    ? input.grocery.totalBuyCount === 0 ? 100 : percent(input.grocery.completedCount, input.grocery.totalBuyCount)
+    : 100;
+  const hydrationPct = percent(input.water?.glassesLogged || 0, input.water?.dailyTarget || 8);
+
+  const scoresWithoutMomentum: NutritionCoachScore[] = [
+    {
+      id: 'nutritionConsistency',
+      label: 'Nutrition Consistency',
+      value: clampScore((percent(consistency.proteinGoalDays, 7) * 0.45) + (percent(consistency.calorieTargetDays, 7) * 0.35) + (consistency.missingNutritionMeals.length === 0 && meals.length > 0 ? 20 : 0)),
+      trend: consistency.proteinGoalDays >= 4 && consistency.calorieTargetDays >= 4 ? 'up' : consistency.trackedProteinDays.length >= 3 ? 'steady' : 'attention',
+      description: `${consistency.proteinGoalDays}/7 protein-paced days and ${consistency.calorieTargetDays}/7 calorie-paced days.`,
+    },
+    {
+      id: 'prepEfficiency',
+      label: 'Prep Efficiency',
+      value: clampScore((prep.generatedScore * 0.45) + (prep.completionPercent * 0.35) + (prep.readinessScore * 0.2)),
+      trend: prep.completionPercent >= 70 ? 'up' : prep.batchOpportunities.length > 0 ? 'steady' : 'attention',
+      description: `${prep.batchOpportunities.length} batch opportunities with ${prep.completionPercent}% prep completion.`,
+    },
+    {
+      id: 'groceryReadiness',
+      label: 'Grocery Readiness',
+      value: clampScore(groceryReadinessPct),
+      trend: groceryReadinessPct >= 85 ? 'up' : groceryReadinessPct >= 50 ? 'steady' : 'attention',
+      description: input.grocery ? `${input.grocery.completedCount}/${Math.max(1, input.grocery.totalBuyCount)} grocery items ready.` : 'No grocery list items required yet.',
+    },
+    {
+      id: 'planningCompleteness',
+      label: 'Planning Completeness',
+      value: clampScore(readiness.planningCompleteness),
+      trend: readiness.planningCompleteness >= 90 ? 'up' : readiness.planningCompleteness >= 60 ? 'steady' : 'attention',
+      description: `${plannedSlots}/${totalSlots} weekly meal slots are planned.`,
+    },
+  ];
+
+  const scores: NutritionCoachScore[] = [
+    ...scoresWithoutMomentum,
+    {
+      id: 'weeklyMomentum',
+      label: 'Weekly Momentum',
+      value: calculateNutritionMomentum(scoresWithoutMomentum),
+      trend: readiness.weekReady || scoresWithoutMomentum.every((score) => score.value >= 75) ? 'up' : scoresWithoutMomentum.some((score) => score.value < 45) ? 'attention' : 'steady',
+      description: readiness.weekReady ? 'Planning, grocery, and prep signals are aligned.' : 'Momentum blends planning, grocery, prep, and macro pacing.',
+    },
+  ];
+
+  const insights: NutritionCoachInsight[] = [];
+
+  if (meals.length === 0) {
+    insights.push(makeInsight({
+      id: 'coach-start-week-plan',
+      category: 'scheduling',
+      title: 'Start with anchor meals',
+      description: 'No meals are planned yet. Add a few anchor meals first so the coach can analyze nutrition pacing, grocery readiness, and prep opportunities.',
+      severity: 'neutral',
+      priority: 80,
+      kind: 'recommendation',
+      relatedMeals: [],
+      relatedPrepSessions: [],
+      suggestedActions: ['Plan one breakfast, one lunch, and one dinner before filling snacks.'],
+      evidence: [`${plannedSlots}/${totalSlots} slots planned`],
+    }));
+  }
+
+  if (missingSlots > 0 && meals.length > 0) {
+    insights.push(makeInsight({
+      id: 'coach-missing-meal-coverage',
+      category: 'scheduling',
+      title: `${missingSlots} planner slot${missingSlots === 1 ? '' : 's'} still open`,
+      description: missingDays.length > 0
+        ? `${missingDays.map((day) => day.day).slice(0, 3).join(', ')} ${missingDays.length === 1 ? 'has' : 'have'} no meals planned yet.`
+        : 'A few meal periods are still open. Filling them improves grocery and prep accuracy.',
+      severity: missingSlots >= 8 ? 'high-priority' : 'warning',
+      priority: missingSlots >= 8 ? 95 : 78,
+      kind: 'warning',
+      relatedMeals: [],
+      relatedPrepSessions: [],
+      suggestedActions: ['Fill open lunches or dinners first, then add snacks only where useful.'],
+      evidence: [`${plannedSlots}/${totalSlots} slots planned`],
+    }));
+  } else if (plannedSlots === totalSlots && totalSlots > 0) {
+    insights.push(makeInsight({
+      id: 'coach-full-planning-coverage',
+      category: 'scheduling',
+      title: 'Full weekly planning coverage',
+      description: 'Every meal slot has at least one planned meal, giving grocery, prep, and macro insights complete weekly context.',
+      severity: 'positive',
+      priority: 70,
+      kind: 'positive',
+      relatedMeals: meals.slice(0, 6).map((meal) => meal.name),
+      relatedPrepSessions: [],
+      suggestedActions: ['Review grocery and prep scores before the week starts.'],
+      evidence: [`${plannedSlots}/${totalSlots} slots planned`],
+    }));
+  }
+
+  if (consistency.trackedProteinDays.length >= 3) {
+    if (consistency.proteinGoalDays >= 5 || consistency.proteinSpread <= Math.max(30, input.proteinGoal * 0.35)) {
+      insights.push(makeInsight({
+        id: 'coach-protein-consistency',
+        category: 'nutrition',
+        title: 'Protein intake looks consistent',
+        description: `You are averaging ${Math.round(consistency.avgProtein)}g protein across tracked days, with ${consistency.proteinGoalDays}/7 days near your target.`,
+        severity: 'positive',
+        priority: 68,
+        kind: 'positive',
+        relatedMeals: meals.filter((meal) => meal.protein >= 25).slice(0, 4).map((meal) => meal.name),
+        relatedPrepSessions: [],
+        suggestedActions: ['Keep protein-forward meals distributed across breakfast, lunch, and dinner.'],
+        evidence: [`Average protein ${Math.round(consistency.avgProtein)}g`, `${consistency.proteinGoalDays}/7 target days`],
+      }));
+    } else if (macros.lowProteinDays.length > 0) {
+      insights.push(makeInsight({
+        id: 'coach-low-protein-days',
+        category: 'nutrition',
+        title: `${macros.lowProteinDays.length} low-protein day${macros.lowProteinDays.length === 1 ? '' : 's'} detected`,
+        description: `${macros.lowProteinDays.map((day) => day.day).slice(0, 3).join(', ')} ${macros.lowProteinDays.length === 1 ? 'is' : 'are'} materially below your protein goal.`,
+        severity: 'warning',
+        priority: 85,
+        kind: 'warning',
+        relatedMeals: meals.filter((meal) => macros.lowProteinDays.some((day) => day.day === meal.day)).map((meal) => meal.name).slice(0, 5),
+        relatedPrepSessions: [],
+        suggestedActions: ['Add a protein-forward option to the lowest-protein day before changing every meal.'],
+        evidence: macros.lowProteinDays.map((day) => `${day.day}: ${Math.round(day.protein)}g`),
+      }));
+    }
+  }
+
+  if (macros.highVariance) {
+    insights.push(makeInsight({
+      id: 'coach-calorie-pacing-variance',
+      category: 'recovery',
+      title: 'Calorie pacing varies across the week',
+      description: 'Tracked calories swing meaningfully between days. Consider balancing portion sizes before making aggressive changes.',
+      severity: 'neutral',
+      priority: 62,
+      kind: 'recommendation',
+      relatedMeals: [],
+      relatedPrepSessions: [],
+      suggestedActions: ['Compare your highest and lowest calorie days and adjust portions gradually.'],
+      evidence: [`Weekly calorie spread: ${Math.round(consistency.calorieSpread)} kcal`],
+    }));
+  }
+
+  if (consistency.missingNutritionMeals.length > 0 && meals.length > 0) {
+    insights.push(makeInsight({
+      id: 'coach-missing-nutrition-details',
+      category: 'adherence',
+      title: 'Some planned meals need nutrition details',
+      description: `${consistency.missingNutritionMeals.length} meal${consistency.missingNutritionMeals.length === 1 ? '' : 's'} missing calories or macros reduce the accuracy of coaching scores.`,
+      severity: 'neutral',
+      priority: 58,
+      kind: 'recommendation',
+      relatedMeals: consistency.missingNutritionMeals.slice(0, 5).map((meal) => meal.name),
+      relatedPrepSessions: [],
+      suggestedActions: ['Add calories and protein to repeated meals first for the biggest analytics improvement.'],
+      evidence: [`${consistency.missingNutritionMeals.length}/${meals.length} meals missing macro details`],
+    }));
+  }
+
+  if (hydrationPct >= 100) {
+    insights.push(makeInsight({
+      id: 'coach-hydration-complete',
+      category: 'hydration',
+      title: 'Hydration target is complete today',
+      description: 'Your current hydration log has reached today’s target. Keep the same steady rhythm tomorrow.',
+      severity: 'positive',
+      priority: 52,
+      kind: 'positive',
+      relatedMeals: [],
+      relatedPrepSessions: [],
+      suggestedActions: ['Keep water visible during prep and meals to make this easier to repeat.'],
+      evidence: [`${input.water?.glassesLogged || 0}/${input.water?.dailyTarget || 8} glasses`],
+    }));
+  } else if (hydrationPct < 60 && meals.length > 0) {
+    insights.push(makeInsight({
+      id: 'coach-hydration-lagging',
+      category: 'hydration',
+      title: 'Hydration is lagging today',
+      description: `You are at ${hydrationPct}% of today’s water target. This is a simple consistency lever alongside meal planning.`,
+      severity: 'neutral',
+      priority: 55,
+      kind: 'recommendation',
+      relatedMeals: [],
+      relatedPrepSessions: [],
+      suggestedActions: ['Pair a glass of water with the next planned meal or prep block.'],
+      evidence: [`${input.water?.glassesLogged || 0}/${input.water?.dailyTarget || 8} glasses`],
+    }));
+  }
+
+  if (repeatedMeals.length > 0) {
+    const first = repeatedMeals[0];
+    insights.push(makeInsight({
+      id: `coach-repetition-${normalizeMealIngredient(first[0].name).replace(/[^a-z0-9]+/g, '-')}`,
+      category: 'consistency',
+      title: 'Meal repetition may create fatigue',
+      description: `${first[0].name} appears ${first.length} times this week. Repetition is efficient, but one swap can keep the plan easier to follow.`,
+      severity: 'neutral',
+      priority: 50,
+      kind: 'recommendation',
+      relatedMeals: first.map((meal) => meal.name),
+      relatedPrepSessions: [],
+      suggestedActions: ['Keep the same macro profile and rotate flavor, sauce, or produce.'],
+      evidence: unique(first.map((meal) => `${meal.day} ${meal.mealType}`)),
+    }));
+  }
+
+  if (repeatedIngredients.length > 0) {
+    const best = repeatedIngredients.sort((a, b) => b.meals.length - a.meals.length)[0];
+    insights.push(makeInsight({
+      id: `coach-batch-${normalizeMealIngredient(best.displayName).replace(/[^a-z0-9]+/g, '-')}`,
+      category: 'prep',
+      title: `${best.displayName} is a batch-prep opportunity`,
+      description: `${best.displayName} appears across ${best.meals.length} meals. A shared prep session can reduce repeated cooking steps.`,
+      severity: 'positive',
+      priority: 72,
+      kind: 'positive',
+      relatedMeals: unique(best.meals.map((meal) => meal.name)).slice(0, 6),
+      relatedPrepSessions: prep.batchOpportunities.map((task) => task.name).slice(0, 3),
+      suggestedActions: [`Batch prep ${best.displayName} once and portion it for the linked meals.`],
+      evidence: unique(best.meals.map((meal) => `${meal.day} ${meal.mealType}`)).slice(0, 6),
+    }));
+  }
+
+  if (prep.estimatedMinutes >= 120 && !input.prep?.completed) {
+    insights.push(makeInsight({
+      id: 'coach-prep-overload',
+      category: 'prep',
+      title: 'Prep load is concentrated',
+      description: `Generated prep tasks estimate about ${prep.estimatedMinutes} minutes. Splitting prep into two sessions may be easier to execute.`,
+      severity: 'warning',
+      priority: 82,
+      kind: 'warning',
+      relatedMeals: [],
+      relatedPrepSessions: input.prep?.orchestration?.sessions.map((session) => session.title).slice(0, 4) || [],
+      suggestedActions: ['Move chopping or snack packing to a shorter midweek prep block.'],
+      evidence: [`${prep.estimatedMinutes} estimated prep minutes`, `${prep.completionPercent}% complete`],
+    }));
+  } else if (prep.savingsMinutes >= 30) {
+    insights.push(makeInsight({
+      id: 'coach-prep-efficiency-savings',
+      category: 'prep',
+      title: 'Prep orchestration can save time',
+      description: `Current prep grouping may save about ${prep.savingsMinutes} minutes versus prepping every meal separately.`,
+      severity: 'positive',
+      priority: 64,
+      kind: 'positive',
+      relatedMeals: [],
+      relatedPrepSessions: input.prep?.orchestration?.sessions.map((session) => session.title).slice(0, 4) || [],
+      suggestedActions: ['Complete generated batch-prep tasks before individual meal assembly.'],
+      evidence: [`${prep.savingsMinutes} estimated minutes saved`],
+    }));
+  }
+
+  if (input.prep?.activeBlockersCount && input.prep.activeBlockersCount > 0) {
+    insights.push(makeInsight({
+      id: 'coach-prep-blockers',
+      category: 'readiness',
+      title: 'Prep blockers need attention',
+      description: `${input.prep.activeBlockersCount} active prep blocker${input.prep.activeBlockersCount === 1 ? '' : 's'} may prevent the week from becoming ready.`,
+      severity: 'high-priority',
+      priority: 98,
+      kind: 'warning',
+      relatedMeals: [],
+      relatedPrepSessions: input.prep?.orchestration?.sessions.map((session) => session.title).slice(0, 3) || [],
+      suggestedActions: ['Resolve grocery-linked blockers first, then mark prep tasks complete as they are done.'],
+      evidence: [`${input.prep.activeBlockersCount} active blockers`],
+    }));
+  }
+
+  if (input.grocery && input.grocery.totalBuyCount > 0) {
+    if (groceryReadinessPct >= 85) {
+      insights.push(makeInsight({
+        id: 'coach-grocery-readiness-strong',
+        category: 'grocery',
+        title: 'Grocery readiness is strong',
+        description: `${input.grocery.completedCount}/${input.grocery.totalBuyCount} grocery items are ready, so prep execution is less likely to stall.`,
+        severity: 'positive',
+        priority: 66,
+        kind: 'positive',
+        relatedMeals: [],
+        relatedPrepSessions: [],
+        suggestedActions: ['Use the grocery-ready window to finish prep tasks while ingredients are fresh.'],
+        evidence: [`${groceryReadinessPct}% grocery readiness`],
+      }));
+    } else if (input.grocery.pendingCount > 0) {
+      insights.push(makeInsight({
+        id: 'coach-grocery-readiness-warning',
+        category: 'grocery',
+        title: 'Grocery readiness is holding back the plan',
+        description: `${input.grocery.pendingCount} grocery item${input.grocery.pendingCount === 1 ? '' : 's'} remain unresolved for this week’s plan.`,
+        severity: input.grocery.pendingCount >= 5 ? 'warning' : 'neutral',
+        priority: input.grocery.pendingCount >= 5 ? 76 : 57,
+        kind: 'warning',
+        relatedMeals: unique((input.grocery.suggestions || []).flatMap((suggestion) => suggestion.linkedMealNames)).slice(0, 5),
+        relatedPrepSessions: [],
+        suggestedActions: ['Clear high-use grocery suggestions before starting batch prep.'],
+        evidence: [`${input.grocery.pendingCount} pending grocery items`],
+      }));
+    }
+  }
+
+  if (pantryIngredientRows.length >= 3) {
+    insights.push(makeInsight({
+      id: 'coach-pantry-waste-reduction',
+      category: 'budget',
+      title: 'Pantry usage is reducing duplicate buys',
+      description: `${pantryIngredientRows.length} planned ingredient uses appear covered by pantry-aware grocery matches.`,
+      severity: 'positive',
+      priority: 54,
+      kind: 'positive',
+      relatedMeals: unique(pantryIngredientRows.map((row) => row.meal.mealName)).slice(0, 5),
+      relatedPrepSessions: [],
+      suggestedActions: ['Prioritize pantry-matched ingredients early in the week to reduce waste risk.'],
+      evidence: unique(pantryIngredientRows.map((row) => row.displayName)).slice(0, 6),
+    }));
+  } else if ((input.grocery?.suggestions || []).filter((suggestion) => suggestion.pantryMatchStatus === 'missing').length >= 5) {
+    insights.push(makeInsight({
+      id: 'coach-pantry-check-opportunity',
+      category: 'budget',
+      title: 'Pantry check could reduce the list',
+      description: 'Several derived grocery suggestions are not matched to pantry items yet. A quick pantry pass may prevent duplicate purchases.',
+      severity: 'neutral',
+      priority: 49,
+      kind: 'recommendation',
+      relatedMeals: [],
+      relatedPrepSessions: [],
+      suggestedActions: ['Check pantry staples before buying repeated grains, sauces, or proteins.'],
+      evidence: [`${(input.grocery?.suggestions || []).filter((suggestion) => suggestion.pantryMatchStatus === 'missing').length} unmatched suggestions`],
+    }));
+  }
+
+  if (weekendGaps.length > 0 && meals.length > 0) {
+    insights.push(makeInsight({
+      id: 'coach-weekend-gap',
+      category: 'scheduling',
+      title: 'Weekend planning gap detected',
+      description: `${weekendGaps.map((day) => day.day).join(' and ')} ${weekendGaps.length === 1 ? 'has' : 'have'} no meals planned. Weekend gaps often create last-minute grocery changes.`,
+      severity: 'neutral',
+      priority: 60,
+      kind: 'recommendation',
+      relatedMeals: [],
+      relatedPrepSessions: [],
+      suggestedActions: ['Add one flexible leftover or freezer-friendly meal for the weekend.'],
+      evidence: weekendGaps.map((day) => `${day.day}: 0 meals`),
+    }));
+  }
+
+  if (readiness.weekReady) {
+    insights.push(makeInsight({
+      id: 'coach-week-ready',
+      category: 'readiness',
+      title: 'Weekly readiness is aligned',
+      description: 'Planning coverage, grocery readiness, and prep execution signals are all aligned for this week.',
+      severity: 'positive',
+      priority: 88,
+      kind: 'positive',
+      relatedMeals: meals.slice(0, 5).map((meal) => meal.name),
+      relatedPrepSessions: input.prep?.orchestration?.sessions.map((session) => session.title).slice(0, 3) || [],
+      suggestedActions: ['Maintain momentum by logging completion as meals and prep tasks are finished.'],
+      evidence: ['Week ready signal is active'],
+    }));
+  } else if (readiness.planningCompleteness >= 70 && readiness.groceryReady && !readiness.prepReady) {
+    insights.push(makeInsight({
+      id: 'coach-readiness-prep-lag',
+      category: 'readiness',
+      title: 'Grocery readiness is ahead of prep',
+      description: 'Your grocery signal is strong, but prep readiness has not caught up yet.',
+      severity: 'warning',
+      priority: 84,
+      kind: 'warning',
+      relatedMeals: [],
+      relatedPrepSessions: input.prep?.orchestration?.sessions.map((session) => session.title).slice(0, 4) || [],
+      suggestedActions: ['Complete the highest-impact generated prep task before adding more plan complexity.'],
+      evidence: [`Planning ${readiness.planningCompleteness}%`, `Prep ready: ${readiness.prepReady ? 'yes' : 'no'}`],
+    }));
+  }
+
+  if ((input.adherence?.currentStreak || 0) >= 3) {
+    insights.push(makeInsight({
+      id: 'coach-adherence-streak',
+      category: 'adherence',
+      title: `${input.adherence?.currentStreak} day logging streak`,
+      description: 'Your recent consistency gives the coach better signal quality for weekly recommendations.',
+      severity: 'positive',
+      priority: 51,
+      kind: 'positive',
+      relatedMeals: [],
+      relatedPrepSessions: [],
+      suggestedActions: ['Keep logging simple: complete meals first, then refine macro details.'],
+      evidence: [`${input.adherence?.currentStreak} day streak`],
+    }));
+  }
+
+  const sortedInsights = insights
+    .sort((a, b) => b.priority - a.priority)
+    .slice(0, 12);
+  const recommendations = deriveCoachingRecommendations(sortedInsights);
+
+  return {
+    insights: sortedInsights,
+    recommendations,
+    scores,
+    summary: {
+      topPriority: sortedInsights.find((insight) => insight.kind !== 'positive') || sortedInsights[0] || null,
+      positiveCount: sortedInsights.filter((insight) => insight.kind === 'positive').length,
+      warningCount: sortedInsights.filter((insight) => insight.kind === 'warning').length,
+      recommendationCount: sortedInsights.filter((insight) => insight.kind === 'recommendation').length,
+      plannedSlots,
+      totalSlots,
+      activeDays: consistency.activeDays.length,
+      repeatedMealCount: repeatedMeals.reduce((sum, group) => sum + group.length, 0),
+    },
+  };
+};


### PR DESCRIPTION
### Motivation
- Add a non-AI external, derived coaching layer that analyzes the planner’s weekly nutrition workflow and surfaces premium, actionable insights without changing planner, prep, grocery, or analytics backends. 
- Provide lightweight scoring and prioritized recommendations so the planner feels like an intelligent nutrition product while keeping all existing features and manual workflows intact. 
- Keep the implementation additive, frontend-first, and plug‑and‑play so a real AI service could be connected later.

### Description
- Added a new derived-intelligence module `client/src/components/meal-planner/nutritionCoachUtils.ts` that exposes `deriveNutritionCoachInsights()` plus helpers and types (`analyzeMealConsistency`, `analyzePrepEfficiency`, `analyzeMacroCoverage`, `analyzePlannerReadiness`, `deriveCoachingRecommendations`, `calculateNutritionMomentum`) to produce structured insights, scores, and recommendations. 
- Integrated the coach into the Analytics tab by wiring `deriveNutritionCoachInsights()` into `NutritionMealPlanner` and adding a premium-looking `NutritionCoachPanel` with score cards, a top coaching signal, insight cards, action chips, expandable detail, and quick navigation to Planner/Grocery/Prep. 
- Added a small, local-only dismissal state stored per-user/week (`localStorage`) so users can dismiss insights for the current week without backend schema changes, and kept all planner/grocery/prep/readiness logic and orchestration untouched. 
- Insight & score model: each insight includes `id, category, title, description, severity, priority, kind, relatedMeals, relatedPrepSessions, suggestedActions, evidence`, and derived scores include Nutrition Consistency, Prep Efficiency, Grocery Readiness, Planning Completeness, and Weekly Momentum.

### Testing
- Ran `npm run build:client` which completed successfully (vite build finished; size/chunk warnings reported but build produced assets). 
- Ran `npm run build:server` which completed successfully (esbuild produced server bundle). 
- TypeScript targeted check for the new utils file (`npx tsc --noEmit --... client/src/components/meal-planner/nutritionCoachUtils.ts`) completed for the added module without errors. 
- Full `npx tsc --noEmit` was executed and fails due to pre-existing, unrelated TypeScript issues across the repo (route and typing inconsistencies, missing ambient types, and other legacy type errors); these failures are not caused by the new coach layer and the coach code itself typechecks in isolation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e26e13788325b2e7846b621e9370)