### PR TITLE
Refactor Meal Prep Session Builder UI into modular components

### DIFF
--- a/client/src/components/meal-planner/prep/MealPrepBatchOpportunities.tsx
+++ b/client/src/components/meal-planner/prep/MealPrepBatchOpportunities.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { ListChecks, Utensils } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import type { BatchPrepIngredientGroup, DerivedPrepTask } from '@/components/meal-planner/prepOrchestrationUtils';
+
+type MealPrepBatchOpportunitiesProps = {
+  batchOpportunities: DerivedPrepTask[];
+  sharedIngredients: BatchPrepIngredientGroup[];
+};
+
+const MealPrepBatchOpportunities = ({ batchOpportunities, sharedIngredients }: MealPrepBatchOpportunitiesProps) => (
+  <>
+    <div className="rounded-lg border bg-white p-3">
+      <p className="mb-2 text-sm font-semibold text-gray-900 flex items-center gap-2"><Utensils className="h-4 w-4 text-orange-500" />Batch Opportunities</p>
+      <div className="space-y-2">
+        {batchOpportunities.slice(0, 5).map((task) => (
+          <div key={task.id} className="flex items-center justify-between gap-2 rounded-md bg-orange-50 p-2">
+            <p className="text-xs text-orange-900">{task.name}</p>
+            <Badge variant="outline" className="bg-white">{task.linkedMeals.length} meals</Badge>
+          </div>
+        ))}
+      </div>
+    </div>
+    <div className="rounded-lg border bg-white p-3">
+      <p className="mb-2 text-sm font-semibold text-gray-900 flex items-center gap-2"><ListChecks className="h-4 w-4 text-green-500" />Shared Ingredients</p>
+      <div className="flex flex-wrap gap-2">
+        {sharedIngredients.slice(0, 10).map((ingredient) => (
+          <Badge key={ingredient.id} variant="outline" className="bg-green-50 text-green-800">{ingredient.name} • {ingredient.mealCount}</Badge>
+        ))}
+      </div>
+    </div>
+  </>
+);
+
+export default MealPrepBatchOpportunities;

--- a/client/src/components/meal-planner/prep/MealPrepBuilderPanel.tsx
+++ b/client/src/components/meal-planner/prep/MealPrepBuilderPanel.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { CalendarClock, Sparkles } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import type { PrepOrchestration } from '@/components/meal-planner/prepOrchestrationUtils';
+import MealPrepBatchOpportunities from './MealPrepBatchOpportunities';
+import MealPrepEmptyState from './MealPrepEmptyState';
+import MealPrepMetrics from './MealPrepMetrics';
+import MealPrepSessionCard from './MealPrepSessionCard';
+import MealPrepStorageGuidance from './MealPrepStorageGuidance';
+import MealPrepTimeline from './MealPrepTimeline';
+
+type MealPrepBuilderPanelProps = {
+  prepOrchestration: PrepOrchestration;
+  onToggleGeneratedPrepTask: (taskId: string) => void;
+};
+
+const MealPrepBuilderPanel = ({ prepOrchestration, onToggleGeneratedPrepTask }: MealPrepBuilderPanelProps) => {
+  const prepSummary = prepOrchestration.summary;
+  const hasGeneratedPrep = prepOrchestration.sessions.length > 0;
+
+  return (
+    <Card className="border-violet-200 bg-gradient-to-r from-violet-50 via-white to-orange-50">
+      <CardHeader>
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <CardTitle className="text-lg flex items-center gap-2"><Sparkles className="w-5 h-5 text-violet-600" />Meal Prep Session Builder</CardTitle>
+            <CardDescription>ChefSire analyzes planned meal items, recipe-linked ingredients, and overlaps to suggest batch prep workflows.</CardDescription>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="outline" className="bg-white">{prepSummary.batchOpportunitiesFound} opportunities</Badge>
+            <Badge variant="outline" className="bg-white">{prepSummary.mealsCoveredByPrep}/{prepSummary.plannedMealCount} meals covered</Badge>
+            <Badge variant="outline" className="bg-white">{prepSummary.estimatedWeeklyPrepSavingsMinutes} min saved</Badge>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <MealPrepMetrics prepSummary={prepSummary} />
+
+        {!hasGeneratedPrep ? <MealPrepEmptyState /> : (
+          <>
+            <div className="space-y-3">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-sm font-semibold text-gray-900 flex items-center gap-2"><CalendarClock className="h-4 w-4 text-violet-600" />Suggested Prep Sessions</p>
+                <Badge variant="secondary">Frontend-derived</Badge>
+              </div>
+              <div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
+                {prepOrchestration.sessions.map((session) => (
+                  <MealPrepSessionCard key={session.id} session={session} onToggleGeneratedPrepTask={onToggleGeneratedPrepTask} />
+                ))}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+              <MealPrepBatchOpportunities batchOpportunities={prepOrchestration.batchOpportunities} sharedIngredients={prepOrchestration.sharedIngredients} />
+              <MealPrepTimeline timeline={prepOrchestration.timeline} />
+              <MealPrepStorageGuidance storageGuidance={prepOrchestration.storageGuidance} />
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default MealPrepBuilderPanel;

--- a/client/src/components/meal-planner/prep/MealPrepEmptyState.tsx
+++ b/client/src/components/meal-planner/prep/MealPrepEmptyState.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { ChefHat } from 'lucide-react';
+
+const MealPrepEmptyState = () => (
+  <div className="rounded-lg border border-dashed bg-white p-5 text-center">
+    <ChefHat className="mx-auto mb-2 h-8 w-8 text-violet-400" />
+    <p className="text-sm font-medium text-gray-900">No batch-prep overlaps detected yet.</p>
+    <p className="mt-1 text-xs text-gray-600">Add structured meal items or recipe-linked meals with repeated ingredients to unlock intelligent sessions.</p>
+  </div>
+);
+
+export default MealPrepEmptyState;

--- a/client/src/components/meal-planner/prep/MealPrepMetrics.tsx
+++ b/client/src/components/meal-planner/prep/MealPrepMetrics.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Progress } from '@/components/ui/progress';
+import type { PrepOrchestrationSummary } from '@/components/meal-planner/prepOrchestrationUtils';
+
+type MealPrepMetricsProps = { prepSummary: PrepOrchestrationSummary };
+
+const MealPrepMetrics = ({ prepSummary }: MealPrepMetricsProps) => (
+  <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+    <div className="rounded-lg border bg-white p-3"><p className="text-xs text-gray-500">Prep readiness</p><p className="text-2xl font-semibold text-violet-700">{prepSummary.readinessScore}%</p><Progress value={prepSummary.readinessScore} className="mt-2 h-2" /></div>
+    <div className="rounded-lg border bg-white p-3"><p className="text-xs text-gray-500">Generated tracking</p><p className="text-2xl font-semibold text-green-700">{prepSummary.completedGeneratedTasks}/{prepSummary.totalGeneratedTasks}</p><p className="text-xs text-gray-500">tasks complete</p></div>
+    <div className="rounded-lg border bg-white p-3"><p className="text-xs text-gray-500">Prep estimate</p><p className="text-2xl font-semibold text-orange-700">{prepSummary.estimatedWeeklyPrepMinutes}</p><p className="text-xs text-gray-500">minutes</p></div>
+    <div className="rounded-lg border bg-white p-3"><p className="text-xs text-gray-500">Efficiency score</p><p className="text-2xl font-semibold text-blue-700">{prepSummary.prepEfficiencyScore}%</p><p className="text-xs text-gray-500">batch leverage</p></div>
+  </div>
+);
+
+export default MealPrepMetrics;

--- a/client/src/components/meal-planner/prep/MealPrepSessionCard.tsx
+++ b/client/src/components/meal-planner/prep/MealPrepSessionCard.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Timer } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import type { DerivedPrepSession } from '@/components/meal-planner/prepOrchestrationUtils';
+import MealPrepTaskCard from './MealPrepTaskCard';
+
+type MealPrepSessionCardProps = {
+  session: DerivedPrepSession;
+  onToggleGeneratedPrepTask: (taskId: string) => void;
+};
+
+const MealPrepSessionCard = ({ session, onToggleGeneratedPrepTask }: MealPrepSessionCardProps) => (
+  <div className="rounded-xl border bg-white p-4 shadow-sm">
+    <div className="flex flex-wrap items-start justify-between gap-2">
+      <div>
+        <h4 className="font-semibold text-gray-900">{session.title}</h4>
+        <p className="text-xs text-gray-600">{session.summary}</p>
+      </div>
+      <div className="flex flex-wrap gap-1">
+        <Badge variant="outline"><Timer className="mr-1 h-3 w-3" />{session.estimatedMinutes} min</Badge>
+        <Badge variant="outline">{session.complexity}</Badge>
+      </div>
+    </div>
+    <div className="mt-3 flex flex-wrap gap-1.5">
+      {session.linkedIngredients.slice(0, 5).map((ingredient) => (
+        <Badge key={ingredient} variant="secondary" className="text-[11px]">{ingredient}</Badge>
+      ))}
+    </div>
+    <div className="mt-3 space-y-2">
+      {session.tasks.map((task) => (
+        <MealPrepTaskCard key={task.id} task={task} onToggleGeneratedPrepTask={onToggleGeneratedPrepTask} />
+      ))}
+    </div>
+  </div>
+);
+
+export default MealPrepSessionCard;

--- a/client/src/components/meal-planner/prep/MealPrepStorageGuidance.tsx
+++ b/client/src/components/meal-planner/prep/MealPrepStorageGuidance.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Refrigerator } from 'lucide-react';
+import type { PrepOrchestration } from '@/components/meal-planner/prepOrchestrationUtils';
+import { formatStorageRecommendation } from './prepUiUtils';
+
+type MealPrepStorageGuidanceProps = {
+  storageGuidance: PrepOrchestration['storageGuidance'];
+};
+
+const MealPrepStorageGuidance = ({ storageGuidance }: MealPrepStorageGuidanceProps) => (
+  <div className="rounded-lg border bg-white p-3">
+    <p className="mb-2 text-sm font-semibold text-gray-900 flex items-center gap-2"><Refrigerator className="h-4 w-4 text-indigo-500" />Storage Guidance</p>
+    <div className="space-y-2">
+      {storageGuidance.slice(0, 4).map((item) => (
+        <div key={item.id} className="rounded-md bg-indigo-50 p-2 text-xs text-indigo-900">
+          <p className="font-medium">{item.title}</p>
+          <p>{formatStorageRecommendation(item.guidance)}</p>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export default MealPrepStorageGuidance;

--- a/client/src/components/meal-planner/prep/MealPrepTaskCard.tsx
+++ b/client/src/components/meal-planner/prep/MealPrepTaskCard.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Package } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
+import type { DerivedPrepTask } from '@/components/meal-planner/prepOrchestrationUtils';
+import { formatPrepTypeLabel } from './prepUiUtils';
+
+type MealPrepTaskCardProps = {
+  task: DerivedPrepTask;
+  onToggleGeneratedPrepTask: (taskId: string) => void;
+};
+
+const MealPrepTaskCard = ({ task, onToggleGeneratedPrepTask }: MealPrepTaskCardProps) => (
+  <details className="rounded-lg border border-gray-100 bg-gray-50 p-2">
+    <summary className="cursor-pointer list-none">
+      <div className="flex items-center justify-between gap-2">
+        <label className="flex items-center gap-2 text-sm font-medium text-gray-800" onClick={(event) => event.stopPropagation()}>
+          <Checkbox checked={task.completed} onCheckedChange={() => onToggleGeneratedPrepTask(task.id)} />
+          <span className={task.completed ? 'line-through text-gray-500' : ''}>{task.name}</span>
+        </label>
+        <Badge variant="outline" className="text-[10px]">{formatPrepTypeLabel(task.prepType)}</Badge>
+      </div>
+    </summary>
+    <div className="mt-2 space-y-2 pl-7">
+      <div className="flex flex-wrap gap-1">
+        {task.linkedMeals.slice(0, 4).map((meal) => (
+          <Badge key={meal} variant="outline" className="bg-white text-[10px]">{meal}</Badge>
+        ))}
+      </div>
+      <ul className="list-disc space-y-1 pl-4 text-xs text-gray-600">
+        {task.checklist.map((step) => <li key={step}>{step}</li>)}
+      </ul>
+      <p className="text-xs text-gray-600"><Package className="mr-1 inline h-3.5 w-3.5" />{task.recommendedContainers}</p>
+    </div>
+  </details>
+);
+
+export default MealPrepTaskCard;

--- a/client/src/components/meal-planner/prep/MealPrepTimeline.tsx
+++ b/client/src/components/meal-planner/prep/MealPrepTimeline.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Clock } from 'lucide-react';
+import type { PrepTimelineStep } from '@/components/meal-planner/prepOrchestrationUtils';
+
+type MealPrepTimelineProps = { timeline: PrepTimelineStep[] };
+
+const MealPrepTimeline = ({ timeline }: MealPrepTimelineProps) => (
+  <div className="rounded-lg border bg-white p-3">
+    <p className="mb-2 text-sm font-semibold text-gray-900 flex items-center gap-2"><Clock className="h-4 w-4 text-blue-500" />Prep Timeline</p>
+    <div className="space-y-2">
+      {timeline.map((step, index) => (
+        <div key={step.id} className="flex gap-2 text-xs text-gray-700">
+          <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-blue-100 font-semibold text-blue-700">{index + 1}</span>
+          <div><p className="font-medium text-gray-900">{step.label} • {step.minutes} min</p><p>{step.detail}</p></div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export default MealPrepTimeline;

--- a/client/src/components/meal-planner/prep/prepUiUtils.ts
+++ b/client/src/components/meal-planner/prep/prepUiUtils.ts
@@ -1,0 +1,6 @@
+import type { PrepStorageRecommendation, PrepSessionType } from '@/components/meal-planner/prepOrchestrationUtils';
+
+export const formatPrepTypeLabel = (prepType: PrepSessionType) => prepType;
+
+export const formatStorageRecommendation = (guidance: PrepStorageRecommendation) =>
+  `Recommended: ${guidance.primary.replace('-', ' ')} • best within about ${guidance.bestWithinDays} day${guidance.bestWithinDays === 1 ? '' : 's'} • ${guidance.containerCount} container${guidance.containerCount === 1 ? '' : 's'}`;

--- a/client/src/components/meal-planner/sections/PrepTabSection.tsx
+++ b/client/src/components/meal-planner/sections/PrepTabSection.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { AlertTriangle, CalendarClock, CheckCircle2, ChefHat, Clock, Lightbulb, ListChecks, MoveRight, Package, Refrigerator, ShoppingCart, Sparkles, Timer, Utensils } from 'lucide-react';
+import { AlertTriangle, CalendarClock, CheckCircle2, Clock, Lightbulb, ListChecks, MoveRight, ShoppingCart } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
-import { Progress } from '@/components/ui/progress';
 import { type PrepOrchestration } from '@/components/meal-planner/prepOrchestrationUtils';
+import MealPrepBuilderPanel from '@/components/meal-planner/prep/MealPrepBuilderPanel';
 
 export type PrepTask = {
   id: string;
@@ -109,168 +109,9 @@ const PrepTabSection = ({
 }: PrepTabSectionProps) => {
   const activeBlockers = prepSession.blockers.filter((blocker) => blocker.active);
   const unfinishedTasks = prepSession.tasks.filter((task) => !task.done);
-  const prepSummary = prepOrchestration.summary;
-  const hasGeneratedPrep = prepOrchestration.sessions.length > 0;
-
   return (
     <>
-    <Card className="border-violet-200 bg-gradient-to-r from-violet-50 via-white to-orange-50">
-      <CardHeader>
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-          <div>
-            <CardTitle className="text-lg flex items-center gap-2">
-              <Sparkles className="w-5 h-5 text-violet-600" />
-              Meal Prep Session Builder
-            </CardTitle>
-            <CardDescription>
-              ChefSire analyzes planned meal items, recipe-linked ingredients, and overlaps to suggest batch prep workflows.
-            </CardDescription>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <Badge variant="outline" className="bg-white">{prepSummary.batchOpportunitiesFound} opportunities</Badge>
-            <Badge variant="outline" className="bg-white">{prepSummary.mealsCoveredByPrep}/{prepSummary.plannedMealCount} meals covered</Badge>
-            <Badge variant="outline" className="bg-white">{prepSummary.estimatedWeeklyPrepSavingsMinutes} min saved</Badge>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
-          <div className="rounded-lg border bg-white p-3">
-            <p className="text-xs text-gray-500">Prep readiness</p>
-            <p className="text-2xl font-semibold text-violet-700">{prepSummary.readinessScore}%</p>
-            <Progress value={prepSummary.readinessScore} className="mt-2 h-2" />
-          </div>
-          <div className="rounded-lg border bg-white p-3">
-            <p className="text-xs text-gray-500">Generated tracking</p>
-            <p className="text-2xl font-semibold text-green-700">{prepSummary.completedGeneratedTasks}/{prepSummary.totalGeneratedTasks}</p>
-            <p className="text-xs text-gray-500">tasks complete</p>
-          </div>
-          <div className="rounded-lg border bg-white p-3">
-            <p className="text-xs text-gray-500">Prep estimate</p>
-            <p className="text-2xl font-semibold text-orange-700">{prepSummary.estimatedWeeklyPrepMinutes}</p>
-            <p className="text-xs text-gray-500">minutes</p>
-          </div>
-          <div className="rounded-lg border bg-white p-3">
-            <p className="text-xs text-gray-500">Efficiency score</p>
-            <p className="text-2xl font-semibold text-blue-700">{prepSummary.prepEfficiencyScore}%</p>
-            <p className="text-xs text-gray-500">batch leverage</p>
-          </div>
-        </div>
-
-        {!hasGeneratedPrep ? (
-          <div className="rounded-lg border border-dashed bg-white p-5 text-center">
-            <ChefHat className="mx-auto mb-2 h-8 w-8 text-violet-400" />
-            <p className="text-sm font-medium text-gray-900">No batch-prep overlaps detected yet.</p>
-            <p className="mt-1 text-xs text-gray-600">Add structured meal items or recipe-linked meals with repeated ingredients to unlock intelligent sessions.</p>
-          </div>
-        ) : (
-          <>
-            <div className="space-y-3">
-              <div className="flex items-center justify-between gap-2">
-                <p className="text-sm font-semibold text-gray-900 flex items-center gap-2"><CalendarClock className="h-4 w-4 text-violet-600" />Suggested Prep Sessions</p>
-                <Badge variant="secondary">Frontend-derived</Badge>
-              </div>
-              <div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
-                {prepOrchestration.sessions.map((session) => (
-                  <div key={session.id} className="rounded-xl border bg-white p-4 shadow-sm">
-                    <div className="flex flex-wrap items-start justify-between gap-2">
-                      <div>
-                        <h4 className="font-semibold text-gray-900">{session.title}</h4>
-                        <p className="text-xs text-gray-600">{session.summary}</p>
-                      </div>
-                      <div className="flex flex-wrap gap-1">
-                        <Badge variant="outline"><Timer className="mr-1 h-3 w-3" />{session.estimatedMinutes} min</Badge>
-                        <Badge variant="outline">{session.complexity}</Badge>
-                      </div>
-                    </div>
-                    <div className="mt-3 flex flex-wrap gap-1.5">
-                      {session.linkedIngredients.slice(0, 5).map((ingredient) => (
-                        <Badge key={ingredient} variant="secondary" className="text-[11px]">{ingredient}</Badge>
-                      ))}
-                    </div>
-                    <div className="mt-3 space-y-2">
-                      {session.tasks.map((task) => (
-                        <details key={task.id} className="rounded-lg border border-gray-100 bg-gray-50 p-2">
-                          <summary className="cursor-pointer list-none">
-                            <div className="flex items-center justify-between gap-2">
-                              <label className="flex items-center gap-2 text-sm font-medium text-gray-800" onClick={(event) => event.stopPropagation()}>
-                                <Checkbox checked={task.completed} onCheckedChange={() => onToggleGeneratedPrepTask(task.id)} />
-                                <span className={task.completed ? 'line-through text-gray-500' : ''}>{task.name}</span>
-                              </label>
-                              <Badge variant="outline" className="text-[10px]">{task.prepType}</Badge>
-                            </div>
-                          </summary>
-                          <div className="mt-2 space-y-2 pl-7">
-                            <div className="flex flex-wrap gap-1">
-                              {task.linkedMeals.slice(0, 4).map((meal) => (
-                                <Badge key={meal} variant="outline" className="bg-white text-[10px]">{meal}</Badge>
-                              ))}
-                            </div>
-                            <ul className="list-disc space-y-1 pl-4 text-xs text-gray-600">
-                              {task.checklist.map((step) => <li key={step}>{step}</li>)}
-                            </ul>
-                            <p className="text-xs text-gray-600"><Package className="mr-1 inline h-3.5 w-3.5" />{task.recommendedContainers}</p>
-                          </div>
-                        </details>
-                      ))}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-              <div className="rounded-lg border bg-white p-3">
-                <p className="mb-2 text-sm font-semibold text-gray-900 flex items-center gap-2"><Utensils className="h-4 w-4 text-orange-500" />Batch Opportunities</p>
-                <div className="space-y-2">
-                  {prepOrchestration.batchOpportunities.slice(0, 5).map((task) => (
-                    <div key={task.id} className="flex items-center justify-between gap-2 rounded-md bg-orange-50 p-2">
-                      <p className="text-xs text-orange-900">{task.name}</p>
-                      <Badge variant="outline" className="bg-white">{task.linkedMeals.length} meals</Badge>
-                    </div>
-                  ))}
-                </div>
-              </div>
-              <div className="rounded-lg border bg-white p-3">
-                <p className="mb-2 text-sm font-semibold text-gray-900 flex items-center gap-2"><ListChecks className="h-4 w-4 text-green-500" />Shared Ingredients</p>
-                <div className="flex flex-wrap gap-2">
-                  {prepOrchestration.sharedIngredients.slice(0, 10).map((ingredient) => (
-                    <Badge key={ingredient.id} variant="outline" className="bg-green-50 text-green-800">
-                      {ingredient.name} • {ingredient.mealCount}
-                    </Badge>
-                  ))}
-                </div>
-              </div>
-              <div className="rounded-lg border bg-white p-3">
-                <p className="mb-2 text-sm font-semibold text-gray-900 flex items-center gap-2"><Clock className="h-4 w-4 text-blue-500" />Prep Timeline</p>
-                <div className="space-y-2">
-                  {prepOrchestration.timeline.map((step, index) => (
-                    <div key={step.id} className="flex gap-2 text-xs text-gray-700">
-                      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-blue-100 font-semibold text-blue-700">{index + 1}</span>
-                      <div>
-                        <p className="font-medium text-gray-900">{step.label} • {step.minutes} min</p>
-                        <p>{step.detail}</p>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-              <div className="rounded-lg border bg-white p-3">
-                <p className="mb-2 text-sm font-semibold text-gray-900 flex items-center gap-2"><Refrigerator className="h-4 w-4 text-indigo-500" />Storage Guidance</p>
-                <div className="space-y-2">
-                  {prepOrchestration.storageGuidance.slice(0, 4).map((item) => (
-                    <div key={item.id} className="rounded-md bg-indigo-50 p-2 text-xs text-indigo-900">
-                      <p className="font-medium">{item.title}</p>
-                      <p>Recommended: {item.guidance.primary.replace('-', ' ')} • best within about {item.guidance.bestWithinDays} day{item.guidance.bestWithinDays === 1 ? '' : 's'} • {item.guidance.containerCount} container{item.guidance.containerCount === 1 ? '' : 's'}</p>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </>
-        )}
-      </CardContent>
-    </Card>
+    <MealPrepBuilderPanel prepOrchestration={prepOrchestration} onToggleGeneratedPrepTask={onToggleGeneratedPrepTask} />
 
     <Card className="border-indigo-200 bg-gradient-to-r from-indigo-50 via-white to-orange-50">
       <CardHeader>


### PR DESCRIPTION
### Motivation
- Reduce the large amount of presentation/rendering logic living inside `PrepTabSection.tsx` by separating UI into focused, reusable components for maintainability.
- Preserve all existing orchestration, prep-tracking, grocery integration, and behavior while making the builder UI presentation easier to extend and test.

### Description
- Extracted the prep-builder presentation into a new `client/src/components/meal-planner/prep/` folder and added presentational components: `MealPrepBuilderPanel.tsx`, `MealPrepSessionCard.tsx`, `MealPrepTaskCard.tsx`, `MealPrepMetrics.tsx`, `MealPrepTimeline.tsx`, `MealPrepBatchOpportunities.tsx`, `MealPrepStorageGuidance.tsx`, `MealPrepEmptyState.tsx`, and `prepUiUtils.ts` (formatting helpers).  
- Updated `PrepTabSection.tsx` to be orchestration/composition-only by rendering the new `MealPrepBuilderPanel` and retaining all session tracker state, actions, and blocker/checklist wiring; no orchestration logic from `prepOrchestrationUtils.ts` was moved or changed.  
- All shared prep types continue to be imported from `prepOrchestrationUtils.ts` to avoid type duplication and to keep derivation/orchestration logic isolated.  
- Presentation-only responsibilities (session/task card rendering, badges, progress, timelines, storage guidance, empty state) now live in the new components and accept typed props from `PrepTabSection` without changing behavior.

### Testing
- Built the client bundle with `npm run build:client`, which completed successfully (build artifacts produced).  
- Built the server bundle with `npm run build:server`, which completed successfully.  
- Attempted targeted TypeScript checks with standalone `npx tsc` invocations which failed in this environment because of JSX/path-alias and project-config context (standalone file checks reported JSX/alias errors).  
- Running `npx tsc -p tsconfig.json --noEmit` reported many pre-existing, repository-wide TypeScript errors unrelated to this refactor (errors in unrelated files such as `client/src/App.tsx`, `NutritionMealPlanner.tsx`, and some `server/*` files), confirming the TypeScript failures are not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b710957dc8325a0a61adf544efc34)