### PR TITLE
Add unified planner objective engine and integrate into planner optimization flows

### DIFF
--- a/client/src/components/meal-planner/auto-planner/autoPlannerEngine.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerEngine.ts
@@ -6,6 +6,8 @@ import { evolveWeeklyPlan, summarizeOptimizationDeltas } from './autoPlannerWeek
 import { type AutoPlannerMode, type AutoPlannerPriorities, type AutoPlannerResult } from './autoPlannerTypes';
 import { optimizeWeeklyLifeRhythm } from './autoPlannerRhythmEngine';
 import { evolveWeeklyPlanWithRelationships } from '../meal-relationships/relationshipDrivenPlanning';
+import { summarizeObjectiveImprovements } from '../planner-objectives/plannerObjectiveEngine';
+import { deriveObjectiveContributionChips, deriveObjectiveOptimizationSummary } from '../planner-objectives/plannerObjectiveInsights';
 
 const clone = <T,>(v: T): T => JSON.parse(JSON.stringify(v));
 
@@ -63,6 +65,9 @@ export const generateAdaptiveMealPlan = (weeklyMeals: Record<string, any>, weekD
   const beforeOpt = calculateWeeklyOptimizationScore(weeklyMeals, weekDays, mealTypes);
   const afterOpt = calculateWeeklyOptimizationScore(next, weekDays, mealTypes);
   const contextual = buildAdaptivePlannerRecommendations(weeklyMeals, next, weekDays, mealTypes);
+  const objectiveSummary = summarizeObjectiveImprovements(weeklyMeals, next, weekDays, mealTypes, mode, proteinGoal);
+  const objectiveChips = deriveObjectiveContributionChips(objectiveSummary.after.contributions);
+  const objectiveMessages = deriveObjectiveOptimizationSummary(objectiveSummary.before.metrics, objectiveSummary.after.metrics);
   const tradeoffNotes = summarizeOptimizationDeltas(weeklyMeals, next, weekDays, mealTypes);
   const lifeRhythmBefore = optimizeWeeklyLifeRhythm(weeklyMeals, weekDays, mealTypes);
   const lifeRhythmAfter = optimizeWeeklyLifeRhythm(next, weekDays, mealTypes);
@@ -84,6 +89,9 @@ export const generateAdaptiveMealPlan = (weeklyMeals: Record<string, any>, weekD
       ...tradeoffNotes.map((message, idx) => ({ id: `tradeoff-${idx}`, tone: 'neutral' as const, category: 'core' as const, message })),
       ...rhythmMessages.map((message, idx) => ({ id: `rhythm-${idx}`, tone: 'neutral' as const, category: 'lifestyle' as const, message })),
       ...relationshipSummary.messages.map((message: string, idx: number) => ({ id: `relationship-${idx}`, tone: 'neutral' as const, category: 'prep' as const, message })),
+      ...objectiveMessages.map((message, idx) => ({ id: `objective-${idx}`, tone: 'neutral' as const, category: 'core' as const, message: `Objective: ${message}.` })),
+      ...objectiveChips.map((message, idx) => ({ id: `objective-chip-${idx}`, tone: 'neutral' as const, category: 'core' as const, message: `Optimization breakdown: ${message}` })),
+      ...objectiveSummary.after.overfittingSignals.map((message, idx) => ({ id: `objective-balance-${idx}`, tone: 'warning' as const, category: 'core' as const, message: `Balance guardrail: ${message}` })),
     ],
     lifestyleContext: {
       dayRhythm: lifeRhythmAfter.signals.energyFlow.daily.map((entry) => ({

--- a/client/src/components/meal-planner/auto-planner/autoPlannerOptimizationEngine.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerOptimizationEngine.ts
@@ -6,6 +6,7 @@ import { scoreRelationshipDrivenWeek, deriveRelationshipDrivenRecommendations } 
 import { getMealsForSlot } from '../planner-graph/plannerGraphUtils';
 import { extractMealIngredients } from '../planner-graph/plannerMealExtraction';
 import { calculateMealComplexity } from '../planner-graph/plannerComplexity';
+import { evaluatePlannerObjectives } from '../planner-objectives/plannerObjectiveEngine';
 
 const gatherMeals = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => (
   weekDays.flatMap((day) => mealTypes.flatMap((mealType) => getMealsForSlot(weeklyMeals, day, mealType))).filter(Boolean)
@@ -87,7 +88,9 @@ export const calculateWeeklyOptimizationScore = (weeklyMeals: Record<string, any
   const stress = calculateWeeklyPlannerStress(weeklyMeals, weekDays, mealTypes);
   const relationships = calculateRelationshipEfficiencyScore(weeklyMeals);
   const relationshipDriven = scoreRelationshipDrivenWeek(weeklyMeals, weekDays, mealTypes);
-  return Math.round((macro * 0.2) + ((100 - fatigue) * 0.14) + (overlap * 0.1) + ((100 - fragmentation) * 0.1) + (pantry * 0.1) + ((100 - Math.min(100, stress * 5)) * 0.1) + (relationships.efficiencyScore * 0.12) + (relationshipDriven.score * 0.14));
+  const legacy = Math.round((macro * 0.2) + ((100 - fatigue) * 0.14) + (overlap * 0.1) + ((100 - fragmentation) * 0.1) + (pantry * 0.1) + ((100 - Math.min(100, stress * 5)) * 0.1) + (relationships.efficiencyScore * 0.12) + (relationshipDriven.score * 0.14));
+  const unified = evaluatePlannerObjectives({ weeklyMeals, weekDays, mealTypes, mode: 'balanced' }).score;
+  return Math.round((unified * 0.75) + (legacy * 0.25));
 };
 
 export const optimizePrepDistribution = () => ({ applied: true });

--- a/client/src/components/meal-planner/auto-planner/autoPlannerRhythmEngine.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerRhythmEngine.ts
@@ -88,3 +88,16 @@ export const optimizeWeeklyLifeRhythm = (weeklyMeals: Record<string, any>, weekD
   const freshnessFlow = optimizeFreshnessFlow(signals);
   return { signals, prepTiming, freshnessFlow };
 };
+
+export const calculateFreshnessFlowScore = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
+  const flow = optimizeWeeklyLifeRhythm(weeklyMeals, weekDays, mealTypes).freshnessFlow;
+  const pressureBalance = Math.max(0, 100 - (flow.fragileLateWeek * 12));
+  return Math.max(0, Math.min(100, Math.round((pressureBalance * 0.7) + (flow.improved ? 30 : 0))));
+};
+
+export const calculateTemporalFlowScore = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
+  const rhythm = optimizeWeeklyLifeRhythm(weeklyMeals, weekDays, mealTypes);
+  const prepHeavy = rhythm.signals.energyFlow.prepHeavyDinners;
+  const quickDays = rhythm.prepTiming.quickDays;
+  return Math.max(0, Math.min(100, Math.round(100 - (prepHeavy * 10) + (quickDays * 3))));
+};

--- a/client/src/components/meal-planner/auto-planner/autoPlannerTradeoffAnalysis.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerTradeoffAnalysis.ts
@@ -2,6 +2,7 @@ import { analyzeCalorieDistribution, analyzeProteinDistribution, calculateMacroB
 import { calculateGroceryFragmentation, calculateIngredientOverlapScore, calculateMealFatigueScore, calculatePantryReuseEfficiency, calculateWeeklyPlannerStress } from './autoPlannerOptimizationEngine';
 import { getMealsForSlot } from '../planner-graph/plannerGraphUtils';
 import { calculateMealComplexity } from '../planner-graph/plannerComplexity';
+import { evaluatePlannerObjectives } from '../planner-objectives/plannerObjectiveEngine';
 
 const gatherMeals = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => (
   weekDays.flatMap((day) => mealTypes.flatMap((mealType) => getMealsForSlot(weeklyMeals, day, mealType))).filter(Boolean)
@@ -75,9 +76,11 @@ export const calculateCompositeOptimizationScore = (weeklyMeals: Record<string, 
   const variety = analyzeWeeklyVarietyRhythm(weeklyMeals, weekDays, mealTypes);
   const tradeoffPenalty = calculateTradeoffPenalty(weeklyMeals, weekDays, mealTypes);
 
-  return Math.max(0, Math.min(100, Math.round(
+  const legacy = Math.max(0, Math.min(100, Math.round(
     macro * 0.2 + pantry * 0.12 + fragmentation * 0.14 + fatigue * 0.16 + weeklyBalance * 0.18 + variety * 0.2 - tradeoffPenalty * 0.12,
   )));
+  const unified = evaluatePlannerObjectives({ weeklyMeals, weekDays, mealTypes, mode: 'balanced' }).score;
+  return Math.round((unified * 0.7) + (legacy * 0.3));
 };
 
 export const deriveOptimizationTradeoffs = (before: Record<string, any>, after: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {

--- a/client/src/components/meal-planner/auto-planner/autoPlannerWeekOptimizer.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerWeekOptimizer.ts
@@ -2,6 +2,7 @@ import type { AutoPlannerMode } from './autoPlannerTypes';
 import { simulateWeeklyArrangement } from './autoPlannerSimulationEngine';
 import { calculateCompositeOptimizationScore, deriveOptimizationTradeoffs } from './autoPlannerTradeoffAnalysis';
 import { scoreRelationshipDrivenWeek } from '../meal-relationships/relationshipDrivenPlanning';
+import { evaluatePlannerObjectives } from '../planner-objectives/plannerObjectiveEngine';
 
 export const compareWeeklyPlans = (a: Record<string, any>, b: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
   const scoreA = calculateCompositeOptimizationScore(a, weekDays, mealTypes);
@@ -11,9 +12,11 @@ export const compareWeeklyPlans = (a: Record<string, any>, b: Record<string, any
 };
 
 export const scoreCandidateWeek = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
+  const mode: AutoPlannerMode = 'balanced';
+  const unified = evaluatePlannerObjectives({ weeklyMeals, weekDays, mealTypes, mode }).score;
   const core = calculateCompositeOptimizationScore(weeklyMeals, weekDays, mealTypes);
   const relationship = scoreRelationshipDrivenWeek(weeklyMeals, weekDays, mealTypes).score;
-  return Math.round((core * 0.7) + (relationship * 0.3));
+  return Math.round((unified * 0.7) + (Math.round((core * 0.7) + (relationship * 0.3)) * 0.3));
 };
 
 export const optimizeWeeklyIteration = (weeklyMeals: Record<string, any>, pool: any[], weekDays: readonly string[], mealTypes: readonly string[], mode: AutoPlannerMode, baseScoreMeal: (meal: any) => number) => {

--- a/client/src/components/meal-planner/meal-relationships/relationshipDrivenPlanning.ts
+++ b/client/src/components/meal-planner/meal-relationships/relationshipDrivenPlanning.ts
@@ -5,6 +5,7 @@ import { generateLeftoverCascadeCandidates } from './leftoverCascadePlanning';
 import { flattenPlannerMeals } from '../planner-graph/plannerIteration';
 import { extractMealIngredients } from '../planner-graph/plannerMealExtraction';
 import { MEAL_TYPES, WEEK_DAYS } from '../nutritionMealPlannerUtils';
+import { derivePlannerObjectiveProfile } from '../planner-objectives/plannerObjectiveProfiles';
 
 const getPlannerMeals = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => (
   flattenPlannerMeals(weeklyMeals, weekDays, mealTypes).map((ref) => ref.meal).filter(Boolean)
@@ -32,11 +33,16 @@ export const calculateCandidateLeftoverChainGain = (candidate: any, weeklyMeals:
 };
 
 export const rankCandidatesByRelationshipValue = (candidates: any[], weeklyMeals: Record<string, any>) => {
+  const profile = derivePlannerObjectiveProfile('balanced');
+  const continuityWeight = profile.continuity;
+  const prepWeight = profile.prepEfficiency;
+  const leftoverWeight = profile.momentum;
+  const total = continuityWeight + prepWeight + leftoverWeight;
   return [...candidates].map((candidate) => {
     const continuity = calculateCandidateContinuityGain(candidate, weeklyMeals);
     const prepReuse = calculateCandidatePrepReuseGain(candidate, weeklyMeals);
     const leftover = calculateCandidateLeftoverChainGain(candidate, weeklyMeals);
-    const relationshipValue = Math.round((continuity * 0.45) + (prepReuse * 0.3) + (leftover * 0.25));
+    const relationshipValue = Math.round(((continuity * continuityWeight) + (prepReuse * prepWeight) + (leftover * leftoverWeight)) / Math.max(0.0001, total));
     return { ...candidate, relationshipValue, relationshipDrivenReason: `Continuity +${continuity}, prep reuse +${prepReuse}, leftover chain +${leftover}.` };
   }).sort((a, b) => b.relationshipValue - a.relationshipValue);
 };

--- a/client/src/components/meal-planner/planner-objectives/plannerObjectiveConstraints.ts
+++ b/client/src/components/meal-planner/planner-objectives/plannerObjectiveConstraints.ts
@@ -1,0 +1,32 @@
+import type { PlannerObjectiveMetrics, PlannerObjectiveProfile } from './plannerObjectiveTypes';
+
+export const applyObjectiveBalanceConstraints = (profile: PlannerObjectiveProfile): PlannerObjectiveProfile => {
+  const constrained = { ...profile };
+  const cap = 0.22;
+  const floor = 0.03;
+  (Object.keys(constrained) as Array<keyof PlannerObjectiveProfile>).forEach((key) => {
+    constrained[key] = Math.min(cap, Math.max(floor, constrained[key]));
+  });
+  if (constrained.continuity > constrained.variety * 1.8) constrained.continuity = constrained.variety * 1.8;
+  if (constrained.prepEfficiency > constrained.freshnessTiming * 2.2) constrained.prepEfficiency = constrained.freshnessTiming * 2.2;
+  if (constrained.pantryReuse > constrained.macroQuality * 1.9) constrained.pantryReuse = constrained.macroQuality * 1.9;
+  const total = Object.values(constrained).reduce((a, b) => a + b, 0) || 1;
+  return Object.fromEntries(Object.entries(constrained).map(([k, v]) => [k, v / total])) as PlannerObjectiveProfile;
+};
+
+export const detectObjectiveOverfitting = (metrics: PlannerObjectiveMetrics) => {
+  const messages: string[] = [];
+  if (metrics.continuity > 85 && metrics.variety < 45) messages.push('Continuity is high while variety is lagging.');
+  if (metrics.prepEfficiency > 80 && metrics.freshnessTiming < 45) messages.push('Prep reuse is elevated while freshness timing is weak.');
+  if (metrics.pantryReuse > 80 && metrics.macroQuality < 50) messages.push('Pantry reuse is outpacing macro quality.');
+  return messages;
+};
+
+export const calculateOptimizationTradeoffBalance = (metrics: PlannerObjectiveMetrics) => {
+  const penalties = [
+    Math.max(0, metrics.continuity - metrics.variety),
+    Math.max(0, metrics.prepEfficiency - metrics.freshnessTiming),
+    Math.max(0, metrics.pantryReuse - metrics.macroQuality),
+  ];
+  return Math.max(0, Math.min(100, 100 - Math.round((penalties[0] * 0.35) + (penalties[1] * 0.35) + (penalties[2] * 0.3))));
+};

--- a/client/src/components/meal-planner/planner-objectives/plannerObjectiveEngine.ts
+++ b/client/src/components/meal-planner/planner-objectives/plannerObjectiveEngine.ts
@@ -1,0 +1,37 @@
+import { derivePlannerObjectiveProfile, normalizeObjectiveWeights } from './plannerObjectiveProfiles';
+import { applyObjectiveBalanceConstraints, calculateOptimizationTradeoffBalance, detectObjectiveOverfitting } from './plannerObjectiveConstraints';
+import { calculateObjectiveContributionBreakdown, calculatePlannerObjectiveMetrics, calculateUnifiedPlannerObjectiveScore, deriveObjectiveOptimizationSummary } from './plannerObjectiveScoring';
+import type { ObjectiveMode, PlannerObjectiveEvaluation, PlannerObjectiveProfile } from './plannerObjectiveTypes';
+
+export const evaluatePlannerObjectives = (params: {
+  weeklyMeals: Record<string, any>;
+  weekDays: readonly string[];
+  mealTypes: readonly string[];
+  mode: ObjectiveMode;
+  proteinGoal?: number;
+  profileOverrides?: Partial<PlannerObjectiveProfile>;
+  baselineWeeklyMeals?: Record<string, any>;
+}): PlannerObjectiveEvaluation => {
+  const profile = derivePlannerObjectiveProfile(params.mode, params.profileOverrides);
+  const normalizedProfile = normalizeObjectiveWeights(profile);
+  const constrainedProfile = applyObjectiveBalanceConstraints(normalizedProfile);
+  const metrics = calculatePlannerObjectiveMetrics(params.weeklyMeals, params.weekDays, params.mealTypes, params.proteinGoal || 0);
+  const baseline = params.baselineWeeklyMeals
+    ? calculatePlannerObjectiveMetrics(params.baselineWeeklyMeals, params.weekDays, params.mealTypes, params.proteinGoal || 0)
+    : undefined;
+  const contributions = calculateObjectiveContributionBreakdown(metrics, constrainedProfile, baseline);
+  const score = calculateUnifiedPlannerObjectiveScore(metrics, constrainedProfile);
+  const overfittingSignals = detectObjectiveOverfitting(metrics);
+  const tradeoffBalance = calculateOptimizationTradeoffBalance(metrics);
+  return { profile, normalizedProfile, constrainedProfile, score, metrics, contributions, overfittingSignals, tradeoffBalance };
+};
+
+export const summarizeObjectiveImprovements = (beforeMeals: Record<string, any>, afterMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[], mode: ObjectiveMode, proteinGoal = 0) => {
+  const before = evaluatePlannerObjectives({ weeklyMeals: beforeMeals, weekDays, mealTypes, mode, proteinGoal });
+  const after = evaluatePlannerObjectives({ weeklyMeals: afterMeals, weekDays, mealTypes, mode, proteinGoal, baselineWeeklyMeals: beforeMeals });
+  return {
+    before,
+    after,
+    summary: deriveObjectiveOptimizationSummary(before.metrics, after.metrics),
+  };
+};

--- a/client/src/components/meal-planner/planner-objectives/plannerObjectiveInsights.ts
+++ b/client/src/components/meal-planner/planner-objectives/plannerObjectiveInsights.ts
@@ -1,0 +1,16 @@
+import type { ObjectiveContribution, PlannerObjectiveMetrics } from './plannerObjectiveTypes';
+
+export const formatObjectiveDeltaInsight = (key: string, delta: number) => {
+  if (Math.abs(delta) < 2) return `${key} stable`;
+  return `${key} ${delta > 0 ? 'improved' : 'declined'} by ${Math.abs(Math.round(delta))}%`;
+};
+
+export const deriveObjectiveContributionChips = (contributions: ObjectiveContribution[]) => contributions
+  .slice(0, 6)
+  .map((contribution) => `${contribution.key} +${Math.round(contribution.weightedScore)}`);
+
+export const deriveObjectiveOptimizationSummary = (before: PlannerObjectiveMetrics, after: PlannerObjectiveMetrics) => {
+  return (Object.keys(after) as Array<keyof PlannerObjectiveMetrics>)
+    .map((key) => formatObjectiveDeltaInsight(key, after[key] - before[key]))
+    .slice(0, 8);
+};

--- a/client/src/components/meal-planner/planner-objectives/plannerObjectiveProfiles.ts
+++ b/client/src/components/meal-planner/planner-objectives/plannerObjectiveProfiles.ts
@@ -1,0 +1,46 @@
+import type { ObjectiveMode, PlannerObjectiveProfile } from './plannerObjectiveTypes';
+
+const BALANCED_PROFILE: PlannerObjectiveProfile = {
+  continuity: 1,
+  variety: 1,
+  fatigue: 1,
+  prepEfficiency: 1,
+  groceryEfficiency: 1,
+  freshnessTiming: 1,
+  recoverySpacing: 1,
+  readiness: 1,
+  planningCompleteness: 1,
+  momentum: 1,
+  pantryReuse: 1,
+  macroQuality: 1,
+  temporalFlow: 1,
+};
+
+const MODE_MULTIPLIERS: Record<ObjectiveMode, Partial<PlannerObjectiveProfile>> = {
+  balanced: {},
+  'high-protein': { macroQuality: 1.5, readiness: 1.2 },
+  'budget-friendly': { groceryEfficiency: 1.35, pantryReuse: 1.25 },
+  'minimal-prep': { prepEfficiency: 1.45, fatigue: 1.2, recoverySpacing: 1.15 },
+  'pantry-reuse': { pantryReuse: 1.5, groceryEfficiency: 1.2, freshnessTiming: 0.9 },
+  'variety-focused': { variety: 1.5, fatigue: 1.25, continuity: 0.9 },
+  'grocery-efficient': { groceryEfficiency: 1.5, freshnessTiming: 1.2, pantryReuse: 1.2 },
+  'recovery-focused': { recoverySpacing: 1.5, fatigue: 1.25, temporalFlow: 1.2 },
+};
+
+export const normalizeObjectiveWeights = (profile: PlannerObjectiveProfile): PlannerObjectiveProfile => {
+  const total = Object.values(profile).reduce((sum, value) => sum + Math.max(0, value), 0) || 1;
+  return Object.fromEntries(Object.entries(profile).map(([key, value]) => [key, Math.max(0, value) / total])) as PlannerObjectiveProfile;
+};
+
+export const deriveAdaptiveObjectiveWeights = (mode: ObjectiveMode, overrides?: Partial<PlannerObjectiveProfile>) => {
+  const multipliers = MODE_MULTIPLIERS[mode] || {};
+  const profile = { ...BALANCED_PROFILE };
+  (Object.keys(profile) as Array<keyof PlannerObjectiveProfile>).forEach((key) => {
+    profile[key] = profile[key] * (multipliers[key] || 1) * (overrides?.[key] || 1);
+  });
+  return normalizeObjectiveWeights(profile);
+};
+
+export const derivePlannerObjectiveProfile = (mode: ObjectiveMode, overrides?: Partial<PlannerObjectiveProfile>) => {
+  return deriveAdaptiveObjectiveWeights(mode, overrides);
+};

--- a/client/src/components/meal-planner/planner-objectives/plannerObjectiveScoring.ts
+++ b/client/src/components/meal-planner/planner-objectives/plannerObjectiveScoring.ts
@@ -1,0 +1,60 @@
+import { calculateWeeklyScores } from '../auto-planner/autoPlannerScoring';
+import { calculateRelationshipEfficiencyScore } from '../meal-relationships/relationshipGraph';
+import { scoreRelationshipDrivenWeek } from '../meal-relationships/relationshipDrivenPlanning';
+import { calculateRecoverySpacing, analyzeWeeklyVarietyRhythm } from '../auto-planner/autoPlannerTradeoffAnalysis';
+import { calculateWeeklyPlannerStress, calculateGroceryFragmentation, calculateIngredientOverlapScore, calculatePantryReuseEfficiency, calculateMealFatigueScore } from '../auto-planner/autoPlannerOptimizationEngine';
+import { calculateFreshnessFlowScore, calculateTemporalFlowScore } from '../auto-planner/autoPlannerRhythmEngine';
+import { getMealsForSlot } from '../planner-graph/plannerGraphUtils';
+import type { ObjectiveContribution, PlannerObjectiveMetrics, PlannerObjectiveProfile } from './plannerObjectiveTypes';
+
+const clamp = (v: number) => Math.max(0, Math.min(100, Math.round(v)));
+const gatherMeals = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => weekDays.flatMap((d) => mealTypes.flatMap((m) => getMealsForSlot(weeklyMeals, d, m))).filter(Boolean);
+
+export const calculatePlannerObjectiveMetrics = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[], proteinGoal = 0): PlannerObjectiveMetrics => {
+  const meals = gatherMeals(weeklyMeals, weekDays, mealTypes);
+  const relationshipGraph = calculateRelationshipEfficiencyScore(weeklyMeals);
+  const relationshipWeek = scoreRelationshipDrivenWeek(weeklyMeals, weekDays, mealTypes);
+  const weeklyScores = calculateWeeklyScores(weeklyMeals, weekDays, mealTypes, proteinGoal);
+  const freshnessFlow = calculateFreshnessFlowScore(weeklyMeals, weekDays, mealTypes);
+  const temporalFlow = calculateTemporalFlowScore(weeklyMeals, weekDays, mealTypes);
+  const completeness = weekDays.length * mealTypes.length ? (meals.length / (weekDays.length * mealTypes.length)) * 100 : 0;
+  return {
+    continuity: clamp((relationshipGraph.continuityScore * 0.6) + (relationshipWeek.continuityScore * 0.4)),
+    variety: clamp(analyzeWeeklyVarietyRhythm(weeklyMeals, weekDays, mealTypes)),
+    fatigue: clamp(100 - calculateMealFatigueScore(meals)),
+    prepEfficiency: clamp(100 - Math.min(100, calculateWeeklyPlannerStress(weeklyMeals, weekDays, mealTypes) * 5)),
+    groceryEfficiency: clamp(100 - calculateGroceryFragmentation(meals)),
+    freshnessTiming: clamp(freshnessFlow),
+    recoverySpacing: clamp(calculateRecoverySpacing(weeklyMeals, weekDays, mealTypes)),
+    readiness: clamp(weeklyScores.readinessScore),
+    planningCompleteness: clamp(completeness),
+    momentum: clamp(calculateIngredientOverlapScore(meals)),
+    pantryReuse: clamp(calculatePantryReuseEfficiency(meals)),
+    macroQuality: clamp(weeklyScores.proteinCoverageScore),
+    temporalFlow: clamp(temporalFlow),
+  };
+};
+
+export const calculateObjectiveContributionBreakdown = (metrics: PlannerObjectiveMetrics, profile: PlannerObjectiveProfile, baseline?: PlannerObjectiveMetrics): ObjectiveContribution[] => (
+  (Object.keys(profile) as Array<keyof PlannerObjectiveProfile>).map((key) => ({
+    key,
+    weight: profile[key],
+    value: metrics[key],
+    weightedScore: metrics[key] * profile[key],
+    deltaFromBaseline: baseline ? metrics[key] - baseline[key] : undefined,
+  })).sort((a, b) => b.weightedScore - a.weightedScore)
+);
+
+export const calculateUnifiedPlannerObjectiveScore = (metrics: PlannerObjectiveMetrics, profile: PlannerObjectiveProfile) => {
+  const score = Object.keys(profile).reduce((sum, key) => sum + (metrics[key as keyof PlannerObjectiveProfile] * profile[key as keyof PlannerObjectiveProfile]), 0);
+  return clamp(score);
+};
+
+export const deriveObjectiveOptimizationSummary = (before: PlannerObjectiveMetrics, after: PlannerObjectiveMetrics) => {
+  const deltas = Object.keys(after).map((key) => ({ key, delta: after[key as keyof PlannerObjectiveMetrics] - before[key as keyof PlannerObjectiveMetrics] }));
+  return deltas
+    .filter((d) => Math.abs(d.delta) >= 3)
+    .sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta))
+    .slice(0, 5)
+    .map((d) => `${d.key} ${d.delta >= 0 ? '+' : ''}${Math.round(d.delta)}`);
+};

--- a/client/src/components/meal-planner/planner-objectives/plannerObjectiveTypes.ts
+++ b/client/src/components/meal-planner/planner-objectives/plannerObjectiveTypes.ts
@@ -1,0 +1,41 @@
+import type { AutoPlannerMode } from '../auto-planner/autoPlannerTypes';
+
+export type PlannerObjectiveKey =
+  | 'continuity'
+  | 'variety'
+  | 'fatigue'
+  | 'prepEfficiency'
+  | 'groceryEfficiency'
+  | 'freshnessTiming'
+  | 'recoverySpacing'
+  | 'readiness'
+  | 'planningCompleteness'
+  | 'momentum'
+  | 'pantryReuse'
+  | 'macroQuality'
+  | 'temporalFlow';
+
+export type PlannerObjectiveProfile = Record<PlannerObjectiveKey, number>;
+
+export type ObjectiveMode = AutoPlannerMode | 'balanced';
+
+export type PlannerObjectiveMetrics = Record<PlannerObjectiveKey, number>;
+
+export type ObjectiveContribution = {
+  key: PlannerObjectiveKey;
+  weight: number;
+  value: number;
+  weightedScore: number;
+  deltaFromBaseline?: number;
+};
+
+export type PlannerObjectiveEvaluation = {
+  profile: PlannerObjectiveProfile;
+  normalizedProfile: PlannerObjectiveProfile;
+  constrainedProfile: PlannerObjectiveProfile;
+  score: number;
+  metrics: PlannerObjectiveMetrics;
+  contributions: ObjectiveContribution[];
+  overfittingSignals: string[];
+  tradeoffBalance: number;
+};


### PR DESCRIPTION
### Motivation
- Centralize disparate planner scoring into a single, reusable objective model to make optimization semantics consistent across engines.  
- Preserve existing planner behavior and all current optimization subsystems while enabling a single “planner brain” for orchestration.  
- Provide objective-aware visibility and balance guardrails so the planner can explain tradeoffs and avoid pathological single-objective overfitting.  

### Description
- Introduced a new `planner-objectives` subsystem (`client/src/components/meal-planner/planner-objectives/`) with types and model (`plannerObjectiveTypes.ts`), mode profiles and normalization (`plannerObjectiveProfiles.ts`), balance/overfitting constraints (`plannerObjectiveConstraints.ts`), metric aggregation and unified scoring (`plannerObjectiveScoring.ts`), human-friendly insight helpers (`plannerObjectiveInsights.ts`), and an orchestration entrypoint (`plannerObjectiveEngine.ts`).  
- Reused existing planner metrics (relationship graph, rhythm/freshness, prep stress, grocery fragmentation, readiness, macro scores, etc.) to compute a 13-dimension objective metric set and a single unified objective score (`calculatePlannerObjectiveMetrics`, `calculateUnifiedPlannerObjectiveScore`).  
- Integrated the unified objective into core optimization paths while retaining legacy blends for compatibility by blending unified and legacy scores in `autoPlannerOptimizationEngine.ts`, `autoPlannerTradeoffAnalysis.ts`, and `autoPlannerWeekOptimizer.ts`.  
- Made relationship-driven candidate ranking objective-aware (`relationshipDrivenPlanning.ts`) and surfaced objective explanations and breakdown chips in the Smart Auto-Plan generation flow (`autoPlannerEngine.ts`) without changing UI architecture.  

### Testing
- Ran `npm run build:client` and the client build completed successfully.  
- Ran `npm run build:server` and the server build completed successfully.  
- Ran targeted TypeScript checks (`npx tsc --noEmit` against the new planner-objectives and modified planner optimization modules) and they passed with no targeted errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fa46fb7508325a52b6f4e98ded48d)