### PR TITLE
Meal planner: auto-fill nutrition for every item row, not just the first

### DIFF
--- a/client/src/components/meal-planner/modals/AddMealModal.tsx
+++ b/client/src/components/meal-planner/modals/AddMealModal.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ChefHat, Image as ImageIcon, Plus, Search, Sparkles, Trash2, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { clientSideNutritionLookup } from '@/components/meal-planner/nutritionMealPlannerUtils';
 
 export type MealItemFormRow = {
   id: string;
@@ -579,7 +580,7 @@ const AddMealModal = ({
             <div className="bg-orange-50 border border-orange-200 rounded-lg px-4 py-2 flex items-center gap-2">
               <Sparkles className="w-4 h-4 text-orange-500 shrink-0" />
               <p className="text-xs text-orange-700">
-                Nutrition lookup fills the first item row for backwards-compatible single-item meals. Add more rows for sides, sauces, drinks, and snacks.
+                Type an item name then tap ✨ on that row to auto-fill its nutrition. Add more rows for sides, sauces, drinks, and snacks.
               </p>
             </div>
           )}
@@ -613,7 +614,33 @@ const AddMealModal = ({
                   <div className="grid grid-cols-1 md:grid-cols-6 gap-3">
                     <div className="md:col-span-2">
                       <label className="block text-xs font-medium text-gray-600 mb-1">Item name *</label>
-                      <input className="w-full border rounded px-3 py-2 text-sm" placeholder="Chicken breast" value={item.name || ''} onChange={e => updateMealItem(item.id, { name: e.target.value })} />
+                      <div className="flex gap-1">
+                        <input
+                          className="w-full border rounded px-3 py-2 text-sm"
+                          placeholder="Chicken breast"
+                          value={item.name || ''}
+                          onChange={e => updateMealItem(item.id, { name: e.target.value })}
+                        />
+                        <button
+                          type="button"
+                          title="Auto-fill nutrition"
+                          disabled={!item.name?.trim()}
+                          className="flex-shrink-0 px-2 rounded border border-orange-200 bg-orange-50 text-orange-500 hover:bg-orange-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                          onClick={() => {
+                            if (!item.name?.trim()) return;
+                            const result = clientSideNutritionLookup(item.name.trim());
+                            updateMealItem(item.id, {
+                              calories: String(Math.round(result.calories)),
+                              protein: String(Math.round(result.protein)),
+                              carbs: String(Math.round(result.carbs)),
+                              fat: String(Math.round(result.fat)),
+                              quantity: item.quantity || result.servingSize || '1 serving',
+                            });
+                          }}
+                        >
+                          <Sparkles className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
                     </div>
                     <div>
                       <label className="block text-xs font-medium text-gray-600 mb-1">Quantity</label>

--- a/client/src/components/meal-planner/sections/PlannerTabSection.tsx
+++ b/client/src/components/meal-planner/sections/PlannerTabSection.tsx
@@ -680,13 +680,13 @@ const PlannerTabSection = ({
                   <div key={day} className={`p-4 border-r last:border-r-0 ${isFuture ? 'bg-blue-50' : isToday ? 'bg-orange-50' : 'bg-gray-50'}`}>
                     <div className="flex items-start justify-between gap-1.5">
                       <div className="min-w-0">
-                        <div className="flex items-center gap-1.5">
-                          <div className="text-sm font-medium text-gray-900">{day}</div>
+                        <div className="text-sm font-medium text-gray-900">{day}</div>
+                        <div className="flex items-center gap-1 mt-0.5">
+                          <span className={`text-xs ${isToday ? 'text-orange-600 font-semibold' : isFuture ? 'text-blue-500' : 'text-gray-500'}`}>
+                            {new Date(dayDate + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                          </span>
                           {isFuture && <Badge variant="outline" className="text-[9px] py-0 px-1 border-blue-300 text-blue-600 leading-4">Plan</Badge>}
                           {isToday && <Badge variant="outline" className="text-[9px] py-0 px-1 border-orange-300 text-orange-600 leading-4">Today</Badge>}
-                        </div>
-                        <div className={`text-xs ${isToday ? 'text-orange-600 font-semibold' : isFuture ? 'text-blue-500' : 'text-gray-500'}`}>
-                          {new Date(dayDate + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
                         </div>
                       </div>
                       {renderDayActions(day)}


### PR DESCRIPTION
## Problem

The ✨ lookup at the top of the Add Meal modal only filled in the **first** item row. Any additional rows (sides, drinks, snacks) had empty nutrition fields and required fully manual entry.

## Fix

Each item row now has its own small ✨ button next to the name field. Type the food name, tap ✨, and it instantly fills calories / protein / carbs / fat using the same client-side nutrition lookup that already worked for row 1.

The button is disabled until you've typed something in the name field.

## Test plan

- [ ] Open Add Meal, type "chicken breast" in Item 1 name → tap ✨ → calories/protein/carbs/fat fill in
- [ ] Click "Add item" to get Item 2, type "rice" → tap ✨ → fills correctly for that row only
- [ ] Item 1 values unchanged after filling Item 2
- [ ] Button is greyed out when name field is empty

https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e)_