### PR TITLE
Centralize planner traversal utilities for nutrition subsystem

### DIFF
--- a/client/src/components/meal-planner/auto-planner/autoPlannerContextAnalysis.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerContextAnalysis.ts
@@ -1,3 +1,4 @@
+import { getMealsForSlot } from '../planner-graph/plannerGraphUtils';
 import { type AutoPlannerMode } from './autoPlannerTypes';
 
 export type PlannerSlotContext = {
@@ -18,14 +19,14 @@ export const deriveSlotContext = (day: string, mealType: string, dayIndex: numbe
 
 export const analyzeProteinDistribution = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
   return weekDays.map((d) => mealTypes.reduce((acc, m) => {
-    const arr = Array.isArray(weeklyMeals?.[d]?.[m]) ? weeklyMeals[d][m] : weeklyMeals?.[d]?.[m] ? [weeklyMeals[d][m]] : [];
+    const arr = getMealsForSlot(weeklyMeals, d, m);
     return acc + arr.reduce((s: number, it: any) => s + Number(it?.protein || 0), 0);
   }, 0));
 };
 
 export const analyzeCalorieDistribution = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
   return weekDays.map((d) => mealTypes.reduce((acc, m) => {
-    const arr = Array.isArray(weeklyMeals?.[d]?.[m]) ? weeklyMeals[d][m] : weeklyMeals?.[d]?.[m] ? [weeklyMeals[d][m]] : [];
+    const arr = getMealsForSlot(weeklyMeals, d, m);
     return acc + arr.reduce((s: number, it: any) => s + Number(it?.calories || it?.kcal || 0), 0);
   }, 0));
 };

--- a/client/src/components/meal-planner/auto-planner/autoPlannerEngine.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerEngine.ts
@@ -1,3 +1,4 @@
+import { getMealsForSlot } from '../planner-graph/plannerGraphUtils';
 import { calculateWeeklyScores } from './autoPlannerScoring';
 import { calculateWeeklyOptimizationScore, buildAdaptivePlannerRecommendations } from './autoPlannerOptimizationEngine';
 import { optimizeMealPlacement } from './autoPlannerSimulationEngine';
@@ -32,8 +33,8 @@ export const fillPlannerGaps = (weeklyMeals: Record<string, any>, weekDays: read
   const placement = optimizeMealPlacement(next, pool, weekDays, mealTypes, mode, scoreMeal);
   next = placement.next;
   weekDays.forEach((day) => mealTypes.forEach((mealType) => {
-    const slotMeals = Array.isArray(next?.[day]?.[mealType]) ? next[day][mealType] : next?.[day]?.[mealType] ? [next[day][mealType]] : [];
-    const prevMeals = Array.isArray(weeklyMeals?.[day]?.[mealType]) ? weeklyMeals[day][mealType] : weeklyMeals?.[day]?.[mealType] ? [weeklyMeals[day][mealType]] : [];
+    const slotMeals = getMealsForSlot(next, day, mealType);
+    const prevMeals = getMealsForSlot(weeklyMeals, day, mealType);
     if (!slotMeals.length || prevMeals.length) return;
     const generatedMeal = { ...slotMeals[0], generatedByAutoPlanner: true, autoPlannerMode: mode, optimizationVersion: 3 };
     next[day] = { ...(next[day] || {}), [mealType]: [generatedMeal] };
@@ -45,7 +46,7 @@ export const fillPlannerGaps = (weeklyMeals: Record<string, any>, weekDays: read
 
 export const generateAdaptiveMealPlan = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[], proteinGoal: number, mode: AutoPlannerMode, priorities: AutoPlannerPriorities): AutoPlannerResult => {
   const pool = weekDays.flatMap((d) => mealTypes.flatMap((m) => {
-    const arr = Array.isArray(weeklyMeals?.[d]?.[m]) ? weeklyMeals[d][m] : weeklyMeals?.[d]?.[m] ? [weeklyMeals[d][m]] : [];
+    const arr = getMealsForSlot(weeklyMeals, d, m);
     return arr;
   })).filter(Boolean);
   const beforeScores = calculateWeeklyScores(weeklyMeals, weekDays, mealTypes, proteinGoal);

--- a/client/src/components/meal-planner/auto-planner/autoPlannerRhythmEngine.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerRhythmEngine.ts
@@ -1,3 +1,4 @@
+import { getMealsForSlot } from '../planner-graph/plannerGraphUtils';
 import { analyzeWeeklyEnergyFlow, calculateMealEnergyFit, calculateRecoveryMealSupport } from './autoPlannerTemporalOptimization';
 import { deriveDayRhythmProfile, classifyDayEnergyLevel } from './autoPlannerLifestyleAnalysis';
 
@@ -33,7 +34,7 @@ export const calculateIngredientFreshnessPressure = (dayIndex: number, shelfLife
 export const analyzeGroceryLifecycle = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
   const entries: Array<{ day: string; dayIndex: number; shelfLife: 'fragile' | 'standard' | 'long-life'; freshnessPressure: number }> = [];
   weekDays.forEach((day, dayIndex) => mealTypes.forEach((mealType) => {
-    const meals = Array.isArray(weeklyMeals?.[day]?.[mealType]) ? weeklyMeals[day][mealType] : weeklyMeals?.[day]?.[mealType] ? [weeklyMeals[day][mealType]] : [];
+    const meals = getMealsForSlot(weeklyMeals, day, mealType);
     meals.forEach((meal: any) => {
       const shelfLife = calculateMealShelfLifeWindow(meal);
       entries.push({ day, dayIndex, shelfLife, freshnessPressure: calculateIngredientFreshnessPressure(dayIndex, shelfLife) });

--- a/client/src/components/meal-planner/nutritionCoachUtils.ts
+++ b/client/src/components/meal-planner/nutritionCoachUtils.ts
@@ -1,4 +1,7 @@
-import { MEAL_TYPES, WEEK_DAYS, getMealItems, getMealNutritionTotals, getSlotItems } from './nutritionMealPlannerUtils';
+import { MEAL_TYPES, WEEK_DAYS, getMealNutritionTotals } from './nutritionMealPlannerUtils';
+import { iterateWeeklyMeals } from './planner-graph/plannerIteration';
+import { extractMealIngredients } from './planner-graph/plannerMealExtraction';
+import { getMealsForSlot } from './planner-graph/plannerGraphUtils';
 import { aggregatePlannerGroceries, normalizeMealIngredient, type PlannerGrocerySuggestion } from './plannerGroceryUtils';
 import type { PrepOrchestration } from './prepOrchestrationUtils';
 
@@ -119,24 +122,18 @@ const getPlannedMeals = (
   weekDays: readonly string[],
   mealTypes: readonly string[],
 ): PlannedMeal[] => {
-  if (!weeklyMeals || typeof weeklyMeals !== 'object') return [];
-
   const meals: PlannedMeal[] = [];
-  weekDays.forEach((day) => {
-    mealTypes.forEach((mealType) => {
-      getSlotItems(weeklyMeals, day, mealType).forEach((meal: any, index: number) => {
-        const totals = getMealNutritionTotals(meal);
-        const ingredientNames = getMealItems(meal).map((item) => String(item?.name || '').trim()).filter(Boolean);
-        meals.push({
-          id: String(meal?.entryId || meal?.id || `${day}-${mealType}-${index}`),
-          name: String(meal?.name || meal?.title || `${toTitle(mealType)} meal`).trim(),
-          day,
-          mealType,
-          ...totals,
-          hasNutrition: totals.calories > 0 || totals.protein > 0 || totals.carbs > 0 || totals.fat > 0,
-          ingredientNames,
-        });
-      });
+  iterateWeeklyMeals(weeklyMeals, weekDays, mealTypes, ({ day, mealType, meal, index }) => {
+    const totals = getMealNutritionTotals(meal);
+    const ingredientNames = extractMealIngredients(meal).map((item) => String(item?.name || '').trim()).filter(Boolean);
+    meals.push({
+      id: String(meal?.entryId || meal?.id || `${day}-${mealType}-${index}`),
+      name: String(meal?.name || meal?.title || `${toTitle(mealType)} meal`).trim(),
+      day,
+      mealType,
+      ...totals,
+      hasNutrition: totals.calories > 0 || totals.protein > 0 || totals.carbs > 0 || totals.fat > 0,
+      ingredientNames,
     });
   });
 
@@ -279,7 +276,7 @@ export const deriveNutritionCoachInsights = (input: NutritionCoachInput): Nutrit
   const meals = getPlannedMeals(input.weeklyMeals, weekDays, mealTypes);
   const dayNutrition = getDayNutrition(meals, weekDays);
   const plannedSlots = weekDays.reduce((sum, day) => (
-    sum + mealTypes.filter((mealType) => getSlotItems(input.weeklyMeals || {}, day, mealType).length > 0).length
+    sum + mealTypes.filter((mealType) => getMealsForSlot(input.weeklyMeals || {}, day, mealType).length > 0).length
   ), 0);
   const missingSlots = totalSlots - plannedSlots;
   const missingDays = dayNutrition.filter((day) => day.mealsLogged === 0);

--- a/client/src/components/meal-planner/planner-graph/plannerComplexity.ts
+++ b/client/src/components/meal-planner/planner-graph/plannerComplexity.ts
@@ -1,0 +1,23 @@
+import { extractMealIngredients, extractMealPrepMetadata } from './plannerMealExtraction';
+
+export const calculateMealComplexity = (meal: any): number => {
+  const ingredients = extractMealIngredients(meal).length;
+  const { prepMinutes, cookMinutes, difficulty } = extractMealPrepMetadata(meal);
+  const difficultyScore = difficulty === 'hard' ? 3 : difficulty === 'medium' ? 2 : difficulty ? 1 : 0;
+  return ingredients + Math.round((prepMinutes + cookMinutes) / 15) + difficultyScore;
+};
+
+export const calculatePrepComplexity = (meals: any[]): number => meals.reduce((sum, meal) => sum + calculateMealComplexity(meal), 0);
+
+export const calculateIngredientOverlap = (meals: any[]): number => {
+  const names = meals.flatMap((meal) => extractMealIngredients(meal).map((item: any) => String(item.name || '').toLowerCase().trim()).filter(Boolean));
+  if (!names.length) return 0;
+  const unique = new Set(names);
+  return 1 - (unique.size / names.length);
+};
+
+export const calculateMealDiversity = (meals: any[]): number => {
+  if (!meals.length) return 0;
+  const unique = new Set(meals.map((meal: any) => String(meal?.name || meal?.title || '').trim().toLowerCase()).filter(Boolean));
+  return unique.size / meals.length;
+};

--- a/client/src/components/meal-planner/planner-graph/plannerGraphUtils.ts
+++ b/client/src/components/meal-planner/planner-graph/plannerGraphUtils.ts
@@ -1,0 +1,33 @@
+import { normalizePlannerSlot, normalizeWeeklyMeals } from './plannerNormalization';
+import type { PlannerMeal, PlannerMealRef, PlannerSlotRef, WeeklyMeals } from './plannerTypes';
+
+export const getMealsForDay = <T extends PlannerMeal>(weeklyMeals: WeeklyMeals | null | undefined, day: string): PlannerSlotRef[] => {
+  const normalized = normalizeWeeklyMeals(weeklyMeals);
+  const dayMeals = normalized?.[day] || {};
+  return Object.entries(dayMeals).map(([mealType, slotValue]) => ({
+    day,
+    mealType,
+    meals: normalizePlannerSlot<T>(slotValue),
+  }));
+};
+
+export const getMealsForSlot = <T extends PlannerMeal>(weeklyMeals: WeeklyMeals | null | undefined, day: string, mealType: string): T[] => (
+  normalizePlannerSlot<T>(normalizeWeeklyMeals(weeklyMeals)?.[day]?.[mealType])
+);
+
+export const getAllPlannerMeals = <T extends PlannerMeal>(
+  weeklyMeals: WeeklyMeals | null | undefined,
+  weekDays: readonly string[],
+  mealTypes: readonly string[],
+): PlannerMealRef[] => {
+  const normalized = normalizeWeeklyMeals(weeklyMeals);
+  const refs: PlannerMealRef[] = [];
+  weekDays.forEach((day) => {
+    mealTypes.forEach((mealType) => {
+      getMealsForSlot<T>(normalized, day, mealType).forEach((meal, index) => {
+        refs.push({ day, mealType, index, meal });
+      });
+    });
+  });
+  return refs;
+};

--- a/client/src/components/meal-planner/planner-graph/plannerIteration.ts
+++ b/client/src/components/meal-planner/planner-graph/plannerIteration.ts
@@ -1,0 +1,32 @@
+import { getMealsForSlot } from './plannerGraphUtils';
+import { normalizeWeeklyMeals } from './plannerNormalization';
+import type { PlannerMeal, PlannerMealRef, WeeklyMeals } from './plannerTypes';
+
+export const iteratePlannerDays = (weeklyMeals: WeeklyMeals | null | undefined, cb: (day: string, dayMeals: Record<string, any>) => void) => {
+  const normalized = normalizeWeeklyMeals(weeklyMeals);
+  Object.entries(normalized).forEach(([day, dayMeals]) => cb(day, dayMeals || {}));
+};
+
+export const iteratePlannerSlots = (weeklyMeals: WeeklyMeals | null | undefined, cb: (day: string, mealType: string, meals: PlannerMeal[]) => void) => {
+  iteratePlannerDays(weeklyMeals, (day, dayMeals) => {
+    Object.keys(dayMeals || {}).forEach((mealType) => cb(day, mealType, getMealsForSlot(weeklyMeals, day, mealType)));
+  });
+};
+
+export const iterateWeeklyMeals = <T extends PlannerMeal>(weeklyMeals: WeeklyMeals | null | undefined, weekDays: readonly string[], mealTypes: readonly string[], cb: (ref: PlannerMealRef) => void) => {
+  weekDays.forEach((day) => mealTypes.forEach((mealType) => getMealsForSlot<T>(weeklyMeals, day, mealType).forEach((meal, index) => cb({ day, mealType, meal, index }))));
+};
+
+export const mapWeeklyMeals = <T extends PlannerMeal, R>(weeklyMeals: WeeklyMeals | null | undefined, weekDays: readonly string[], mealTypes: readonly string[], mapper: (ref: PlannerMealRef) => R): R[] => {
+  const out: R[] = [];
+  iterateWeeklyMeals<T>(weeklyMeals, weekDays, mealTypes, (ref) => out.push(mapper(ref)));
+  return out;
+};
+
+export const filterWeeklyMeals = <T extends PlannerMeal>(weeklyMeals: WeeklyMeals | null | undefined, weekDays: readonly string[], mealTypes: readonly string[], predicate: (ref: PlannerMealRef) => boolean): PlannerMealRef[] => {
+  const out: PlannerMealRef[] = [];
+  iterateWeeklyMeals<T>(weeklyMeals, weekDays, mealTypes, (ref) => { if (predicate(ref)) out.push(ref); });
+  return out;
+};
+
+export const flattenPlannerMeals = <T extends PlannerMeal>(weeklyMeals: WeeklyMeals | null | undefined, weekDays: readonly string[], mealTypes: readonly string[]): PlannerMealRef[] => mapWeeklyMeals<T, PlannerMealRef>(weeklyMeals, weekDays, mealTypes, (ref) => ref);

--- a/client/src/components/meal-planner/planner-graph/plannerMealExtraction.ts
+++ b/client/src/components/meal-planner/planner-graph/plannerMealExtraction.ts
@@ -1,0 +1,16 @@
+import { normalizePlannerSlot } from './plannerNormalization';
+
+export const extractMealIngredients = (meal: any): any[] => normalizePlannerSlot(meal?.mealItems).filter((item: any) => item && String(item.name || '').trim());
+export const extractMealProteins = (meal: any): number => Number(meal?.protein) || extractMealIngredients(meal).reduce((sum, item: any) => sum + (Number(item?.protein) || 0), 0);
+export const extractMealTags = (meal: any): string[] => normalizePlannerSlot<string>(meal?.tags).map((t: any) => String(t).trim()).filter(Boolean);
+export const extractMealNutrition = (meal: any) => ({
+  calories: Number(meal?.calories) || 0,
+  protein: Number(meal?.protein) || 0,
+  carbs: Number(meal?.carbs) || 0,
+  fat: Number(meal?.fat) || 0,
+});
+export const extractMealPrepMetadata = (meal: any) => ({
+  prepMinutes: Number(meal?.prepMinutes || meal?.prepTimeMinutes || meal?.prepTime) || 0,
+  cookMinutes: Number(meal?.cookMinutes || meal?.cookTimeMinutes || meal?.cookTime) || 0,
+  difficulty: String(meal?.difficulty || '').toLowerCase(),
+});

--- a/client/src/components/meal-planner/planner-graph/plannerNormalization.ts
+++ b/client/src/components/meal-planner/planner-graph/plannerNormalization.ts
@@ -1,0 +1,13 @@
+import type { PlannerMeal, PlannerSlotValue, WeeklyMeals } from './plannerTypes';
+
+export const normalizePlannerMeal = <T extends PlannerMeal>(meal: T | null | undefined): T | null => (meal ? meal : null);
+
+export const normalizePlannerSlot = <T = PlannerMeal>(slot: PlannerSlotValue): T[] => {
+  if (!slot) return [];
+  const items = Array.isArray(slot) ? slot : [slot];
+  return items.filter(Boolean) as T[];
+};
+
+export const normalizeWeeklyMeals = (weeklyMeals: WeeklyMeals | null | undefined): WeeklyMeals => (
+  weeklyMeals && typeof weeklyMeals === 'object' ? weeklyMeals : {}
+);

--- a/client/src/components/meal-planner/planner-graph/plannerTypes.ts
+++ b/client/src/components/meal-planner/planner-graph/plannerTypes.ts
@@ -1,0 +1,17 @@
+export type PlannerMeal = Record<string, any>;
+export type PlannerSlotValue = PlannerMeal | PlannerMeal[] | null | undefined;
+export type PlannerDayMeals = Record<string, PlannerSlotValue>;
+export type WeeklyMeals = Record<string, PlannerDayMeals | undefined>;
+
+export type PlannerMealRef = {
+  day: string;
+  mealType: string;
+  index: number;
+  meal: PlannerMeal;
+};
+
+export type PlannerSlotRef = {
+  day: string;
+  mealType: string;
+  meals: PlannerMeal[];
+};

--- a/client/src/components/meal-planner/plannerGroceryUtils.ts
+++ b/client/src/components/meal-planner/plannerGroceryUtils.ts
@@ -1,4 +1,6 @@
 import { MEAL_TYPES, WEEK_DAYS } from './nutritionMealPlannerUtils';
+import { getMealsForSlot } from './planner-graph/plannerGraphUtils';
+import { extractMealIngredients } from './planner-graph/plannerMealExtraction';
 
 export type PlannerGrocerySourceMeal = {
   mealName: string;
@@ -117,15 +119,6 @@ export const normalizeMealIngredient = (value: unknown) => {
   return tokens.join(' ').trim();
 };
 
-const getSlotItems = (slotValue: any) => {
-  if (!slotValue) return [];
-  return Array.isArray(slotValue) ? slotValue.filter(Boolean) : [slotValue];
-};
-
-const getMealItems = (meal: any) => (
-  Array.isArray(meal?.mealItems) ? meal.mealItems.filter((item: any) => item && String(item.name || '').trim()) : []
-);
-
 const isUsefulIngredient = (name: string) => {
   const normalized = normalizeMealIngredient(name);
   if (!normalized) return false;
@@ -153,9 +146,9 @@ export const aggregatePlannerGroceries = (weeklyMeals: Record<string, any> | nul
 
   WEEK_DAYS.forEach((day) => {
     MEAL_TYPES.forEach((mealType) => {
-      getSlotItems(weeklyMeals?.[day]?.[mealType]).forEach((meal: any, mealIndex: number) => {
+      getMealsForSlot(weeklyMeals, day, mealType).forEach((meal: any, mealIndex: number) => {
         const mealName = String(meal?.name || meal?.title || `${day} ${mealType}`).trim();
-        getMealItems(meal).forEach((item: any, itemIndex: number) => {
+        extractMealIngredients(meal).forEach((item: any, itemIndex: number) => {
           const rawName = String(item?.name || '').trim();
           if (!isUsefulIngredient(rawName)) return;
           const normalizedName = normalizeMealIngredient(rawName);

--- a/client/src/components/meal-planner/prepOrchestrationUtils.ts
+++ b/client/src/components/meal-planner/prepOrchestrationUtils.ts
@@ -1,4 +1,5 @@
 import { MEAL_TYPES, WEEK_DAYS } from "./nutritionMealPlannerUtils";
+import { iterateWeeklyMeals } from "./planner-graph/plannerIteration";
 import {
   aggregatePlannerGroceries,
   normalizeMealIngredient,
@@ -201,23 +202,12 @@ const safeId = (value: string) =>
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "") || "prep";
 
-const getSlotItems = (slotValue: any) => {
-  if (!slotValue) return [];
-  return Array.isArray(slotValue) ? slotValue.filter(Boolean) : [slotValue];
-};
-
 const getPlannedMeals = (
   weeklyMeals: Record<string, any> | null | undefined,
 ) => {
-  if (!weeklyMeals || typeof weeklyMeals !== "object") return [];
-
   const meals: any[] = [];
-  WEEK_DAYS.forEach((day) => {
-    MEAL_TYPES.forEach((mealType) => {
-      getSlotItems(weeklyMeals?.[day]?.[mealType]).forEach((meal: any) => {
-        meals.push({ ...meal, day, mealType });
-      });
-    });
+  iterateWeeklyMeals(weeklyMeals, WEEK_DAYS, MEAL_TYPES, ({ day, mealType, meal }) => {
+    meals.push({ ...meal, day, mealType });
   });
 
   return meals;


### PR DESCRIPTION
### Motivation
- Remove duplicated planner traversal and normalization logic across nutrition subsystems by providing a single reusable utility layer while preserving all current planner behavior. 
- Create a stable foundation for future optimization, AI coach, and prep/grocery features without changing planner architecture or existing contracts.

### Description
- Added a new `planner-graph` utility package at `client/src/components/meal-planner/planner-graph/` containing `plannerTypes.ts`, `plannerNormalization.ts`, `plannerGraphUtils.ts`, `plannerIteration.ts`, `plannerMealExtraction.ts`, and `plannerComplexity.ts`. 
- Implemented core traversal and iteration APIs (`getMealsForSlot`, `getMealsForDay`, `getAllPlannerMeals`, `iterateWeeklyMeals`, `mapWeeklyMeals`, `filterWeeklyMeals`, `flattenPlannerMeals`) plus normalization, extraction, and complexity helpers. 
- Replaced ad-hoc slot coercion patterns (e.g. `Array.isArray(...) ? ... : [ ... ]`) in refactored modules by calling the centralized helpers in `auto-planner/*` (`autoPlannerEngine.ts`, `autoPlannerContextAnalysis.ts`, `autoPlannerRhythmEngine.ts`), `plannerGroceryUtils.ts`, `prepOrchestrationUtils.ts`, and `nutritionCoachUtils.ts`. 
- Kept changes additive and conservative, preserving single-object and array slot semantics and existing scoring/optimization behavior via `normalizePlannerSlot` and typed planner refs.

### Testing
- Ran `npm run build:client` and the client build completed successfully. 
- Ran `npm run build:server` and the server build completed successfully. 
- Ran targeted TypeScript checks with `npx tsc --noEmit` against the new planner-graph files and modified modules and the checks passed after a small typing tweak in `plannerNormalization.ts`. 
- No unrelated TypeScript failures were observed in the targeted checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e5f9a44b0832582d206ad17e3c4b8)