### PR TITLE
Refactor auto-planner and relationship traversal to planner graph utilities

### DIFF
--- a/client/src/components/meal-planner/auto-planner/autoPlannerOptimizationEngine.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerOptimizationEngine.ts
@@ -3,11 +3,13 @@ import { calculateMealSlotCompatibility, rankMealForSpecificSlot } from './autoP
 import { type AutoPlannerMode, type AutoPlannerPriorities } from './autoPlannerTypes';
 import { calculateRelationshipEfficiencyScore } from '../meal-relationships/relationshipGraph';
 import { scoreRelationshipDrivenWeek, deriveRelationshipDrivenRecommendations } from '../meal-relationships/relationshipDrivenPlanning';
+import { getMealsForSlot } from '../planner-graph/plannerGraphUtils';
+import { extractMealIngredients } from '../planner-graph/plannerMealExtraction';
+import { calculateMealComplexity } from '../planner-graph/plannerComplexity';
 
-const gatherMeals = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => weekDays.flatMap((d) => mealTypes.flatMap((m) => {
-  const arr = Array.isArray(weeklyMeals?.[d]?.[m]) ? weeklyMeals[d][m] : weeklyMeals?.[d]?.[m] ? [weeklyMeals[d][m]] : [];
-  return arr;
-})).filter(Boolean);
+const gatherMeals = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => (
+  weekDays.flatMap((day) => mealTypes.flatMap((mealType) => getMealsForSlot(weeklyMeals, day, mealType))).filter(Boolean)
+);
 
 export const detectRepeatedProteins = (meals: any[]) => {
   const map = new Map<string, number>();
@@ -21,8 +23,8 @@ export const detectRepeatedProteins = (meals: any[]) => {
 
 export const detectIngredientOveruse = (meals: any[]) => {
   const map = new Map<string, number>();
-  meals.forEach((meal) => (meal?.ingredients || []).forEach((i: any) => {
-    const k = String(i?.name || i || '').toLowerCase().trim();
+  meals.forEach((meal) => extractMealIngredients(meal).forEach((i: any) => {
+    const k = String(i?.name || '').toLowerCase().trim();
     if (!k) return;
     map.set(k, (map.get(k) || 0) + 1);
   }));
@@ -37,12 +39,12 @@ export const calculateMealFatigueScore = (meals: any[]) => {
   return Math.max(0, Math.min(100, repeatedProteins * 10 + ingredientOveruse * 7 + namePenalty));
 };
 
-export const calculateDailyPrepStress = (dayMeals: any[]) => dayMeals.reduce((acc, meal) => acc + Number(meal?.mealItems?.length || meal?.ingredients?.length || 1), 0);
+export const calculateDailyPrepStress = (dayMeals: any[]) => dayMeals.reduce((acc, meal) => acc + Math.max(1, calculateMealComplexity(meal)), 0);
 
 export const calculateIngredientOverlapScore = (meals: any[]) => {
   const counts = new Map<string, number>();
-  meals.forEach((m) => (m?.ingredients || []).forEach((i: any) => {
-    const k = String(i?.name || i || '').toLowerCase().trim();
+  meals.forEach((m) => extractMealIngredients(m).forEach((i: any) => {
+    const k = String(i?.name || '').toLowerCase().trim();
     if (!k) return;
     counts.set(k, (counts.get(k) || 0) + 1);
   }));
@@ -52,8 +54,8 @@ export const calculateIngredientOverlapScore = (meals: any[]) => {
 
 export const calculateGroceryFragmentation = (meals: any[]) => {
   const counts = new Map<string, number>();
-  meals.forEach((m) => (m?.ingredients || []).forEach((i: any) => {
-    const k = String(i?.name || i || '').toLowerCase().trim();
+  meals.forEach((m) => extractMealIngredients(m).forEach((i: any) => {
+    const k = String(i?.name || '').toLowerCase().trim();
     if (!k) return;
     counts.set(k, (counts.get(k) || 0) + 1);
   }));
@@ -67,10 +69,7 @@ export const calculatePantryReuseEfficiency = (meals: any[]) => {
 };
 
 export const calculateWeeklyPlannerStress = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
-  const dayStress = weekDays.map((d) => calculateDailyPrepStress(mealTypes.flatMap((m) => {
-    const arr = Array.isArray(weeklyMeals?.[d]?.[m]) ? weeklyMeals[d][m] : weeklyMeals?.[d]?.[m] ? [weeklyMeals[d][m]] : [];
-    return arr;
-  })));
+  const dayStress = weekDays.map((day) => calculateDailyPrepStress(mealTypes.flatMap((mealType) => getMealsForSlot(weeklyMeals, day, mealType))));
   const max = Math.max(0, ...dayStress);
   const avg = dayStress.reduce((a, b) => a + b, 0) / Math.max(1, dayStress.length);
   return Math.round(Math.max(0, max - avg));
@@ -97,7 +96,7 @@ export const optimizeWeeklyDistribution = (params: { weeklyMeals: Record<string,
   const { weeklyMeals, weekDays, mealTypes, pool, mode, baseScoreMeal } = params;
   const selections: Array<{ day: string; mealType: string; candidate: any; reason: string }> = [];
   weekDays.forEach((day, dayIndex) => mealTypes.forEach((mealType) => {
-    const existing = Array.isArray(weeklyMeals?.[day]?.[mealType]) ? weeklyMeals[day][mealType] : weeklyMeals?.[day]?.[mealType] ? [weeklyMeals[day][mealType]] : [];
+    const existing = getMealsForSlot(weeklyMeals, day, mealType);
     if (existing.length > 0) return;
     const context = deriveSlotContext(day, mealType, dayIndex, weekDays.length, mode);
     const ranked = rankMealForSpecificSlot(pool, context, baseScoreMeal);

--- a/client/src/components/meal-planner/auto-planner/autoPlannerRhythmEngine.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerRhythmEngine.ts
@@ -1,9 +1,10 @@
 import { getMealsForSlot } from '../planner-graph/plannerGraphUtils';
+import { extractMealIngredients } from '../planner-graph/plannerMealExtraction';
+import { calculateMealComplexity } from '../planner-graph/plannerComplexity';
 import { analyzeWeeklyEnergyFlow, calculateMealEnergyFit, calculateRecoveryMealSupport } from './autoPlannerTemporalOptimization';
 import { deriveDayRhythmProfile, classifyDayEnergyLevel } from './autoPlannerLifestyleAnalysis';
 
-const ingredientName = (ingredient: any) => String(ingredient?.name || ingredient || '').toLowerCase().trim();
-const ingredientList = (meal: any) => (meal?.ingredients || []).map(ingredientName).filter(Boolean);
+const ingredientList = (meal: any) => extractMealIngredients(meal).map((ingredient: any) => String(ingredient?.name || '').toLowerCase().trim()).filter(Boolean);
 
 export const calculateMealShelfLifeWindow = (meal: any): 'fragile' | 'standard' | 'long-life' => {
   const names = ingredientList(meal);
@@ -13,7 +14,7 @@ export const calculateMealShelfLifeWindow = (meal: any): 'fragile' | 'standard' 
 };
 
 export const calculateLeftoverReusePotential = (meal: any) => {
-  const complexity = Number(meal?.mealItems?.length || meal?.ingredients?.length || 1);
+  const complexity = Math.max(1, calculateMealComplexity(meal));
   const protein = Number(meal?.protein || 0);
   return Math.max(0, Math.min(100, (complexity >= 5 ? 35 : 15) + Math.min(40, protein)));
 };

--- a/client/src/components/meal-planner/auto-planner/autoPlannerSimulationEngine.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerSimulationEngine.ts
@@ -2,17 +2,12 @@ import { deriveSlotContext } from './autoPlannerContextAnalysis';
 import { calculateMealSlotCompatibility, rankMealForSpecificSlot } from './autoPlannerMealCompatibility';
 import type { AutoPlannerMode } from './autoPlannerTypes';
 import { generateRelationshipDrivenCandidates } from '../meal-relationships/relationshipDrivenPlanning';
+import { getMealsForSlot } from '../planner-graph/plannerGraphUtils';
 
 export type PlannerState = Record<string, any>;
 export type PlannerSlot = { day: string; mealType: string };
 
 const clone = <T,>(v: T): T => JSON.parse(JSON.stringify(v));
-
-const getSlotMeals = (weeklyMeals: PlannerState, day: string, mealType: string): any[] => {
-  const value = weeklyMeals?.[day]?.[mealType];
-  if (Array.isArray(value)) return value;
-  return value ? [value] : [];
-};
 
 const setSlotMeal = (weeklyMeals: PlannerState, slot: PlannerSlot, meal: any) => {
   const next = clone(weeklyMeals);
@@ -23,7 +18,7 @@ const setSlotMeal = (weeklyMeals: PlannerState, slot: PlannerSlot, meal: any) =>
 const getOpenSlots = (weeklyMeals: PlannerState, weekDays: readonly string[], mealTypes: readonly string[]) => {
   const slots: PlannerSlot[] = [];
   weekDays.forEach((day) => mealTypes.forEach((mealType) => {
-    if (getSlotMeals(weeklyMeals, day, mealType).length === 0) slots.push({ day, mealType });
+    if (getMealsForSlot(weeklyMeals, day, mealType).length === 0) slots.push({ day, mealType });
   }));
   return slots;
 };
@@ -32,11 +27,11 @@ export const generateMealSwapCandidates = (weeklyMeals: PlannerState, weekDays: 
   const candidates: Array<{ a: PlannerSlot; b: PlannerSlot; type: 'swap' }> = [];
   weekDays.forEach((day) => mealTypes.forEach((mealType, idx) => {
     const from = { day, mealType };
-    const fromMeals = getSlotMeals(weeklyMeals, from.day, from.mealType);
+    const fromMeals = getMealsForSlot(weeklyMeals, from.day, from.mealType);
     if (!fromMeals.length) return;
     mealTypes.slice(idx + 1).forEach((otherType) => {
       const to = { day, mealType: otherType };
-      const toMeals = getSlotMeals(weeklyMeals, to.day, to.mealType);
+      const toMeals = getMealsForSlot(weeklyMeals, to.day, to.mealType);
       if (!toMeals.length) return;
       candidates.push({ a: from, b: to, type: 'swap' });
     });
@@ -47,7 +42,7 @@ export const generateMealSwapCandidates = (weeklyMeals: PlannerState, weekDays: 
 export const evaluateMealRotation = (weeklyMeals: PlannerState, slots: PlannerSlot[]) => {
   if (slots.length < 2) return weeklyMeals;
   const next = clone(weeklyMeals);
-  const meals = slots.map((slot) => getSlotMeals(next, slot.day, slot.mealType)[0]).filter(Boolean);
+  const meals = slots.map((slot) => getMealsForSlot(next, slot.day, slot.mealType)[0]).filter(Boolean);
   if (meals.length !== slots.length) return weeklyMeals;
   slots.forEach((slot, index) => {
     next[slot.day] = { ...(next[slot.day] || {}), [slot.mealType]: [meals[(index + 1) % meals.length]] };
@@ -81,8 +76,8 @@ export const generateCandidateWeeks = (weeklyMeals: PlannerState, pool: any[], w
 
   const swaps = generateMealSwapCandidates(initial, weekDays, mealTypes).slice(0, 6);
   swaps.forEach((swap) => {
-    const aMeal = getSlotMeals(initial, swap.a.day, swap.a.mealType)[0];
-    const bMeal = getSlotMeals(initial, swap.b.day, swap.b.mealType)[0];
+    const aMeal = getMealsForSlot(initial, swap.a.day, swap.a.mealType)[0];
+    const bMeal = getMealsForSlot(initial, swap.b.day, swap.b.mealType)[0];
     if (!aMeal || !bMeal) return;
     let next = setSlotMeal(initial, swap.a, bMeal);
     next = setSlotMeal(next, swap.b, aMeal);

--- a/client/src/components/meal-planner/auto-planner/autoPlannerTradeoffAnalysis.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerTradeoffAnalysis.ts
@@ -1,15 +1,16 @@
 import { analyzeCalorieDistribution, analyzeProteinDistribution, calculateMacroBalanceScore } from './autoPlannerContextAnalysis';
 import { calculateGroceryFragmentation, calculateIngredientOverlapScore, calculateMealFatigueScore, calculatePantryReuseEfficiency, calculateWeeklyPlannerStress } from './autoPlannerOptimizationEngine';
+import { getMealsForSlot } from '../planner-graph/plannerGraphUtils';
+import { calculateMealComplexity } from '../planner-graph/plannerComplexity';
 
-const gatherMeals = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => weekDays.flatMap((d) => mealTypes.flatMap((m) => {
-  const arr = Array.isArray(weeklyMeals?.[d]?.[m]) ? weeklyMeals[d][m] : weeklyMeals?.[d]?.[m] ? [weeklyMeals[d][m]] : [];
-  return arr;
-})).filter(Boolean);
+const gatherMeals = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => (
+  weekDays.flatMap((day) => mealTypes.flatMap((mealType) => getMealsForSlot(weeklyMeals, day, mealType))).filter(Boolean)
+);
 
 export const calculateRecoverySpacing = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
   const dayStress = weekDays.map((d) => mealTypes.reduce((acc, mealType) => {
-    const meals = Array.isArray(weeklyMeals?.[d]?.[mealType]) ? weeklyMeals[d][mealType] : weeklyMeals?.[d]?.[mealType] ? [weeklyMeals[d][mealType]] : [];
-    return acc + meals.reduce((sum, meal) => sum + Number(meal?.mealItems?.length || meal?.ingredients?.length || 1), 0);
+    const meals = getMealsForSlot(weeklyMeals, d, mealType);
+    return acc + meals.reduce((sum, meal) => sum + Math.max(1, calculateMealComplexity(meal)), 0);
   }, 0));
   const heavyThreshold = Math.max(3, Math.round(dayStress.reduce((a, b) => a + b, 0) / Math.max(1, dayStress.length)));
   let penalties = 0;

--- a/client/src/components/meal-planner/meal-relationships/relationshipDrivenPlanning.ts
+++ b/client/src/components/meal-planner/meal-relationships/relationshipDrivenPlanning.ts
@@ -2,23 +2,24 @@ import { buildMealRelationshipGraph } from './relationshipGraph';
 import { buildSeedMealChains } from './mealChainGeneration';
 import { deriveReusablePrepArtifacts, calculateArtifactCoverageScore } from './prepArtifactPlanning';
 import { generateLeftoverCascadeCandidates } from './leftoverCascadePlanning';
+import { flattenPlannerMeals } from '../planner-graph/plannerIteration';
+import { extractMealIngredients } from '../planner-graph/plannerMealExtraction';
+import { MEAL_TYPES, WEEK_DAYS } from '../nutritionMealPlannerUtils';
 
-const getPlannerMeals = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => weekDays.flatMap((day) => mealTypes.flatMap((mealType) => {
-  const value = weeklyMeals?.[day]?.[mealType];
-  if (Array.isArray(value)) return value;
-  return value ? [value] : [];
-}));
+const getPlannerMeals = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => (
+  flattenPlannerMeals(weeklyMeals, weekDays, mealTypes).map((ref) => ref.meal).filter(Boolean)
+);
 
 export const calculateCandidateContinuityGain = (candidate: any, weeklyMeals: Record<string, any>) => {
   const graph = buildMealRelationshipGraph(weeklyMeals);
-  const candidateIngredients = new Set((candidate?.ingredients || []).map((i: any) => String(i?.name || i || '').toLowerCase().trim()));
+  const candidateIngredients = new Set(extractMealIngredients(candidate).map((i: any) => String(i?.name || '').toLowerCase().trim()));
   const continuityMatches = graph.nodes.reduce((sum, node) => sum + node.normalizedIngredients.filter((i) => candidateIngredients.has(i)).length, 0);
   return Math.round(Math.min(100, continuityMatches * 4));
 };
 
 export const calculateCandidatePrepReuseGain = (candidate: any, weeklyMeals: Record<string, any>) => {
   const artifacts = deriveReusablePrepArtifacts(weeklyMeals);
-  const ingredients = new Set((candidate?.ingredients || []).map((i: any) => String(i?.name || i || '').toLowerCase().trim()));
+  const ingredients = new Set(extractMealIngredients(candidate).map((i: any) => String(i?.name || '').toLowerCase().trim()));
   const reusable = artifacts.filter((artifact) => ingredients.has(artifact.ingredient)).length;
   return Math.round(Math.min(100, reusable * 20));
 };
@@ -56,6 +57,8 @@ export const scoreRelationshipDrivenWeek = (weeklyMeals: Record<string, any>, we
   const score = Math.round((graph.continuityScore * 0.35) + (artifactCoverage * 0.25) + (chainValue * 0.2) + (leftoverValue * 0.2));
   return { score, chainValue, artifactCoverage, leftoverValue, continuityScore: graph.continuityScore, chains, artifacts, cascades };
 };
+
+export const scoreCanonicalRelationshipDrivenWeek = (weeklyMeals: Record<string, any>) => scoreRelationshipDrivenWeek(weeklyMeals, WEEK_DAYS, MEAL_TYPES);
 
 export const deriveRelationshipDrivenRecommendations = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
   const summary = scoreRelationshipDrivenWeek(weeklyMeals, weekDays, mealTypes);


### PR DESCRIPTION
### Motivation
- Centralize planner traversal, normalization, and ingredient/complexity extraction to reduce duplicated logic and ensure all planner subsystems operate on the canonical planner-graph utilities.
- Preserve existing planner behavior while eliminating ad-hoc slot coercion, inline ingredient extraction, and duplicated weekly traversal patterns for maintainability and consistency.

### Description
- Replaced local slot coercion and `Array.isArray` patterns with `getMealsForSlot` and `flattenPlannerMeals` and standardized ingredient access via `extractMealIngredients` across auto-planner and relationship modules. (Modified files: `autoPlannerSimulationEngine.ts`, `autoPlannerOptimizationEngine.ts`, `autoPlannerTradeoffAnalysis.ts`, `autoPlannerRhythmEngine.ts`, `relationshipDrivenPlanning.ts`.)
- Switched prep/complexity heuristics to the canonical complexity utilities by using `calculateMealComplexity` for prep stress and leftover-reuse potential calculations. (Files: `autoPlannerOptimizationEngine.ts`, `autoPlannerTradeoffAnalysis.ts`, `autoPlannerRhythmEngine.ts`.)
- Removed a local `getSlotMeals` helper and other ad-hoc weekly flattening helpers, consolidating traversal to planner-graph APIs (`plannerGraphUtils` / `plannerIteration`).
- Added a small convenience wrapper `scoreCanonicalRelationshipDrivenWeek` that reinforces canonical `WEEK_DAYS` and `MEAL_TYPES` traversal semantics while preserving callers and outputs. (File: `relationshipDrivenPlanning.ts`.)

### Testing
- Built the client with `npm run build:client`, which completed successfully.
- Built the server with `npm run build:server`, which completed successfully.
- Ran targeted TypeScript checks with `npx tsc --noEmit --skipLibCheck` against planner-graph, auto-planner, and relationship modules, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f9f2fb4b8832590be069c05d6d46d)