### PR TITLE
Add iterative weekly optimization engine to Smart Auto-Planner

### DIFF
--- a/client/src/components/meal-planner/auto-planner/autoPlannerEngine.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerEngine.ts
@@ -1,5 +1,7 @@
 import { calculateWeeklyScores } from './autoPlannerScoring';
-import { optimizeWeeklyDistribution, calculateWeeklyOptimizationScore, buildAdaptivePlannerRecommendations } from './autoPlannerOptimizationEngine';
+import { calculateWeeklyOptimizationScore, buildAdaptivePlannerRecommendations } from './autoPlannerOptimizationEngine';
+import { optimizeMealPlacement } from './autoPlannerSimulationEngine';
+import { evolveWeeklyPlan, summarizeOptimizationDeltas } from './autoPlannerWeekOptimizer';
 import { type AutoPlannerMode, type AutoPlannerPriorities, type AutoPlannerResult } from './autoPlannerTypes';
 
 const clone = <T,>(v: T): T => JSON.parse(JSON.stringify(v));
@@ -17,7 +19,7 @@ export const rankRecipesForPlannerSlot = (pool: any[], mode: AutoPlannerMode, pr
 };
 
 export const fillPlannerGaps = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[], pool: any[], mode: AutoPlannerMode, priorities: AutoPlannerPriorities) => {
-  const next = clone(weeklyMeals || {});
+  let next = clone(weeklyMeals || {});
   const changes: any[] = [];
   const scoreMeal = (meal: any) => {
     const protein = Number(meal?.protein || 0) * (mode === 'high-protein' ? 2 : priorities.proteinPriority);
@@ -26,12 +28,16 @@ export const fillPlannerGaps = (weeklyMeals: Record<string, any>, weekDays: read
     return protein + pantryBoost - prepPenalty;
   };
 
-  const selections = optimizeWeeklyDistribution({ weeklyMeals: next, weekDays, mealTypes, pool, mode, priorities, baseScoreMeal: scoreMeal });
-  selections.forEach(({ day, mealType, candidate, reason }) => {
-    const generatedMeal = { ...candidate, generatedByAutoPlanner: true, autoPlannerMode: mode, optimizationVersion: 2 };
+  const placement = optimizeMealPlacement(next, pool, weekDays, mealTypes, mode, scoreMeal);
+  next = placement.next;
+  weekDays.forEach((day) => mealTypes.forEach((mealType) => {
+    const slotMeals = Array.isArray(next?.[day]?.[mealType]) ? next[day][mealType] : next?.[day]?.[mealType] ? [next[day][mealType]] : [];
+    const prevMeals = Array.isArray(weeklyMeals?.[day]?.[mealType]) ? weeklyMeals[day][mealType] : weeklyMeals?.[day]?.[mealType] ? [weeklyMeals[day][mealType]] : [];
+    if (!slotMeals.length || prevMeals.length) return;
+    const generatedMeal = { ...slotMeals[0], generatedByAutoPlanner: true, autoPlannerMode: mode, optimizationVersion: 3 };
     next[day] = { ...(next[day] || {}), [mealType]: [generatedMeal] };
-    changes.push({ id: `${day}-${mealType}`, slot: { day, mealType }, action: 'add', meal: generatedMeal, reason, generatedByAutoPlanner: true, autoPlannerMode: mode, optimizationVersion: 2 });
-  });
+    changes.push({ id: `${day}-${mealType}`, slot: { day, mealType }, action: 'add', meal: generatedMeal, reason: `Iterative placement optimization for ${mealType} on ${day}.`, generatedByAutoPlanner: true, autoPlannerMode: mode, optimizationVersion: 3 });
+  }));
 
   return { next, changes };
 };
@@ -42,13 +48,20 @@ export const generateAdaptiveMealPlan = (weeklyMeals: Record<string, any>, weekD
     return arr;
   })).filter(Boolean);
   const beforeScores = calculateWeeklyScores(weeklyMeals, weekDays, mealTypes, proteinGoal);
-  const { next, changes } = fillPlannerGaps(weeklyMeals, weekDays, mealTypes, pool, mode, priorities);
+  const { next: seededPlan, changes } = fillPlannerGaps(weeklyMeals, weekDays, mealTypes, pool, mode, priorities);
+  const { next, evaluatedWeeks } = evolveWeeklyPlan(seededPlan, pool, weekDays, mealTypes, mode, (meal: any) => {
+    const protein = Number(meal?.protein || 0) * (mode === 'high-protein' ? 2 : priorities.proteinPriority);
+    const prepPenalty = Number(meal?.mealItems?.length || 0) * priorities.prepSimplicity;
+    const pantryBoost = (meal?.source === 'pantry' || meal?.isPantryItem ? 20 : 0) * priorities.pantryReusePriority;
+    return protein + pantryBoost - prepPenalty;
+  });
   const afterScores = calculateWeeklyScores(next, weekDays, mealTypes, proteinGoal);
   const beforeOpt = calculateWeeklyOptimizationScore(weeklyMeals, weekDays, mealTypes);
   const afterOpt = calculateWeeklyOptimizationScore(next, weekDays, mealTypes);
   const contextual = buildAdaptivePlannerRecommendations(weeklyMeals, next, weekDays, mealTypes);
+  const tradeoffNotes = summarizeOptimizationDeltas(weeklyMeals, next, weekDays, mealTypes);
   const optTone: 'positive' | 'warning' = afterOpt >= beforeOpt ? 'positive' : 'warning';
-  return { mode, changes, beforeScores, afterScores, suggestions: [{ id: 'autofill', tone: 'neutral', message: `Auto-filled ${changes.length} meal slots via contextual weekly optimization.` }, { id: 'opt-score', tone: optTone, message: `Weekly optimization score ${beforeOpt} → ${afterOpt}.` }, ...contextual.map((message, idx) => ({ id: `ctx-${idx}`, tone: 'neutral' as const, message }))] };
+  return { mode, changes, beforeScores, afterScores, suggestions: [{ id: 'autofill', tone: 'neutral', message: `Auto-filled ${changes.length} meal slots via contextual weekly optimization.` }, { id: 'opt-score', tone: optTone, message: `Weekly optimization score ${beforeOpt} → ${afterOpt} after evaluating ${evaluatedWeeks} candidate week arrangements.` }, ...contextual.map((message, idx) => ({ id: `ctx-${idx}`, tone: 'neutral' as const, message })), ...tradeoffNotes.map((message, idx) => ({ id: `tradeoff-${idx}`, tone: 'neutral' as const, message }))] };
 };
 
 export const optimizeWeeklyPlan = generateAdaptiveMealPlan;

--- a/client/src/components/meal-planner/auto-planner/autoPlannerSimulationEngine.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerSimulationEngine.ts
@@ -1,0 +1,98 @@
+import { deriveSlotContext } from './autoPlannerContextAnalysis';
+import { calculateMealSlotCompatibility, rankMealForSpecificSlot } from './autoPlannerMealCompatibility';
+import type { AutoPlannerMode } from './autoPlannerTypes';
+
+export type PlannerState = Record<string, any>;
+export type PlannerSlot = { day: string; mealType: string };
+
+const clone = <T,>(v: T): T => JSON.parse(JSON.stringify(v));
+
+const getSlotMeals = (weeklyMeals: PlannerState, day: string, mealType: string): any[] => {
+  const value = weeklyMeals?.[day]?.[mealType];
+  if (Array.isArray(value)) return value;
+  return value ? [value] : [];
+};
+
+const setSlotMeal = (weeklyMeals: PlannerState, slot: PlannerSlot, meal: any) => {
+  const next = clone(weeklyMeals);
+  next[slot.day] = { ...(next[slot.day] || {}), [slot.mealType]: [meal] };
+  return next;
+};
+
+const getOpenSlots = (weeklyMeals: PlannerState, weekDays: readonly string[], mealTypes: readonly string[]) => {
+  const slots: PlannerSlot[] = [];
+  weekDays.forEach((day) => mealTypes.forEach((mealType) => {
+    if (getSlotMeals(weeklyMeals, day, mealType).length === 0) slots.push({ day, mealType });
+  }));
+  return slots;
+};
+
+export const generateMealSwapCandidates = (weeklyMeals: PlannerState, weekDays: readonly string[], mealTypes: readonly string[]) => {
+  const candidates: Array<{ a: PlannerSlot; b: PlannerSlot; type: 'swap' }> = [];
+  weekDays.forEach((day) => mealTypes.forEach((mealType, idx) => {
+    const from = { day, mealType };
+    const fromMeals = getSlotMeals(weeklyMeals, from.day, from.mealType);
+    if (!fromMeals.length) return;
+    mealTypes.slice(idx + 1).forEach((otherType) => {
+      const to = { day, mealType: otherType };
+      const toMeals = getSlotMeals(weeklyMeals, to.day, to.mealType);
+      if (!toMeals.length) return;
+      candidates.push({ a: from, b: to, type: 'swap' });
+    });
+  }));
+  return candidates;
+};
+
+export const evaluateMealRotation = (weeklyMeals: PlannerState, slots: PlannerSlot[]) => {
+  if (slots.length < 2) return weeklyMeals;
+  const next = clone(weeklyMeals);
+  const meals = slots.map((slot) => getSlotMeals(next, slot.day, slot.mealType)[0]).filter(Boolean);
+  if (meals.length !== slots.length) return weeklyMeals;
+  slots.forEach((slot, index) => {
+    next[slot.day] = { ...(next[slot.day] || {}), [slot.mealType]: [meals[(index + 1) % meals.length]] };
+  });
+  return next;
+};
+
+export const optimizeMealPlacement = (weeklyMeals: PlannerState, pool: any[], weekDays: readonly string[], mealTypes: readonly string[], mode: AutoPlannerMode, baseScoreMeal: (meal: any) => number) => {
+  let next = clone(weeklyMeals);
+  const placementNotes: string[] = [];
+  const openSlots = getOpenSlots(next, weekDays, mealTypes);
+
+  openSlots.forEach((slot) => {
+    const dayIndex = Math.max(0, weekDays.indexOf(slot.day));
+    const context = deriveSlotContext(slot.day, slot.mealType, dayIndex, weekDays.length, mode);
+    const ranked = rankMealForSpecificSlot(pool, context, baseScoreMeal).slice(0, 3);
+    if (!ranked.length) return;
+    const best = ranked.sort((a, b) => calculateMealSlotCompatibility(b, context) - calculateMealSlotCompatibility(a, context))[0];
+    next = setSlotMeal(next, slot, best);
+    const compatibility = calculateMealSlotCompatibility(best, context);
+    placementNotes.push(`Placed ${best?.name || slot.mealType} on ${slot.day} ${slot.mealType} (compatibility ${compatibility}).`);
+  });
+
+  return { next, placementNotes };
+};
+
+export const generateCandidateWeeks = (weeklyMeals: PlannerState, pool: any[], weekDays: readonly string[], mealTypes: readonly string[], mode: AutoPlannerMode, baseScoreMeal: (meal: any) => number) => {
+  const initial = optimizeMealPlacement(weeklyMeals, pool, weekDays, mealTypes, mode, baseScoreMeal).next;
+  const candidates: PlannerState[] = [initial];
+
+  const swaps = generateMealSwapCandidates(initial, weekDays, mealTypes).slice(0, 6);
+  swaps.forEach((swap) => {
+    const aMeal = getSlotMeals(initial, swap.a.day, swap.a.mealType)[0];
+    const bMeal = getSlotMeals(initial, swap.b.day, swap.b.mealType)[0];
+    if (!aMeal || !bMeal) return;
+    let next = setSlotMeal(initial, swap.a, bMeal);
+    next = setSlotMeal(next, swap.b, aMeal);
+    candidates.push(next);
+  });
+
+  const dinnerRotationSlots = weekDays.slice(0, 3).map((day) => ({ day, mealType: 'dinner' }));
+  candidates.push(evaluateMealRotation(initial, dinnerRotationSlots));
+
+  return candidates;
+};
+
+export const simulateWeeklyArrangement = (weeklyMeals: PlannerState, pool: any[], weekDays: readonly string[], mealTypes: readonly string[], mode: AutoPlannerMode, baseScoreMeal: (meal: any) => number) => {
+  return generateCandidateWeeks(weeklyMeals, pool, weekDays, mealTypes, mode, baseScoreMeal);
+};

--- a/client/src/components/meal-planner/auto-planner/autoPlannerTradeoffAnalysis.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerTradeoffAnalysis.ts
@@ -1,0 +1,94 @@
+import { analyzeCalorieDistribution, analyzeProteinDistribution, calculateMacroBalanceScore } from './autoPlannerContextAnalysis';
+import { calculateGroceryFragmentation, calculateIngredientOverlapScore, calculateMealFatigueScore, calculatePantryReuseEfficiency, calculateWeeklyPlannerStress } from './autoPlannerOptimizationEngine';
+
+const gatherMeals = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => weekDays.flatMap((d) => mealTypes.flatMap((m) => {
+  const arr = Array.isArray(weeklyMeals?.[d]?.[m]) ? weeklyMeals[d][m] : weeklyMeals?.[d]?.[m] ? [weeklyMeals[d][m]] : [];
+  return arr;
+})).filter(Boolean);
+
+export const calculateRecoverySpacing = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
+  const dayStress = weekDays.map((d) => mealTypes.reduce((acc, mealType) => {
+    const meals = Array.isArray(weeklyMeals?.[d]?.[mealType]) ? weeklyMeals[d][mealType] : weeklyMeals?.[d]?.[mealType] ? [weeklyMeals[d][mealType]] : [];
+    return acc + meals.reduce((sum, meal) => sum + Number(meal?.mealItems?.length || meal?.ingredients?.length || 1), 0);
+  }, 0));
+  const heavyThreshold = Math.max(3, Math.round(dayStress.reduce((a, b) => a + b, 0) / Math.max(1, dayStress.length)));
+  let penalties = 0;
+  for (let i = 1; i < dayStress.length; i += 1) {
+    if (dayStress[i] >= heavyThreshold && dayStress[i - 1] >= heavyThreshold) penalties += 1;
+  }
+  return Math.max(0, 100 - penalties * 20);
+};
+
+export const calculateWeeklyBalanceScore = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
+  const stress = calculateWeeklyPlannerStress(weeklyMeals, weekDays, mealTypes);
+  const recoverySpacing = calculateRecoverySpacing(weeklyMeals, weekDays, mealTypes);
+  return Math.max(0, Math.min(100, Math.round((100 - Math.min(100, stress * 5)) * 0.6 + recoverySpacing * 0.4)));
+};
+
+export const calculateAdvancedFatigueScore = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
+  const meals = gatherMeals(weeklyMeals, weekDays, mealTypes);
+  const baseFatigue = calculateMealFatigueScore(meals);
+  const prepTypeMap = new Map<string, number>();
+  meals.forEach((meal) => {
+    const prepType = String(meal?.prepStyle || meal?.cookingMethod || meal?.texture || '').toLowerCase();
+    if (!prepType) return;
+    prepTypeMap.set(prepType, (prepTypeMap.get(prepType) || 0) + 1);
+  });
+  const prepRepetition = Array.from(prepTypeMap.values()).filter((count) => count >= 3).length;
+  return Math.min(100, baseFatigue + prepRepetition * 8);
+};
+
+export const detectMealPatternRepetition = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
+  const meals = gatherMeals(weeklyMeals, weekDays, mealTypes);
+  const repeatedNames = new Map<string, number>();
+  meals.forEach((meal) => {
+    const key = String(meal?.name || '').toLowerCase().trim();
+    if (!key) return;
+    repeatedNames.set(key, (repeatedNames.get(key) || 0) + 1);
+  });
+  return Array.from(repeatedNames.entries()).filter(([, count]) => count >= 2);
+};
+
+export const analyzeWeeklyVarietyRhythm = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
+  const repetition = detectMealPatternRepetition(weeklyMeals, weekDays, mealTypes).length;
+  const overlap = calculateIngredientOverlapScore(gatherMeals(weeklyMeals, weekDays, mealTypes));
+  return Math.max(0, Math.min(100, 100 - repetition * 10 - Math.max(0, overlap - 55)));
+};
+
+export const calculateTradeoffPenalty = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
+  const fatigue = calculateAdvancedFatigueScore(weeklyMeals, weekDays, mealTypes);
+  const fragmentation = calculateGroceryFragmentation(gatherMeals(weeklyMeals, weekDays, mealTypes));
+  const pantry = calculatePantryReuseEfficiency(gatherMeals(weeklyMeals, weekDays, mealTypes));
+  const pantryFatigueTension = pantry > 60 ? Math.max(0, fatigue - 50) : 0;
+  return Math.round((fatigue * 0.35) + (fragmentation * 0.35) + (pantryFatigueTension * 0.3));
+};
+
+export const calculateCompositeOptimizationScore = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
+  const protein = analyzeProteinDistribution(weeklyMeals, weekDays, mealTypes);
+  const calories = analyzeCalorieDistribution(weeklyMeals, weekDays, mealTypes);
+  const macro = calculateMacroBalanceScore(protein, calories);
+  const pantry = calculatePantryReuseEfficiency(gatherMeals(weeklyMeals, weekDays, mealTypes));
+  const fragmentation = 100 - calculateGroceryFragmentation(gatherMeals(weeklyMeals, weekDays, mealTypes));
+  const fatigue = 100 - calculateAdvancedFatigueScore(weeklyMeals, weekDays, mealTypes);
+  const weeklyBalance = calculateWeeklyBalanceScore(weeklyMeals, weekDays, mealTypes);
+  const variety = analyzeWeeklyVarietyRhythm(weeklyMeals, weekDays, mealTypes);
+  const tradeoffPenalty = calculateTradeoffPenalty(weeklyMeals, weekDays, mealTypes);
+
+  return Math.max(0, Math.min(100, Math.round(
+    macro * 0.2 + pantry * 0.12 + fragmentation * 0.14 + fatigue * 0.16 + weeklyBalance * 0.18 + variety * 0.2 - tradeoffPenalty * 0.12,
+  )));
+};
+
+export const deriveOptimizationTradeoffs = (before: Record<string, any>, after: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
+  const messages: string[] = [];
+  const pantryDelta = calculatePantryReuseEfficiency(gatherMeals(after, weekDays, mealTypes)) - calculatePantryReuseEfficiency(gatherMeals(before, weekDays, mealTypes));
+  const fatigueDelta = calculateAdvancedFatigueScore(after, weekDays, mealTypes) - calculateAdvancedFatigueScore(before, weekDays, mealTypes);
+  const stressDelta = calculateWeeklyPlannerStress(after, weekDays, mealTypes) - calculateWeeklyPlannerStress(before, weekDays, mealTypes);
+  const groceryDelta = calculateGroceryFragmentation(gatherMeals(after, weekDays, mealTypes)) - calculateGroceryFragmentation(gatherMeals(before, weekDays, mealTypes));
+
+  if (pantryDelta > 0 && fatigueDelta <= 5) messages.push('Pantry reuse increased while maintaining acceptable variety.');
+  if (stressDelta < 0 && groceryDelta <= 4) messages.push('Prep stress reduced with only minimal grocery fragmentation increase.');
+  if (fatigueDelta <= 0 && groceryDelta <= 0) messages.push('Ingredient overlap improved without increasing meal repetition.');
+
+  return messages;
+};

--- a/client/src/components/meal-planner/auto-planner/autoPlannerWeekOptimizer.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerWeekOptimizer.ts
@@ -1,0 +1,47 @@
+import type { AutoPlannerMode } from './autoPlannerTypes';
+import { simulateWeeklyArrangement } from './autoPlannerSimulationEngine';
+import { calculateCompositeOptimizationScore, deriveOptimizationTradeoffs } from './autoPlannerTradeoffAnalysis';
+
+export const compareWeeklyPlans = (a: Record<string, any>, b: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
+  const scoreA = calculateCompositeOptimizationScore(a, weekDays, mealTypes);
+  const scoreB = calculateCompositeOptimizationScore(b, weekDays, mealTypes);
+  if (scoreA === scoreB) return 0;
+  return scoreA > scoreB ? -1 : 1;
+};
+
+export const scoreCandidateWeek = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
+  return calculateCompositeOptimizationScore(weeklyMeals, weekDays, mealTypes);
+};
+
+export const optimizeWeeklyIteration = (weeklyMeals: Record<string, any>, pool: any[], weekDays: readonly string[], mealTypes: readonly string[], mode: AutoPlannerMode, baseScoreMeal: (meal: any) => number) => {
+  const candidates = simulateWeeklyArrangement(weeklyMeals, pool, weekDays, mealTypes, mode, baseScoreMeal);
+  const ranked = [...candidates].sort((a, b) => compareWeeklyPlans(a, b, weekDays, mealTypes));
+  const best = ranked[0] || weeklyMeals;
+  return { best, score: scoreCandidateWeek(best, weekDays, mealTypes), evaluated: ranked.length };
+};
+
+export const runOptimizationPass = (weeklyMeals: Record<string, any>, pool: any[], weekDays: readonly string[], mealTypes: readonly string[], mode: AutoPlannerMode, baseScoreMeal: (meal: any) => number) => {
+  return optimizeWeeklyIteration(weeklyMeals, pool, weekDays, mealTypes, mode, baseScoreMeal);
+};
+
+export const evolveWeeklyPlan = (weeklyMeals: Record<string, any>, pool: any[], weekDays: readonly string[], mealTypes: readonly string[], mode: AutoPlannerMode, baseScoreMeal: (meal: any) => number, iterations = 3) => {
+  let current = weeklyMeals;
+  let bestScore = scoreCandidateWeek(current, weekDays, mealTypes);
+  let evaluatedWeeks = 1;
+
+  for (let i = 0; i < iterations; i += 1) {
+    const result = runOptimizationPass(current, pool, weekDays, mealTypes, mode, baseScoreMeal);
+    evaluatedWeeks += result.evaluated;
+    if (result.score <= bestScore) break;
+    current = result.best;
+    bestScore = result.score;
+  }
+
+  return { next: current, score: bestScore, evaluatedWeeks };
+};
+
+export const optimizeWeeklyRhythm = evolveWeeklyPlan;
+
+export const summarizeOptimizationDeltas = (before: Record<string, any>, after: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
+  return deriveOptimizationTradeoffs(before, after, weekDays, mealTypes);
+};


### PR DESCRIPTION
### Motivation
- Move the planner from independent slot-by-slot selection to a bounded, iterative whole-week optimization flow that evaluates competing weekly arrangements and measured tradeoffs.
- Preserve the existing Smart Auto-Plan UI/workflow and all additive metadata while enabling multi-objective reasoning (prep stress, pantry reuse, grocery fragmentation, fatigue, variety, macro balance).

### Description
- Added a simulation layer that generates bounded candidate weeks using optimized placement, limited swaps, and simple rotations (`simulateWeeklyArrangement`, `generateCandidateWeeks`, `generateMealSwapCandidates`, `evaluateMealRotation`, `optimizeMealPlacement`) in `autoPlannerSimulationEngine.ts`.
- Added multi-objective tradeoff analysis and composite scoring including weekly balance, recovery spacing, advanced fatigue and tradeoff penalties (`calculateCompositeOptimizationScore`, `calculateWeeklyBalanceScore`, `calculateAdvancedFatigueScore`, `calculateTradeoffPenalty`, `deriveOptimizationTradeoffs`) in `autoPlannerTradeoffAnalysis.ts`.
- Added an optimizer orchestrator that runs iterative passes and evolves the week by selecting higher-scoring candidates (`optimizeWeeklyIteration`, `evolveWeeklyPlan`, `runOptimizationPass`, `optimizeWeeklyRhythm`, `compareWeeklyPlans`) in `autoPlannerWeekOptimizer.ts`.
- Integrated the new engine into the existing gap-fill flow (modified `autoPlannerEngine.ts`) so gaps are seeded, iteratively improved, and user suggestions are enriched with evaluated-candidate counts and measured tradeoff messages while remaining deterministic and frontend-only.

### Testing
- Ran `npm run build:client` and the client build completed successfully.
- Ran `npm run build:server` and the server build completed successfully.
- Ran targeted TypeScript checks with `npx tsc --noEmit` against the new/updated auto-planner modules and they passed without unrelated TypeScript failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e454611248325830170ed3ea192dc)