### PR TITLE
Relationship-driven generative planning for Smart Auto-Planner

### DIFF
--- a/client/src/components/meal-planner/auto-planner/SmartAutoPlannerPanel.tsx
+++ b/client/src/components/meal-planner/auto-planner/SmartAutoPlannerPanel.tsx
@@ -30,6 +30,7 @@ export default function SmartAutoPlannerPanel({ weeklyMeals, weekDays, mealTypes
       </div>
       {preview && <div className="space-y-2 rounded-lg border bg-white p-3">
         <div className="flex gap-2 flex-wrap">
+          <Badge variant="outline">Relationship Notes {preview.suggestions.filter((s: any) => s.id.startsWith('relationship-')).length}</Badge>
           <Badge variant="secondary">Changes: {preview.changes.length}</Badge>
           <Badge variant="outline">Readiness Δ {preview.afterScores.readinessScore - preview.beforeScores.readinessScore}</Badge>
           <Badge variant="outline">Protein Δ {preview.afterScores.proteinCoverageScore - preview.beforeScores.proteinCoverageScore}</Badge>

--- a/client/src/components/meal-planner/auto-planner/autoPlannerEngine.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerEngine.ts
@@ -5,6 +5,7 @@ import { optimizeMealPlacement } from './autoPlannerSimulationEngine';
 import { evolveWeeklyPlan, summarizeOptimizationDeltas } from './autoPlannerWeekOptimizer';
 import { type AutoPlannerMode, type AutoPlannerPriorities, type AutoPlannerResult } from './autoPlannerTypes';
 import { optimizeWeeklyLifeRhythm } from './autoPlannerRhythmEngine';
+import { evolveWeeklyPlanWithRelationships } from '../meal-relationships/relationshipDrivenPlanning';
 
 const clone = <T,>(v: T): T => JSON.parse(JSON.stringify(v));
 
@@ -50,8 +51,9 @@ export const generateAdaptiveMealPlan = (weeklyMeals: Record<string, any>, weekD
     return arr;
   })).filter(Boolean);
   const beforeScores = calculateWeeklyScores(weeklyMeals, weekDays, mealTypes, proteinGoal);
-  const { next: seededPlan, changes } = fillPlannerGaps(weeklyMeals, weekDays, mealTypes, pool, mode, priorities);
-  const { next, evaluatedWeeks } = evolveWeeklyPlan(seededPlan, pool, weekDays, mealTypes, mode, (meal: any) => {
+  const { prioritizedPool, relationshipSummary } = evolveWeeklyPlanWithRelationships(weeklyMeals, weekDays, mealTypes, pool);
+  const { next: seededPlan, changes } = fillPlannerGaps(weeklyMeals, weekDays, mealTypes, prioritizedPool, mode, priorities);
+  const { next, evaluatedWeeks } = evolveWeeklyPlan(seededPlan, prioritizedPool, weekDays, mealTypes, mode, (meal: any) => {
     const protein = Number(meal?.protein || 0) * (mode === 'high-protein' ? 2 : priorities.proteinPriority);
     const prepPenalty = Number(meal?.mealItems?.length || 0) * priorities.prepSimplicity;
     const pantryBoost = (meal?.source === 'pantry' || meal?.isPantryItem ? 20 : 0) * priorities.pantryReusePriority;
@@ -81,6 +83,7 @@ export const generateAdaptiveMealPlan = (weeklyMeals: Record<string, any>, weekD
       ...contextual.map((message, idx) => ({ id: `ctx-${idx}`, tone: 'neutral' as const, category: 'core' as const, message })),
       ...tradeoffNotes.map((message, idx) => ({ id: `tradeoff-${idx}`, tone: 'neutral' as const, category: 'core' as const, message })),
       ...rhythmMessages.map((message, idx) => ({ id: `rhythm-${idx}`, tone: 'neutral' as const, category: 'lifestyle' as const, message })),
+      ...relationshipSummary.messages.map((message: string, idx: number) => ({ id: `relationship-${idx}`, tone: 'neutral' as const, category: 'prep' as const, message })),
     ],
     lifestyleContext: {
       dayRhythm: lifeRhythmAfter.signals.energyFlow.daily.map((entry) => ({

--- a/client/src/components/meal-planner/auto-planner/autoPlannerOptimizationEngine.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerOptimizationEngine.ts
@@ -2,6 +2,7 @@ import { deriveSlotContext, analyzeProteinDistribution, analyzeCalorieDistributi
 import { calculateMealSlotCompatibility, rankMealForSpecificSlot } from './autoPlannerMealCompatibility';
 import { type AutoPlannerMode, type AutoPlannerPriorities } from './autoPlannerTypes';
 import { calculateRelationshipEfficiencyScore } from '../meal-relationships/relationshipGraph';
+import { scoreRelationshipDrivenWeek, deriveRelationshipDrivenRecommendations } from '../meal-relationships/relationshipDrivenPlanning';
 
 const gatherMeals = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => weekDays.flatMap((d) => mealTypes.flatMap((m) => {
   const arr = Array.isArray(weeklyMeals?.[d]?.[m]) ? weeklyMeals[d][m] : weeklyMeals?.[d]?.[m] ? [weeklyMeals[d][m]] : [];
@@ -86,7 +87,8 @@ export const calculateWeeklyOptimizationScore = (weeklyMeals: Record<string, any
   const pantry = calculatePantryReuseEfficiency(meals);
   const stress = calculateWeeklyPlannerStress(weeklyMeals, weekDays, mealTypes);
   const relationships = calculateRelationshipEfficiencyScore(weeklyMeals);
-  return Math.round((macro * 0.22) + ((100 - fatigue) * 0.16) + (overlap * 0.12) + ((100 - fragmentation) * 0.12) + (pantry * 0.12) + ((100 - Math.min(100, stress * 5)) * 0.12) + (relationships.efficiencyScore * 0.14));
+  const relationshipDriven = scoreRelationshipDrivenWeek(weeklyMeals, weekDays, mealTypes);
+  return Math.round((macro * 0.2) + ((100 - fatigue) * 0.14) + (overlap * 0.1) + ((100 - fragmentation) * 0.1) + (pantry * 0.1) + ((100 - Math.min(100, stress * 5)) * 0.1) + (relationships.efficiencyScore * 0.12) + (relationshipDriven.score * 0.14));
 };
 
 export const optimizePrepDistribution = () => ({ applied: true });
@@ -125,5 +127,7 @@ export const buildAdaptivePlannerRecommendations = (before: Record<string, any>,
   const beforeRelationships = calculateRelationshipEfficiencyScore(before);
   const afterRelationships = calculateRelationshipEfficiencyScore(after);
   if (afterRelationships.continuityScore > beforeRelationships.continuityScore) messages.push('Meal chain continuity improved across prep and leftover windows.');
+  const relationshipSummary = deriveRelationshipDrivenRecommendations(after, weekDays, mealTypes);
+  relationshipSummary.messages.forEach((message) => messages.push(message));
   return messages;
 };

--- a/client/src/components/meal-planner/auto-planner/autoPlannerSimulationEngine.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerSimulationEngine.ts
@@ -1,6 +1,7 @@
 import { deriveSlotContext } from './autoPlannerContextAnalysis';
 import { calculateMealSlotCompatibility, rankMealForSpecificSlot } from './autoPlannerMealCompatibility';
 import type { AutoPlannerMode } from './autoPlannerTypes';
+import { generateRelationshipDrivenCandidates } from '../meal-relationships/relationshipDrivenPlanning';
 
 export type PlannerState = Record<string, any>;
 export type PlannerSlot = { day: string; mealType: string };
@@ -62,7 +63,8 @@ export const optimizeMealPlacement = (weeklyMeals: PlannerState, pool: any[], we
   openSlots.forEach((slot) => {
     const dayIndex = Math.max(0, weekDays.indexOf(slot.day));
     const context = deriveSlotContext(slot.day, slot.mealType, dayIndex, weekDays.length, mode);
-    const ranked = rankMealForSpecificSlot(pool, context, baseScoreMeal).slice(0, 3);
+    const relationshipCandidates = generateRelationshipDrivenCandidates(pool, next);
+    const ranked = rankMealForSpecificSlot(relationshipCandidates, context, baseScoreMeal).slice(0, 3);
     if (!ranked.length) return;
     const best = ranked.sort((a, b) => calculateMealSlotCompatibility(b, context) - calculateMealSlotCompatibility(a, context))[0];
     next = setSlotMeal(next, slot, best);

--- a/client/src/components/meal-planner/auto-planner/autoPlannerWeekOptimizer.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerWeekOptimizer.ts
@@ -1,6 +1,7 @@
 import type { AutoPlannerMode } from './autoPlannerTypes';
 import { simulateWeeklyArrangement } from './autoPlannerSimulationEngine';
 import { calculateCompositeOptimizationScore, deriveOptimizationTradeoffs } from './autoPlannerTradeoffAnalysis';
+import { scoreRelationshipDrivenWeek } from '../meal-relationships/relationshipDrivenPlanning';
 
 export const compareWeeklyPlans = (a: Record<string, any>, b: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
   const scoreA = calculateCompositeOptimizationScore(a, weekDays, mealTypes);
@@ -10,7 +11,9 @@ export const compareWeeklyPlans = (a: Record<string, any>, b: Record<string, any
 };
 
 export const scoreCandidateWeek = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
-  return calculateCompositeOptimizationScore(weeklyMeals, weekDays, mealTypes);
+  const core = calculateCompositeOptimizationScore(weeklyMeals, weekDays, mealTypes);
+  const relationship = scoreRelationshipDrivenWeek(weeklyMeals, weekDays, mealTypes).score;
+  return Math.round((core * 0.7) + (relationship * 0.3));
 };
 
 export const optimizeWeeklyIteration = (weeklyMeals: Record<string, any>, pool: any[], weekDays: readonly string[], mealTypes: readonly string[], mode: AutoPlannerMode, baseScoreMeal: (meal: any) => number) => {

--- a/client/src/components/meal-planner/meal-relationships/leftoverCascadePlanning.ts
+++ b/client/src/components/meal-planner/meal-relationships/leftoverCascadePlanning.ts
@@ -1,0 +1,41 @@
+import { buildMealRelationshipGraph } from './relationshipGraph';
+
+export type LeftoverCascade = {
+  id: string;
+  mealIds: string[];
+  mealNames: string[];
+  daySpan: string;
+  score: number;
+};
+
+export const scoreLeftoverCascade = (chain: any) => {
+  const reuseLinks = Array.isArray(chain?.mealIds) ? Math.max(0, chain.mealIds.length - 1) : 0;
+  const span = Math.max(1, Number(chain?.spanDays || chain?.mealIds?.length || 1));
+  return Math.round((reuseLinks * 15) + Math.max(0, (4 - span) * 6));
+};
+
+export const generateLeftoverCascadeCandidates = (weeklyMeals: Record<string, any>): LeftoverCascade[] => {
+  const graph = buildMealRelationshipGraph(weeklyMeals);
+  return graph.leftoverChains.map((chain, index) => {
+    const mealIds = chain.mealIds;
+    const linkedNodes = graph.nodes.filter((node) => mealIds.includes(node.id));
+    const mealNames = linkedNodes.map((meal) => meal.mealName);
+    const start = linkedNodes[0]?.day || 'start';
+    const end = linkedNodes[linkedNodes.length - 1]?.day || start;
+    return {
+      id: `leftover-${index}`,
+      mealIds,
+      mealNames,
+      daySpan: `${start}→${end}`,
+      score: scoreLeftoverCascade(chain),
+    };
+  }).sort((a, b) => b.score - a.score);
+};
+
+export const scheduleLeftoverChain = (weeklyMeals: Record<string, any>) => {
+  return generateLeftoverCascadeCandidates(weeklyMeals).slice(0, 4).map((cascade) => ({
+    ...cascade,
+    leftoverCascadeId: cascade.id,
+    generatedFromRelationshipGraph: true,
+  }));
+};

--- a/client/src/components/meal-planner/meal-relationships/mealChainGeneration.ts
+++ b/client/src/components/meal-planner/meal-relationships/mealChainGeneration.ts
@@ -1,0 +1,56 @@
+import { buildMealRelationshipGraph } from './relationshipGraph';
+
+export type RelationshipMealChain = {
+  id: string;
+  seedMealId: string;
+  mealIds: string[];
+  days: string[];
+  mealNames: string[];
+  score: number;
+};
+
+export const generateDerivativeMealOptions = (weeklyMeals: Record<string, any>, seedMealId: string) => {
+  const graph = buildMealRelationshipGraph(weeklyMeals);
+  const edges = graph.edges.filter((edge) => edge.sourceId === seedMealId || edge.targetId === seedMealId);
+  return edges.map((edge) => ({
+    mealId: edge.sourceId === seedMealId ? edge.targetId : edge.sourceId,
+    relation: edge.type,
+    weight: edge.weight,
+  })).sort((a, b) => b.weight - a.weight);
+};
+
+export const scoreMealChainPotential = (weeklyMeals: Record<string, any>, mealIds: string[]) => {
+  const graph = buildMealRelationshipGraph(weeklyMeals);
+  const edgeSet = new Set(mealIds);
+  const edgeScore = graph.edges
+    .filter((edge) => edgeSet.has(edge.sourceId) && edgeSet.has(edge.targetId))
+    .reduce((sum, edge) => sum + edge.weight, 0);
+  const leftovers = graph.leftoverChains.filter((chain) => chain.mealIds.some((mealId) => edgeSet.has(mealId))).length;
+  return Math.round(edgeScore + (leftovers * 8));
+};
+
+export const constructMealReuseSequence = (weeklyMeals: Record<string, any>, chain: RelationshipMealChain) => {
+  return chain.mealIds.map((mealId, index) => ({
+    mealId,
+    chainId: chain.id,
+    sequenceIndex: index,
+    generatedFromRelationshipGraph: true,
+  }));
+};
+
+export const buildSeedMealChains = (weeklyMeals: Record<string, any>) => {
+  const graph = buildMealRelationshipGraph(weeklyMeals);
+  return graph.nodes.slice(0, 24).map((node) => {
+    const derivatives = generateDerivativeMealOptions(weeklyMeals, node.id).slice(0, 3);
+    const mealIds = [node.id, ...derivatives.map((item) => item.mealId)];
+    const meals = graph.nodes.filter((candidate) => mealIds.includes(candidate.id));
+    return {
+      id: `chain-${node.id}`,
+      seedMealId: node.id,
+      mealIds,
+      mealNames: meals.map((meal) => meal.mealName),
+      days: meals.map((meal) => meal.day),
+      score: scoreMealChainPotential(weeklyMeals, mealIds),
+    } satisfies RelationshipMealChain;
+  }).filter((chain) => chain.mealIds.length > 1).sort((a, b) => b.score - a.score);
+};

--- a/client/src/components/meal-planner/meal-relationships/prepArtifactPlanning.ts
+++ b/client/src/components/meal-planner/meal-relationships/prepArtifactPlanning.ts
@@ -1,0 +1,34 @@
+import { buildMealRelationshipGraph } from './relationshipGraph';
+
+export type PrepArtifact = {
+  id: string;
+  label: string;
+  ingredient: string;
+  supportedMealIds: string[];
+  coverageScore: number;
+};
+
+export const deriveReusablePrepArtifacts = (weeklyMeals: Record<string, any>): PrepArtifact[] => {
+  const graph = buildMealRelationshipGraph(weeklyMeals);
+  return graph.ingredientClusters.map((cluster, index) => ({
+    id: `artifact-${index}`,
+    label: `Batch prep ${cluster.ingredient}`,
+    ingredient: cluster.ingredient,
+    supportedMealIds: cluster.mealIds,
+    coverageScore: Math.round((cluster.mealIds.length / Math.max(1, graph.nodes.length)) * 100),
+  })).filter((artifact) => artifact.supportedMealIds.length >= 2).sort((a, b) => b.coverageScore - a.coverageScore);
+};
+
+export const calculateArtifactCoverageScore = (artifacts: PrepArtifact[], totalMeals: number) => {
+  const coveredMeals = new Set(artifacts.flatMap((artifact) => artifact.supportedMealIds));
+  return Math.round((coveredMeals.size / Math.max(1, totalMeals)) * 100);
+};
+
+export const planMealsAroundPrepArtifacts = (weeklyMeals: Record<string, any>) => {
+  const graph = buildMealRelationshipGraph(weeklyMeals);
+  const artifacts = deriveReusablePrepArtifacts(weeklyMeals);
+  return artifacts.slice(0, 6).map((artifact) => ({
+    ...artifact,
+    mealNames: graph.nodes.filter((node) => artifact.supportedMealIds.includes(node.id)).map((node) => node.mealName),
+  }));
+};

--- a/client/src/components/meal-planner/meal-relationships/relationshipDrivenPlanning.ts
+++ b/client/src/components/meal-planner/meal-relationships/relationshipDrivenPlanning.ts
@@ -1,0 +1,77 @@
+import { buildMealRelationshipGraph } from './relationshipGraph';
+import { buildSeedMealChains } from './mealChainGeneration';
+import { deriveReusablePrepArtifacts, calculateArtifactCoverageScore } from './prepArtifactPlanning';
+import { generateLeftoverCascadeCandidates } from './leftoverCascadePlanning';
+
+const getPlannerMeals = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => weekDays.flatMap((day) => mealTypes.flatMap((mealType) => {
+  const value = weeklyMeals?.[day]?.[mealType];
+  if (Array.isArray(value)) return value;
+  return value ? [value] : [];
+}));
+
+export const calculateCandidateContinuityGain = (candidate: any, weeklyMeals: Record<string, any>) => {
+  const graph = buildMealRelationshipGraph(weeklyMeals);
+  const candidateIngredients = new Set((candidate?.ingredients || []).map((i: any) => String(i?.name || i || '').toLowerCase().trim()));
+  const continuityMatches = graph.nodes.reduce((sum, node) => sum + node.normalizedIngredients.filter((i) => candidateIngredients.has(i)).length, 0);
+  return Math.round(Math.min(100, continuityMatches * 4));
+};
+
+export const calculateCandidatePrepReuseGain = (candidate: any, weeklyMeals: Record<string, any>) => {
+  const artifacts = deriveReusablePrepArtifacts(weeklyMeals);
+  const ingredients = new Set((candidate?.ingredients || []).map((i: any) => String(i?.name || i || '').toLowerCase().trim()));
+  const reusable = artifacts.filter((artifact) => ingredients.has(artifact.ingredient)).length;
+  return Math.round(Math.min(100, reusable * 20));
+};
+
+export const calculateCandidateLeftoverChainGain = (candidate: any, weeklyMeals: Record<string, any>) => {
+  const cascades = generateLeftoverCascadeCandidates(weeklyMeals);
+  const name = String(candidate?.name || '').toLowerCase();
+  const matches = cascades.filter((cascade) => cascade.mealNames.some((mealName) => mealName.toLowerCase() === name)).length;
+  return Math.round(Math.min(100, matches * 30 + (Number(candidate?.leftoverFriendly) ? 25 : 0)));
+};
+
+export const rankCandidatesByRelationshipValue = (candidates: any[], weeklyMeals: Record<string, any>) => {
+  return [...candidates].map((candidate) => {
+    const continuity = calculateCandidateContinuityGain(candidate, weeklyMeals);
+    const prepReuse = calculateCandidatePrepReuseGain(candidate, weeklyMeals);
+    const leftover = calculateCandidateLeftoverChainGain(candidate, weeklyMeals);
+    const relationshipValue = Math.round((continuity * 0.45) + (prepReuse * 0.3) + (leftover * 0.25));
+    return { ...candidate, relationshipValue, relationshipDrivenReason: `Continuity +${continuity}, prep reuse +${prepReuse}, leftover chain +${leftover}.` };
+  }).sort((a, b) => b.relationshipValue - a.relationshipValue);
+};
+
+export const generateRelationshipDrivenCandidates = (pool: any[], weeklyMeals: Record<string, any>) => {
+  return rankCandidatesByRelationshipValue(pool, weeklyMeals).slice(0, Math.max(8, Math.min(30, pool.length)));
+};
+
+export const scoreRelationshipDrivenWeek = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
+  const graph = buildMealRelationshipGraph(weeklyMeals);
+  const chains = buildSeedMealChains(weeklyMeals);
+  const artifacts = deriveReusablePrepArtifacts(weeklyMeals);
+  const cascades = generateLeftoverCascadeCandidates(weeklyMeals);
+  const meals = getPlannerMeals(weeklyMeals, weekDays, mealTypes);
+  const artifactCoverage = calculateArtifactCoverageScore(artifacts, meals.length);
+  const chainValue = Math.round(chains.slice(0, 4).reduce((sum, chain) => sum + chain.score, 0) / Math.max(1, Math.min(4, chains.length)));
+  const leftoverValue = Math.round(cascades.slice(0, 4).reduce((sum, cascade) => sum + cascade.score, 0) / Math.max(1, Math.min(4, cascades.length)));
+  const score = Math.round((graph.continuityScore * 0.35) + (artifactCoverage * 0.25) + (chainValue * 0.2) + (leftoverValue * 0.2));
+  return { score, chainValue, artifactCoverage, leftoverValue, continuityScore: graph.continuityScore, chains, artifacts, cascades };
+};
+
+export const deriveRelationshipDrivenRecommendations = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
+  const summary = scoreRelationshipDrivenWeek(weeklyMeals, weekDays, mealTypes);
+  const chain = summary.chains[0];
+  const artifact = summary.artifacts[0];
+  const cascade = summary.cascades[0];
+  const messages: string[] = [];
+  if (chain) messages.push(`${chain.mealNames[0]} now supports ${chain.mealIds.length} linked meals across ${chain.days[0]}–${chain.days[chain.days.length - 1]}.`);
+  if (artifact) messages.push(`${artifact.label} is reused across ${artifact.supportedMealIds.length} meals to reduce prep duplication.`);
+  if (cascade) messages.push(`A leftover-friendly chain was created from ${cascade.daySpan} across ${cascade.mealNames.length} connected meals.`);
+  messages.push(`Continuity score is ${summary.continuityScore} with artifact coverage at ${summary.artifactCoverage}%.`);
+  return { ...summary, messages };
+};
+
+export const evolveWeeklyPlanWithRelationships = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[], candidatePool: any[]) => {
+  const scored = deriveRelationshipDrivenRecommendations(weeklyMeals, weekDays, mealTypes);
+  const prioritizedPool = generateRelationshipDrivenCandidates(candidatePool, weeklyMeals);
+  return { prioritizedPool, relationshipSummary: scored };
+};


### PR DESCRIPTION
### Motivation
- Move the planner from a post-hoc relationship-aware optimizer into a generation-time, relationship-driven planner that intentionally builds operational meal chains and reusable prep artifacts. 
- Favor candidates that improve continuity, enable prep reuse, and create safe leftover cascades so weekly plans are operationally efficient rather than only scored after the fact. 

### Description
- Added relationship-driven planning layer with helpers such as `generateRelationshipDrivenCandidates`, `rankCandidatesByRelationshipValue`, `calculateCandidateContinuityGain`, `calculateCandidatePrepReuseGain`, and `calculateCandidateLeftoverChainGain` in `client/src/components/meal-planner/meal-relationships/relationshipDrivenPlanning.ts`. 
- Added modular planners for chain/artifact/cascade generation: `mealChainGeneration.ts` (`buildSeedMealChains`, `generateDerivativeMealOptions`, `scoreMealChainPotential`, `constructMealReuseSequence`), `prepArtifactPlanning.ts` (`deriveReusablePrepArtifacts`, `planMealsAroundPrepArtifacts`, `calculateArtifactCoverageScore`), and `leftoverCascadePlanning.ts` (`generateLeftoverCascadeCandidates`, `scoreLeftoverCascade`, `scheduleLeftoverChain`). 
- Integrated graph-driven prioritization into the auto-planner flow so generation uses a relationship-prioritized pool via `evolveWeeklyPlanWithRelationships` and `generateRelationshipDrivenCandidates`, and blended relationship scoring into weekly optimization via changes to `autoPlannerEngine.ts`, `autoPlannerSimulationEngine.ts`, `autoPlannerWeekOptimizer.ts`, and `autoPlannerOptimizationEngine.ts`. 
- Kept the UI and user workflows intact while adding a small preview badge and relationship note items to the Smart Auto-Plan preview in `SmartAutoPlannerPanel.tsx` (preview/apply/discard and manual controls preserved). 

### Testing
- Ran `npm run build:client` and the client build completed successfully. 
- Ran `npm run build:server` and the server build completed successfully. 
- Ran targeted TypeScript checks with `npx tsc --noEmit` for the new relationship modules and modified auto-planner modules and they completed successfully after resolving transient type mismatches encountered during development.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f95f5f894832599a4b1bf7eb62850)