### PR TITLE
Create Neon-ready adaptive planner persistence contracts

### DIFF
--- a/client/src/components/meal-planner/planner-adaptation/adaptivePersistenceAdapter.ts
+++ b/client/src/components/meal-planner/planner-adaptation/adaptivePersistenceAdapter.ts
@@ -1,0 +1,110 @@
+import type {
+  AdaptiveNutritionPersonalityMemoryRecord,
+  AdaptivePlannerPersistenceSnapshot,
+  PlannerObjectiveHistoryRecord,
+  RelationshipLearningHistoryRecord,
+} from './adaptivePersistenceTypes';
+import { ADAPTIVE_PLANNER_STORAGE_KEYS } from './adaptivePersistenceTypes';
+import type { LongitudinalPlanningSnapshot } from './adaptationTypes';
+
+const MAX_LONGITUDINAL_HISTORY = 12;
+const MAX_PERSONALITY_MEMORY = 24;
+
+const readJsonArray = <T>(key: string): T[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(key) || '[]');
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch {
+    return [];
+  }
+};
+
+const writeJsonArray = <T>(key: string, value: T[]) => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // no-op: persistence failures should not affect planner behavior
+  }
+};
+
+export type AdaptivePlannerPersistenceAdapter = {
+  getLongitudinalSnapshots: () => LongitudinalPlanningSnapshot[];
+  putLongitudinalSnapshot: (snapshot: LongitudinalPlanningSnapshot) => void;
+  getNutritionPersonalityMemory: () => AdaptiveNutritionPersonalityMemoryRecord[];
+  appendNutritionPersonalityMemory: (records: AdaptiveNutritionPersonalityMemoryRecord[]) => void;
+  // TODO(neon-api): add getAdaptivePlannerProfile and putAdaptivePlannerProfile endpoints.
+  // TODO(neon-api): add getObjectiveHistory and putObjectiveHistory endpoints.
+  // TODO(neon-api): add getRelationshipLearningHistory and putRelationshipLearningHistory endpoints.
+  getObjectiveHistory: () => PlannerObjectiveHistoryRecord[];
+  putObjectiveHistory: (_records: PlannerObjectiveHistoryRecord[]) => void;
+  getRelationshipLearningHistory: () => RelationshipLearningHistoryRecord[];
+  putRelationshipLearningHistory: (_records: RelationshipLearningHistoryRecord[]) => void;
+  getSnapshot: () => AdaptivePlannerPersistenceSnapshot;
+};
+
+export const createLocalAdaptivePlannerPersistenceAdapter = (): AdaptivePlannerPersistenceAdapter => ({
+  getLongitudinalSnapshots: () => readJsonArray<LongitudinalPlanningSnapshot>(ADAPTIVE_PLANNER_STORAGE_KEYS.longitudinalSnapshots).slice(-MAX_LONGITUDINAL_HISTORY),
+  putLongitudinalSnapshot: (snapshot) => {
+    const current = readJsonArray<LongitudinalPlanningSnapshot>(ADAPTIVE_PLANNER_STORAGE_KEYS.longitudinalSnapshots);
+    const next = [...current.filter((entry) => entry.weekKey !== snapshot.weekKey), snapshot].slice(-MAX_LONGITUDINAL_HISTORY);
+    writeJsonArray(ADAPTIVE_PLANNER_STORAGE_KEYS.longitudinalSnapshots, next);
+  },
+  getNutritionPersonalityMemory: () => {
+    const records = readJsonArray<AdaptiveNutritionPersonalityMemoryRecord | { message: string; observedAt: string }>(ADAPTIVE_PLANNER_STORAGE_KEYS.nutritionPersonalityMemory).slice(-MAX_PERSONALITY_MEMORY);
+    return records.map((record) => ({ id: 'id' in record ? record.id : `${record.observedAt}-${record.message}`, observedAt: record.observedAt, message: record.message }));
+  },
+  appendNutritionPersonalityMemory: (records) => {
+    const current = readJsonArray<AdaptiveNutritionPersonalityMemoryRecord | { message: string; observedAt: string }>(ADAPTIVE_PLANNER_STORAGE_KEYS.nutritionPersonalityMemory);
+    const normalizedCurrent = current.map((record) => ({ id: 'id' in record ? record.id : `${record.observedAt}-${record.message}`, observedAt: record.observedAt, message: record.message }));
+    writeJsonArray(ADAPTIVE_PLANNER_STORAGE_KEYS.nutritionPersonalityMemory, [...normalizedCurrent, ...records].slice(-MAX_PERSONALITY_MEMORY));
+  },
+  getObjectiveHistory: () => [],
+  putObjectiveHistory: () => {},
+  getRelationshipLearningHistory: () => [],
+  putRelationshipLearningHistory: () => {},
+  getSnapshot: () => ({
+    profile: {
+      id: `adaptive-profile-${new Date().toISOString()}`,
+      observedAt: new Date().toISOString(),
+      profileVersion: 'v1',
+      objectiveHistory: [],
+      relationshipLearningHistory: [],
+    },
+    longitudinalSnapshots: readJsonArray<LongitudinalPlanningSnapshot>(ADAPTIVE_PLANNER_STORAGE_KEYS.longitudinalSnapshots).slice(-MAX_LONGITUDINAL_HISTORY),
+    nutritionPersonalityMemory: readJsonArray<AdaptiveNutritionPersonalityMemoryRecord | { message: string; observedAt: string }>(ADAPTIVE_PLANNER_STORAGE_KEYS.nutritionPersonalityMemory)
+      .slice(-MAX_PERSONALITY_MEMORY)
+      .map((record) => ({ id: 'id' in record ? record.id : `${record.observedAt}-${record.message}`, observedAt: record.observedAt, message: record.message })),
+  }),
+});
+
+export const createNeonAdaptivePlannerPersistenceAdapter = (): AdaptivePlannerPersistenceAdapter => ({
+  // TODO(neon-api): implement GET /api/adaptive-planner/snapshots.
+  getLongitudinalSnapshots: () => [],
+  // TODO(neon-api): implement POST /api/adaptive-planner/snapshots.
+  putLongitudinalSnapshot: () => {},
+  // TODO(neon-api): implement GET /api/adaptive-planner/nutrition-personality-memory.
+  getNutritionPersonalityMemory: () => [],
+  // TODO(neon-api): implement POST /api/adaptive-planner/nutrition-personality-memory.
+  appendNutritionPersonalityMemory: () => {},
+  // TODO(neon-api): implement GET /api/adaptive-planner/objective-history.
+  getObjectiveHistory: () => [],
+  // TODO(neon-api): implement POST /api/adaptive-planner/objective-history.
+  putObjectiveHistory: () => {},
+  // TODO(neon-api): implement GET /api/adaptive-planner/relationship-history.
+  getRelationshipLearningHistory: () => [],
+  // TODO(neon-api): implement POST /api/adaptive-planner/relationship-history.
+  putRelationshipLearningHistory: () => {},
+  getSnapshot: () => ({
+    profile: {
+      id: 'adaptive-profile-neon-placeholder',
+      observedAt: new Date().toISOString(),
+      profileVersion: 'v1',
+      objectiveHistory: [],
+      relationshipLearningHistory: [],
+    },
+    longitudinalSnapshots: [],
+    nutritionPersonalityMemory: [],
+  }),
+});

--- a/client/src/components/meal-planner/planner-adaptation/adaptivePersistenceTypes.ts
+++ b/client/src/components/meal-planner/planner-adaptation/adaptivePersistenceTypes.ts
@@ -1,0 +1,47 @@
+import type { AdaptiveNutritionIdentity } from '../personality-modeling/personalityTypes';
+import type { LongitudinalPlanningSnapshot } from './adaptationTypes';
+
+export const ADAPTIVE_PLANNER_STORAGE_KEYS = {
+  longitudinalSnapshots: 'mealPlanner.longitudinalHistory.v1',
+  nutritionPersonalityMemory: 'mealPlanner.nutritionPersonality.v1',
+} as const;
+
+export type PlannerObjectiveHistoryRecord = {
+  id: string;
+  observedAt: string;
+  objectiveKey: string;
+  message: string;
+  source: 'objective' | 'recommendation' | 'personality';
+  scoreDelta?: number;
+};
+
+export type RelationshipLearningHistoryRecord = {
+  id: string;
+  observedAt: string;
+  weekKey?: string;
+  successfulChains: number;
+  abandonedChains: number;
+  successRate: number;
+  notes: string[];
+};
+
+export type AdaptiveNutritionPersonalityMemoryRecord = {
+  id: string;
+  observedAt: string;
+  message: string;
+};
+
+export type AdaptivePlannerProfileSnapshot = {
+  id: string;
+  observedAt: string;
+  profileVersion: 'v1';
+  nutritionPersonality?: AdaptiveNutritionIdentity;
+  objectiveHistory: PlannerObjectiveHistoryRecord[];
+  relationshipLearningHistory: RelationshipLearningHistoryRecord[];
+};
+
+export type AdaptivePlannerPersistenceSnapshot = {
+  profile: AdaptivePlannerProfileSnapshot;
+  longitudinalSnapshots: LongitudinalPlanningSnapshot[];
+  nutritionPersonalityMemory: AdaptiveNutritionPersonalityMemoryRecord[];
+};

--- a/client/src/components/meal-planner/planner-adaptation/adaptivePlanningProfiles.ts
+++ b/client/src/components/meal-planner/planner-adaptation/adaptivePlanningProfiles.ts
@@ -5,23 +5,7 @@ import { deriveSustainablePlanningProfile } from './sustainabilityEngine';
 import { deriveRelationshipLearningProfile } from './adaptiveRelationshipLearning';
 import { buildAdaptiveNutritionIdentity } from '../personality-modeling/nutritionPersonality';
 import { derivePersonalityObjectiveAdjustments, derivePersonalityRecommendations } from '../personality-modeling/personalityObjectiveAdjustments';
-
-
-const PERSONALITY_STORAGE_KEY = 'mealPlanner.nutritionPersonality.v1';
-const PERSONALITY_MEMORY_LIMIT = 24;
-
-const persistNutritionPersonalityMemory = (recommendations: string[], observedAt: string) => {
-  if (typeof window === 'undefined') return;
-  try {
-    const parsed = JSON.parse(window.localStorage.getItem(PERSONALITY_STORAGE_KEY) || '[]');
-    const safe = Array.isArray(parsed) ? parsed : [];
-    const next = [...safe, ...recommendations.map((message) => ({ message, observedAt }))].slice(-PERSONALITY_MEMORY_LIMIT);
-    window.localStorage.setItem(PERSONALITY_STORAGE_KEY, JSON.stringify(next));
-  } catch {
-    // no-op: storage failures should not affect planner behavior
-  }
-};
-
+import { appendNutritionPersonalityMemory } from './localAdaptivePlannerStore';
 
 export const deriveAdaptivePlannerProfile = (history: LongitudinalPlanningSnapshot[]): AdaptivePlannerProfile => {
   const historyProfile = derivePlannerHistoryProfile(history);
@@ -41,7 +25,12 @@ export const deriveAdaptivePlannerProfile = (history: LongitudinalPlanningSnapsh
   recommendations.push(...sustainability.unsustainablePatterns);
   recommendations.push(...relationshipLearning.breakdownPatterns);
   recommendations.push(...derivePersonalityRecommendations(nutritionPersonality));
-  persistNutritionPersonalityMemory(recommendations, new Date().toISOString());
+  const observedAt = new Date().toISOString();
+  appendNutritionPersonalityMemory(recommendations.map((message) => ({
+    id: `${observedAt}-${message}`,
+    observedAt,
+    message,
+  })));
 
   return {
     history: historyProfile,

--- a/client/src/components/meal-planner/planner-adaptation/localAdaptivePlannerStore.ts
+++ b/client/src/components/meal-planner/planner-adaptation/localAdaptivePlannerStore.ts
@@ -1,0 +1,22 @@
+import {
+  createLocalAdaptivePlannerPersistenceAdapter,
+  type AdaptivePlannerPersistenceAdapter,
+} from './adaptivePersistenceAdapter';
+import type { AdaptiveNutritionPersonalityMemoryRecord } from './adaptivePersistenceTypes';
+import type { LongitudinalPlanningSnapshot } from './adaptationTypes';
+
+const localAdaptivePlannerStore: AdaptivePlannerPersistenceAdapter = createLocalAdaptivePlannerPersistenceAdapter();
+
+export const readLongitudinalPlanningHistory = (): LongitudinalPlanningSnapshot[] => localAdaptivePlannerStore.getLongitudinalSnapshots();
+
+export const writeLongitudinalPlanningSnapshot = (snapshot: LongitudinalPlanningSnapshot) => {
+  localAdaptivePlannerStore.putLongitudinalSnapshot(snapshot);
+};
+
+export const appendNutritionPersonalityMemory = (records: AdaptiveNutritionPersonalityMemoryRecord[]) => {
+  localAdaptivePlannerStore.appendNutritionPersonalityMemory(records);
+};
+
+export const readNutritionPersonalityMemory = (): AdaptiveNutritionPersonalityMemoryRecord[] => (
+  localAdaptivePlannerStore.getNutritionPersonalityMemory()
+);

--- a/client/src/components/meal-planner/planner-adaptation/longitudinalHistory.ts
+++ b/client/src/components/meal-planner/planner-adaptation/longitudinalHistory.ts
@@ -1,25 +1,12 @@
 import { type LongitudinalPlanningSnapshot, type PlannerHistoryProfile } from './adaptationTypes';
-
-const STORAGE_KEY = 'mealPlanner.longitudinalHistory.v1';
-const MAX_HISTORY = 12;
+import { readLongitudinalPlanningHistory, writeLongitudinalPlanningSnapshot } from './localAdaptivePlannerStore';
 
 const clamp = (v: number, min = 0, max = 1) => Math.max(min, Math.min(max, v));
 
-export const buildLongitudinalPlanningHistory = (): LongitudinalPlanningSnapshot[] => {
-  if (typeof window === 'undefined') return [];
-  try {
-    const parsed = JSON.parse(window.localStorage.getItem(STORAGE_KEY) || '[]');
-    return Array.isArray(parsed) ? parsed.slice(-MAX_HISTORY) : [];
-  } catch {
-    return [];
-  }
-};
+export const buildLongitudinalPlanningHistory = (): LongitudinalPlanningSnapshot[] => readLongitudinalPlanningHistory();
 
 export const persistLongitudinalPlanningSnapshot = (snapshot: LongitudinalPlanningSnapshot) => {
-  if (typeof window === 'undefined') return;
-  const current = buildLongitudinalPlanningHistory();
-  const next = [...current.filter((entry) => entry.weekKey !== snapshot.weekKey), snapshot].slice(-MAX_HISTORY);
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  writeLongitudinalPlanningSnapshot(snapshot);
 };
 
 export const calculateHistoricalAdherence = (history: LongitudinalPlanningSnapshot[]) => {


### PR DESCRIPTION
### Motivation
- Prepare the adaptive planner for durable Neon/Postgres persistence by introducing clear shared types and an adapter boundary while keeping existing localStorage behavior as the runtime fallback.
- Make the planner’s longitudinal history, nutrition personality memory, objective history, and relationship-learning history first-class, normalized contracts to simplify future backend migration.
- Keep changes additive and non-destructive so current planner behavior and keys remain unchanged.

### Description
- Added normalized persistence types and storage key constants in `client/src/components/meal-planner/planner-adaptation/adaptivePersistenceTypes.ts` including `AdaptivePlannerPersistenceSnapshot`, `AdaptivePlannerProfileSnapshot`, `PlannerObjectiveHistoryRecord`, `RelationshipLearningHistoryRecord`, and `AdaptiveNutritionPersonalityMemoryRecord`.
- Introduced an adapter boundary `AdaptivePlannerPersistenceAdapter` and two constructors in `client/src/components/meal-planner/planner-adaptation/adaptivePersistenceAdapter.ts` with a concrete localStorage-backed implementation and a placeholder `createNeonAdaptivePlannerPersistenceAdapter` containing explicit `TODO(neon-api)` comments for future endpoints.
- Added a small wrapper `localAdaptivePlannerStore.ts` at `client/src/components/meal-planner/planner-adaptation/localAdaptivePlannerStore.ts` that exposes `readLongitudinalPlanningHistory`, `writeLongitudinalPlanningSnapshot`, `appendNutritionPersonalityMemory`, and `readNutritionPersonalityMemory` and wires code to the local adapter.
- Refactored existing modules to use the adapter boundary instead of direct `window.localStorage` access: `longitudinalHistory.ts` now delegates to `localAdaptivePlannerStore`, and `adaptivePlanningProfiles.ts` appends personality memory via the adapter; existing storage keys (`mealPlanner.longitudinalHistory.v1` and `mealPlanner.nutritionPersonality.v1`) and max-window semantics are preserved.
- All backend-facing behavior is only scaffolded via `TODO` comments; no fake or auto-migrated server endpoints were introduced and no destructive migrations were added.

### Testing
- Built the client with `npm run build:client` and the build completed successfully (Vite produced bundles). 
- Built the server with `npm run build:server` and the server bundle completed successfully (esbuild produced `server/dist/index.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10bb4f0e40832589d0f098e621a25d)