### PR TITLE
Add adaptive nutrition personality modeling to meal planner adaptation

### DIFF
--- a/client/src/components/meal-planner/personality-modeling/boredomModeling.ts
+++ b/client/src/components/meal-planner/personality-modeling/boredomModeling.ts
@@ -1,0 +1,37 @@
+import type { LongitudinalPlanningSnapshot } from '../planner-adaptation/adaptationTypes';
+import type { BoredomProfile } from './personalityTypes';
+
+const clamp = (v: number, min = 0, max = 1) => Math.max(min, Math.min(max, v));
+
+export const deriveVarietyTolerance = (history: LongitudinalPlanningSnapshot[]) => {
+  if (!history.length) return 0.5;
+  const averageRepetition = history.reduce((sum, entry) => sum + entry.repeatedMeals, 0) / history.length;
+  const repetitionLoad = clamp(averageRepetition / 8);
+  const continuitySupport = clamp(history.reduce((sum, entry) => sum + entry.continuityScore, 0) / history.length);
+  return clamp((1 - repetitionLoad) * 0.6 + continuitySupport * 0.4);
+};
+
+export const deriveRepetitionStability = (history: LongitudinalPlanningSnapshot[]) => {
+  if (history.length < 2) return 0.5;
+  const sorted = [...history].slice(-8);
+  const firstHalf = sorted.slice(0, Math.floor(sorted.length / 2));
+  const secondHalf = sorted.slice(Math.floor(sorted.length / 2));
+  const avg = (items: LongitudinalPlanningSnapshot[]) => items.reduce((sum, item) => sum + item.repeatedMeals, 0) / Math.max(1, items.length);
+  const delta = Math.abs(avg(secondHalf) - avg(firstHalf));
+  return clamp(1 - delta / 6);
+};
+
+export const detectContinuityFatigue = (history: LongitudinalPlanningSnapshot[]) => {
+  if (!history.length) return 0;
+  const fatigueCoupling = history.reduce((sum, entry) => sum + (entry.continuityScore * entry.lateWeekDropoff), 0) / history.length;
+  return clamp(fatigueCoupling);
+};
+
+export const calculateMealBoredomRisk = (history: LongitudinalPlanningSnapshot[]): BoredomProfile => {
+  const varietyTolerance = deriveVarietyTolerance(history);
+  const repetitionStability = deriveRepetitionStability(history);
+  const continuityFatigueRisk = detectContinuityFatigue(history);
+  const textureFatigueRisk = clamp((1 - repetitionStability) * 0.65 + continuityFatigueRisk * 0.35);
+  const flavorFatigueRisk = clamp((1 - varietyTolerance) * 0.7 + continuityFatigueRisk * 0.3);
+  return { varietyTolerance, repetitionStability, continuityFatigueRisk, textureFatigueRisk, flavorFatigueRisk };
+};

--- a/client/src/components/meal-planner/personality-modeling/cookingIdentity.ts
+++ b/client/src/components/meal-planner/personality-modeling/cookingIdentity.ts
@@ -1,0 +1,23 @@
+import type { LongitudinalPlanningSnapshot } from '../planner-adaptation/adaptationTypes';
+import type { CookingIdentityProfile } from './personalityTypes';
+
+const clamp = (v: number, min = 0, max = 1) => Math.max(min, Math.min(max, v));
+
+export const calculateCookingEngagement = (history: LongitudinalPlanningSnapshot[]) => {
+  if (!history.length) return 0.5;
+  return clamp(history.reduce((sum, entry) => sum + ((entry.prepCompletionRate + entry.readinessAverage) / 2), 0) / history.length);
+};
+
+export const detectPrepResistancePatterns = (history: LongitudinalPlanningSnapshot[]) => {
+  if (!history.length) return 0.5;
+  return clamp(history.reduce((sum, entry) => sum + (entry.complexityLoad * (1 - entry.prepCompletionRate)), 0) / history.length);
+};
+
+export const deriveCookingIdentityProfile = (history: LongitudinalPlanningSnapshot[]): CookingIdentityProfile => {
+  const cookingEngagement = calculateCookingEngagement(history);
+  const prepResistance = detectPrepResistancePatterns(history);
+  const weeknightComplexityTolerance = clamp(1 - prepResistance);
+  const weekendPrepEnthusiasm = clamp(cookingEngagement * 0.7 + (1 - history.reduce((sum, entry) => sum + entry.lateWeekDropoff, 0) / Math.max(1, history.length)) * 0.3);
+  const modularMealPreference = clamp((1 - prepResistance) * 0.5 + history.reduce((sum, entry) => sum + entry.continuityScore, 0) / Math.max(1, history.length) * 0.5);
+  return { cookingEngagement, prepResistance, weeknightComplexityTolerance, weekendPrepEnthusiasm, modularMealPreference };
+};

--- a/client/src/components/meal-planner/personality-modeling/nutritionPersonality.ts
+++ b/client/src/components/meal-planner/personality-modeling/nutritionPersonality.ts
@@ -1,0 +1,57 @@
+import type { LongitudinalPlanningSnapshot } from '../planner-adaptation/adaptationTypes';
+import { calculateMealBoredomRisk } from './boredomModeling';
+import { deriveCookingIdentityProfile } from './cookingIdentity';
+import { deriveRecoveryMealPatterns } from './recoveryPatterns';
+import { deriveScheduleVolatilityProfile } from './scheduleVolatility';
+import type { AdaptiveNutritionIdentity, MealTypeAdherencePattern, NutritionPersonalityProfile } from './personalityTypes';
+
+const clamp = (v: number, min = 0, max = 1) => Math.max(min, Math.min(max, v));
+
+export const deriveBehavioralMealPreferences = (history: LongitudinalPlanningSnapshot[]): MealTypeAdherencePattern => {
+  if (!history.length) return { breakfast: 0.5, lunch: 0.5, dinner: 0.5 };
+  const adherence = history.reduce((sum, entry) => sum + entry.completedMeals / Math.max(1, entry.completedMeals + entry.skippedMeals), 0) / history.length;
+  return {
+    breakfast: clamp(adherence * 0.95 + 0.05),
+    lunch: clamp(adherence),
+    dinner: clamp(adherence - history.reduce((sum, entry) => sum + entry.lateWeekDropoff, 0) / history.length * 0.2),
+  };
+};
+
+export const deriveRoutineStabilityProfile = (history: LongitudinalPlanningSnapshot[]) => {
+  if (!history.length) return 0.5;
+  const continuity = history.reduce((sum, entry) => sum + entry.continuityScore, 0) / history.length;
+  const dropoffPenalty = history.reduce((sum, entry) => sum + entry.lateWeekDropoff, 0) / history.length;
+  return clamp(continuity * 0.7 + (1 - dropoffPenalty) * 0.3);
+};
+
+export const deriveNutritionPersonalityProfile = (history: LongitudinalPlanningSnapshot[]): NutritionPersonalityProfile => {
+  const mealTypeAdherence = deriveBehavioralMealPreferences(history);
+  const routineStability = deriveRoutineStabilityProfile(history);
+  const prepHeavyDinnerFatigue = clamp(history.reduce((sum, entry) => sum + (entry.complexityLoad * entry.lateWeekDropoff), 0) / Math.max(1, history.length));
+  return {
+    repetitiveBreakfastPreference: clamp(routineStability * mealTypeAdherence.breakfast),
+    lunchContinuitySuccess: clamp(mealTypeAdherence.lunch * routineStability),
+    prepHeavyDinnerFatigue,
+    comfortRecoveryTendency: clamp(history.reduce((sum, entry) => sum + entry.fatigueAverage, 0) / Math.max(1, history.length)),
+    lateWeekCookingAdherence: clamp(1 - history.reduce((sum, entry) => sum + entry.lateWeekDropoff, 0) / Math.max(1, history.length)),
+    shoppingConsistency: clamp(history.reduce((sum, entry) => sum + entry.groceryCompletionRate, 0) / Math.max(1, history.length)),
+    mealTypeAdherence,
+  };
+};
+
+export const buildAdaptiveNutritionIdentity = (history: LongitudinalPlanningSnapshot[]): AdaptiveNutritionIdentity => {
+  const historyWindowUsed = history.slice(-12);
+  const personality = deriveNutritionPersonalityProfile(historyWindowUsed);
+  const boredom = calculateMealBoredomRisk(historyWindowUsed);
+  const cookingIdentity = deriveCookingIdentityProfile(historyWindowUsed);
+  const scheduleVolatility = deriveScheduleVolatilityProfile(historyWindowUsed);
+  const recoveryComfort = deriveRecoveryMealPatterns(historyWindowUsed);
+  const adaptivePreferenceMemory = [
+    { key: 'breakfast-continuity', score: personality.repetitiveBreakfastPreference, observedAt: new Date().toISOString() },
+    { key: 'dinner-fatigue-risk', score: personality.prepHeavyDinnerFatigue, observedAt: new Date().toISOString() },
+    { key: 'comfort-recovery', score: recoveryComfort.recoveryMealTendency, observedAt: new Date().toISOString() },
+    { key: 'variety-tolerance', score: boredom.varietyTolerance, observedAt: new Date().toISOString() },
+  ].slice(-16);
+
+  return { personality, boredom, cookingIdentity, scheduleVolatility, recoveryComfort, adaptivePreferenceMemory, historyWindowUsed };
+};

--- a/client/src/components/meal-planner/personality-modeling/personalityObjectiveAdjustments.ts
+++ b/client/src/components/meal-planner/personality-modeling/personalityObjectiveAdjustments.ts
@@ -1,0 +1,30 @@
+import type { BehavioralOptimizationAdjustments } from '../planner-adaptation/adaptationTypes';
+import type { AdaptiveNutritionIdentity } from './personalityTypes';
+
+const clamp = (v: number, min = 0.7, max = 1.35) => Math.max(min, Math.min(max, v));
+
+export const derivePersonalityObjectiveAdjustments = (identity: AdaptiveNutritionIdentity): BehavioralOptimizationAdjustments => {
+  const dinnerFatigue = identity.personality.prepHeavyDinnerFatigue;
+  const boredomRisk = identity.boredom.continuityFatigueRisk;
+  const volatility = identity.scheduleVolatility.scheduleVolatility;
+  const recoveryStrength = identity.recoveryComfort.fallbackMealEffectiveness;
+
+  return {
+    prepComplexityMultiplier: clamp(1 - dinnerFatigue * 0.3),
+    continuityMultiplier: clamp(1 + (identity.personality.lunchContinuitySuccess - boredomRisk) * 0.2),
+    temporalIntensityMultiplier: clamp(1 - volatility * 0.25),
+    readinessBalanceBias: clamp(1 + recoveryStrength * 0.1, 0.8, 1.2),
+    failedChainPenalty: clamp(1 - (boredomRisk * 0.15), 0.75, 1.2),
+  };
+};
+
+export const derivePersonalityRecommendations = (identity: AdaptiveNutritionIdentity): string[] => {
+  const notes: string[] = [];
+  if (identity.personality.repetitiveBreakfastPreference > 0.65) notes.push('Breakfast continuity remains a strong adherence anchor.');
+  if (identity.boredom.textureFatigueRisk > 0.55) notes.push('Rotating dinner textures improved completion stability.');
+  if (identity.personality.prepHeavyDinnerFatigue > 0.55) notes.push('Prep-heavy Wednesday dinners continue reducing completion consistency.');
+  if (identity.cookingIdentity.weekendPrepEnthusiasm > 0.6) notes.push('Weekend prep enthusiasm remains high.');
+  if (identity.scheduleVolatility.volatilePlanningZones.includes('friday')) notes.push('Low-effort Friday meals improved sustainability.');
+  notes.push(...identity.recoveryComfort.comfortMealStabilizers);
+  return notes.slice(0, 10);
+};

--- a/client/src/components/meal-planner/personality-modeling/personalityTypes.ts
+++ b/client/src/components/meal-planner/personality-modeling/personalityTypes.ts
@@ -1,0 +1,53 @@
+import type { LongitudinalPlanningSnapshot } from '../planner-adaptation/adaptationTypes';
+
+export type MealTypeAdherencePattern = Record<string, number>;
+
+export type NutritionPersonalityProfile = {
+  repetitiveBreakfastPreference: number;
+  lunchContinuitySuccess: number;
+  prepHeavyDinnerFatigue: number;
+  comfortRecoveryTendency: number;
+  lateWeekCookingAdherence: number;
+  shoppingConsistency: number;
+  mealTypeAdherence: MealTypeAdherencePattern;
+};
+
+export type BoredomProfile = {
+  varietyTolerance: number;
+  repetitionStability: number;
+  continuityFatigueRisk: number;
+  textureFatigueRisk: number;
+  flavorFatigueRisk: number;
+};
+
+export type CookingIdentityProfile = {
+  cookingEngagement: number;
+  prepResistance: number;
+  weeknightComplexityTolerance: number;
+  weekendPrepEnthusiasm: number;
+  modularMealPreference: number;
+};
+
+export type ScheduleVolatilityProfile = {
+  weeklyStabilityMap: Record<string, number>;
+  volatilePlanningZones: string[];
+  scheduleVolatility: number;
+  sundayResetStrength: number;
+};
+
+export type RecoveryComfortProfile = {
+  recoveryMealTendency: number;
+  comfortMealStabilizers: string[];
+  fallbackMealEffectiveness: number;
+  lowEnergyFallbackBias: number;
+};
+
+export type AdaptiveNutritionIdentity = {
+  personality: NutritionPersonalityProfile;
+  boredom: BoredomProfile;
+  cookingIdentity: CookingIdentityProfile;
+  scheduleVolatility: ScheduleVolatilityProfile;
+  recoveryComfort: RecoveryComfortProfile;
+  adaptivePreferenceMemory: Array<{ key: string; score: number; observedAt: string }>;
+  historyWindowUsed: LongitudinalPlanningSnapshot[];
+};

--- a/client/src/components/meal-planner/personality-modeling/recoveryPatterns.ts
+++ b/client/src/components/meal-planner/personality-modeling/recoveryPatterns.ts
@@ -1,0 +1,28 @@
+import type { LongitudinalPlanningSnapshot } from '../planner-adaptation/adaptationTypes';
+import type { RecoveryComfortProfile } from './personalityTypes';
+
+const clamp = (v: number, min = 0, max = 1) => Math.max(min, Math.min(max, v));
+
+export const calculateFallbackMealEffectiveness = (history: LongitudinalPlanningSnapshot[]) => {
+  if (!history.length) return 0.5;
+  const rescueSignal = history.reduce((sum, entry) => sum + (entry.lateWeekDropoff > 0.4 ? entry.completedMeals / Math.max(1, entry.completedMeals + entry.skippedMeals) : 0), 0) / history.length;
+  return clamp(rescueSignal);
+};
+
+export const detectComfortMealStabilizers = (history: LongitudinalPlanningSnapshot[]) => {
+  const stabilizers: string[] = [];
+  const fallbackEffectiveness = calculateFallbackMealEffectiveness(history);
+  if (fallbackEffectiveness > 0.55) stabilizers.push('Comfort-style bowl meals improved late-week adherence.');
+  const continuity = history.reduce((sum, entry) => sum + entry.continuityScore, 0) / Math.max(1, history.length);
+  if (continuity > 0.6) stabilizers.push('Recovery-friendly continuity is stabilizing lower-energy days.');
+  if (!stabilizers.length) stabilizers.push('Low-effort fallback meals remain a useful recovery anchor.');
+  return stabilizers;
+};
+
+export const deriveRecoveryMealPatterns = (history: LongitudinalPlanningSnapshot[]): RecoveryComfortProfile => {
+  const fallbackMealEffectiveness = calculateFallbackMealEffectiveness(history);
+  const lowEnergyFallbackBias = clamp(history.reduce((sum, entry) => sum + (entry.fatigueAverage * entry.prepCompletionRate), 0) / Math.max(1, history.length));
+  const recoveryMealTendency = clamp((fallbackMealEffectiveness + lowEnergyFallbackBias) / 2);
+  const comfortMealStabilizers = detectComfortMealStabilizers(history);
+  return { recoveryMealTendency, comfortMealStabilizers, fallbackMealEffectiveness, lowEnergyFallbackBias };
+};

--- a/client/src/components/meal-planner/personality-modeling/scheduleVolatility.ts
+++ b/client/src/components/meal-planner/personality-modeling/scheduleVolatility.ts
@@ -1,0 +1,27 @@
+import type { LongitudinalPlanningSnapshot } from '../planner-adaptation/adaptationTypes';
+import type { ScheduleVolatilityProfile } from './personalityTypes';
+
+const clamp = (v: number, min = 0, max = 1) => Math.max(min, Math.min(max, v));
+
+const dayOrder = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+
+export const calculateWeeklyStabilityMap = (history: LongitudinalPlanningSnapshot[]) => {
+  const baseStability = clamp(1 - history.reduce((sum, entry) => sum + entry.lateWeekDropoff, 0) / Math.max(1, history.length));
+  return dayOrder.reduce<Record<string, number>>((acc, day, idx) => {
+    const lateWeekPenalty = idx >= 4 ? 0.15 : 0;
+    const midWeekVolatility = day === 'wednesday' ? 0.1 : 0;
+    acc[day] = clamp(baseStability - lateWeekPenalty - midWeekVolatility);
+    return acc;
+  }, {});
+};
+
+export const detectVolatilePlanningZones = (stabilityMap: Record<string, number>) =>
+  Object.entries(stabilityMap).filter(([, stability]) => stability < 0.55).map(([day]) => day);
+
+export const deriveScheduleVolatilityProfile = (history: LongitudinalPlanningSnapshot[]): ScheduleVolatilityProfile => {
+  const weeklyStabilityMap = calculateWeeklyStabilityMap(history);
+  const volatilePlanningZones = detectVolatilePlanningZones(weeklyStabilityMap);
+  const scheduleVolatility = clamp(1 - Object.values(weeklyStabilityMap).reduce((sum, value) => sum + value, 0) / dayOrder.length);
+  const sundayResetStrength = weeklyStabilityMap.sunday || 0.5;
+  return { weeklyStabilityMap, volatilePlanningZones, scheduleVolatility, sundayResetStrength };
+};

--- a/client/src/components/meal-planner/planner-adaptation/adaptationTypes.ts
+++ b/client/src/components/meal-planner/planner-adaptation/adaptationTypes.ts
@@ -1,3 +1,5 @@
+import type { AdaptiveNutritionIdentity } from '../personality-modeling/personalityTypes';
+
 export type LongitudinalPlanningSnapshot = {
   id: string;
   createdAt: string;
@@ -68,4 +70,5 @@ export type AdaptivePlannerProfile = {
   sustainability: SustainabilityProfile;
   relationshipLearning: RelationshipLearningProfile;
   recommendations: string[];
+  nutritionPersonality?: AdaptiveNutritionIdentity;
 };

--- a/client/src/components/meal-planner/planner-adaptation/adaptivePlanningProfiles.ts
+++ b/client/src/components/meal-planner/planner-adaptation/adaptivePlanningProfiles.ts
@@ -3,6 +3,25 @@ import { derivePlannerHistoryProfile } from './longitudinalHistory';
 import { deriveAdaptiveBehaviorSignals, deriveBehavioralOptimizationAdjustments } from './behavioralAdaptation';
 import { deriveSustainablePlanningProfile } from './sustainabilityEngine';
 import { deriveRelationshipLearningProfile } from './adaptiveRelationshipLearning';
+import { buildAdaptiveNutritionIdentity } from '../personality-modeling/nutritionPersonality';
+import { derivePersonalityObjectiveAdjustments, derivePersonalityRecommendations } from '../personality-modeling/personalityObjectiveAdjustments';
+
+
+const PERSONALITY_STORAGE_KEY = 'mealPlanner.nutritionPersonality.v1';
+const PERSONALITY_MEMORY_LIMIT = 24;
+
+const persistNutritionPersonalityMemory = (recommendations: string[], observedAt: string) => {
+  if (typeof window === 'undefined') return;
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(PERSONALITY_STORAGE_KEY) || '[]');
+    const safe = Array.isArray(parsed) ? parsed : [];
+    const next = [...safe, ...recommendations.map((message) => ({ message, observedAt }))].slice(-PERSONALITY_MEMORY_LIMIT);
+    window.localStorage.setItem(PERSONALITY_STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // no-op: storage failures should not affect planner behavior
+  }
+};
+
 
 export const deriveAdaptivePlannerProfile = (history: LongitudinalPlanningSnapshot[]): AdaptivePlannerProfile => {
   const historyProfile = derivePlannerHistoryProfile(history);
@@ -10,6 +29,8 @@ export const deriveAdaptivePlannerProfile = (history: LongitudinalPlanningSnapsh
   const behaviorAdjustments = deriveBehavioralOptimizationAdjustments(historyProfile);
   const sustainability = deriveSustainablePlanningProfile(history);
   const relationshipLearning = deriveRelationshipLearningProfile(history);
+  const nutritionPersonality = buildAdaptiveNutritionIdentity(history);
+  const personalityAdjustments = derivePersonalityObjectiveAdjustments(nutritionPersonality);
 
   const recommendations: string[] = [];
   if (behaviorSignals.reducePrepComplexity) recommendations.push('Lower prep complexity improved adherence in recent planning cycles.');
@@ -19,13 +40,23 @@ export const deriveAdaptivePlannerProfile = (history: LongitudinalPlanningSnapsh
   if (relationshipLearning.successRate > 0.65) recommendations.push('Batch-prep chains are improving grocery completion consistency.');
   recommendations.push(...sustainability.unsustainablePatterns);
   recommendations.push(...relationshipLearning.breakdownPatterns);
+  recommendations.push(...derivePersonalityRecommendations(nutritionPersonality));
+  persistNutritionPersonalityMemory(recommendations, new Date().toISOString());
 
   return {
     history: historyProfile,
     behaviorSignals,
-    behaviorAdjustments,
+    behaviorAdjustments: {
+      ...behaviorAdjustments,
+      prepComplexityMultiplier: behaviorAdjustments.prepComplexityMultiplier * personalityAdjustments.prepComplexityMultiplier,
+      continuityMultiplier: behaviorAdjustments.continuityMultiplier * personalityAdjustments.continuityMultiplier,
+      temporalIntensityMultiplier: behaviorAdjustments.temporalIntensityMultiplier * personalityAdjustments.temporalIntensityMultiplier,
+      readinessBalanceBias: behaviorAdjustments.readinessBalanceBias * personalityAdjustments.readinessBalanceBias,
+      failedChainPenalty: behaviorAdjustments.failedChainPenalty * personalityAdjustments.failedChainPenalty,
+    },
     sustainability,
     relationshipLearning,
     recommendations,
+    nutritionPersonality,
   };
 };


### PR DESCRIPTION
### Motivation
- Evolve the planner from an operational-only optimization engine toward a lightweight, human-aware adaptive nutrition behavior layer that models boredom, cooking identity, schedule volatility, and recovery/comfort without changing core planner architecture.
- Keep changes additive and frontend-only so existing Smart Auto-Plan, drag/drop workflows, longitudinal adaptation, objective engine, relationship-driven generation, and grocery/prep intelligence remain intact.

### Description
- Added a new `personality-modeling` module under `client/src/components/meal-planner/personality-modeling/` with typed helpers: `personalityTypes.ts`, `nutritionPersonality.ts`, `boredomModeling.ts`, `cookingIdentity.ts`, `scheduleVolatility.ts`, `recoveryPatterns.ts`, and `personalityObjectiveAdjustments.ts` that derive bounded personality signals from longitudinal snapshots.
- Implemented `buildAdaptiveNutritionIdentity()` and helpers (`deriveNutritionPersonalityProfile()`, `deriveBehavioralMealPreferences()`, `deriveRoutineStabilityProfile()`, `calculateMealBoredomRisk()`, `deriveCookingIdentityProfile()`, `deriveScheduleVolatilityProfile()`, `deriveRecoveryMealPatterns()`, and `derivePersonalityObjectiveAdjustments()`) that produce a small `AdaptiveNutritionIdentity` envelope and personality-aware recommendation strings.
- Integrated personality modeling into the adaptation pipeline by augmenting `deriveAdaptivePlannerProfile()` to compute `nutritionPersonality`, generate personality-aware recommendations, persist a bounded frontend-only recommendation memory (`localStorage` key `mealPlanner.nutritionPersonality.v1`), and multiply personality-derived multipliers into the existing `behaviorAdjustments` (preserving original logic as baseline).
- Updated types to expose `nutritionPersonality?: AdaptiveNutritionIdentity` on `AdaptivePlannerProfile` and ensured all additions are additive with no backend schema changes or invasive UI rewrites.

### Testing
- Ran `npm run build:client` which completed successfully (Vite build). 
- Ran `npm run build:server` which completed successfully (esbuild server bundle). 
- Ran targeted TypeScript checks with `npx tsc --noEmit` for the new personality modules and related adaptation/objective/auto-planner modules which succeeded with no new type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fb4d004748325beeddbb20f66deda)