### PR TITLE
Meal planner: auto-fill nutrition for every item row on name blur

### DIFF
--- a/client/src/components/meal-planner/modals/AddMealModal.tsx
+++ b/client/src/components/meal-planner/modals/AddMealModal.tsx
@@ -580,7 +580,7 @@ const AddMealModal = ({
             <div className="bg-orange-50 border border-orange-200 rounded-lg px-4 py-2 flex items-center gap-2">
               <Sparkles className="w-4 h-4 text-orange-500 shrink-0" />
               <p className="text-xs text-orange-700">
-                Type an item name then tap ✨ on that row to auto-fill its nutrition. Add more rows for sides, sauces, drinks, and snacks.
+                Type an item name and move to the next field — nutrition fills automatically. Adjust any value manually if needed.
               </p>
             </div>
           )}
@@ -614,21 +614,19 @@ const AddMealModal = ({
                   <div className="grid grid-cols-1 md:grid-cols-6 gap-3">
                     <div className="md:col-span-2">
                       <label className="block text-xs font-medium text-gray-600 mb-1">Item name *</label>
-                      <div className="flex gap-1">
-                        <input
-                          className="w-full border rounded px-3 py-2 text-sm"
-                          placeholder="Chicken breast"
-                          value={item.name || ''}
-                          onChange={e => updateMealItem(item.id, { name: e.target.value })}
-                        />
-                        <button
-                          type="button"
-                          title="Auto-fill nutrition"
-                          disabled={!item.name?.trim()}
-                          className="flex-shrink-0 px-2 rounded border border-orange-200 bg-orange-50 text-orange-500 hover:bg-orange-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-                          onClick={() => {
-                            if (!item.name?.trim()) return;
-                            const result = clientSideNutritionLookup(item.name.trim());
+                      <input
+                        className="w-full border rounded px-3 py-2 text-sm"
+                        placeholder="e.g. pork chop, rice, broccoli"
+                        value={item.name || ''}
+                        onChange={e => updateMealItem(item.id, { name: e.target.value })}
+                        onBlur={e => {
+                          const name = e.target.value.trim();
+                          if (!name) return;
+                          // Auto-fill nutrition whenever the name field loses focus
+                          // and nutrition fields are still empty
+                          const hasNutrition = item.calories || item.protein || item.carbs || item.fat;
+                          if (!hasNutrition) {
+                            const result = clientSideNutritionLookup(name);
                             updateMealItem(item.id, {
                               calories: String(Math.round(result.calories)),
                               protein: String(Math.round(result.protein)),
@@ -636,11 +634,9 @@ const AddMealModal = ({
                               fat: String(Math.round(result.fat)),
                               quantity: item.quantity || result.servingSize || '1 serving',
                             });
-                          }}
-                        >
-                          <Sparkles className="w-3.5 h-3.5" />
-                        </button>
-                      </div>
+                          }
+                        }}
+                      />
                     </div>
                     <div>
                       <label className="block text-xs font-medium text-gray-600 mb-1">Quantity</label>


### PR DESCRIPTION
## Problem

Only the first item row got nutrition auto-filled (via the meal-level AI button). Every additional row required manually typing calories, protein, carbs, and fat.

## Fix

Every item row now auto-fills nutrition the moment you finish typing the food name and tab/click away. No button click needed.

**Flow:**
1. Type "pork chop" in Item 1 name → tab away → calories/protein/carbs/fat fill automatically
2. Click "Add item" → type "rice" in Item 2 name → tab away → fills automatically
3. Repeat for as many items as needed
4. Manually adjust any value — won't be overwritten unless the fields were empty

## Test plan

- [ ] Type food name in any item row → click/tab to next field → nutrition fills automatically
- [ ] Manually edit a nutrition value → tab back to name → change name → manually entered values are NOT overwritten (only fills when empty)
- [ ] Works for item 1, item 2, item 3 etc.

https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e)_