### PR TITLE
Nutrition Planner: add campaign experience foundation (UI + engine + persistence)

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -45,6 +45,9 @@ import { derivePrepSessions } from '@/components/meal-planner/prepOrchestrationU
 import { deriveNutritionCoachInsights } from '@/components/meal-planner/nutritionCoachUtils';
 import { optimizeWeeklyPlan } from '@/components/meal-planner/auto-planner/autoPlannerEngine';
 import NutritionCoachPanel from '@/components/meal-planner/coach/NutritionCoachPanel';
+import NutritionCampaignPanel from '@/components/meal-planner/campaigns/NutritionCampaignPanel';
+import { evaluateCampaignProgress } from '@/components/meal-planner/campaigns/nutritionCampaignEngine';
+import { loadActiveCampaignState, saveActiveCampaignState } from '@/components/meal-planner/campaigns/nutritionCampaignProgress';
 import {
   LineChart,
   Line,
@@ -332,6 +335,8 @@ const NutritionMealPlanner = () => {
   const [isPremium, setIsPremium] = useState(false);
   const [loading, setLoading] = useState(true);
   const [weeklyMeals, setWeeklyMeals] = useState<Record<string, any>>({});
+  const [activeCampaignId, setActiveCampaignId] = useState<string | null>(null);
+  const [activeCampaignStartedAt, setActiveCampaignStartedAt] = useState<string | null>(null);
   const [showAddMealModal, setShowAddMealModal] = useState(false);
   const [showGoalsModal, setShowGoalsModal] = useState(false);
   const [selectedMealSlot, setSelectedMealSlot] = useState<{day: string, type: string} | null>(null);
@@ -2546,6 +2551,31 @@ const NutritionMealPlanner = () => {
     [prepSession.generatedPrepTaskCompletions, weeklyMeals],
   );
   const generatedPrepProgress = prepOrchestration.summary.completionPercent;
+  const plannedBreakfasts = useMemo(
+    () => weekDays.reduce((sum, day) => sum + getMealSlotItems(weeklyMeals, day, 'breakfast').length, 0),
+    [weekDays, weeklyMeals],
+  );
+  const prepTasksCompleted = useMemo(
+    () => prepSession.tasks.filter((task) => task.done).length + Object.values(prepSession.generatedPrepTaskCompletions || {}).filter(Boolean).length,
+    [prepSession.generatedPrepTaskCompletions, prepSession.tasks],
+  );
+  const pantryIngredientsUsed = useMemo(
+    () => Math.min(10, groceryList.filter((item: any) => item?.isPantryItem && item?.completed).length),
+    [groceryList],
+  );
+  const leftoverFriendlyMeals = useMemo(() => {
+    const matches = ['leftover', 'batch', 'reuse', 'repurpose'];
+    let count = 0;
+    weekDays.forEach((day) => {
+      mealTypes.forEach((type) => {
+        const items = getMealSlotItems(weeklyMeals, day, type);
+        count += items.filter((item: any) => matches.some((token) => String(item?.name || '').toLowerCase().includes(token))).length;
+      });
+    });
+    return count;
+  }, [mealTypes, weekDays, weeklyMeals]);
+  const semanticVarietyScore = Math.round((nutritionCoachAnalysis?.scoreBreakdown?.variety ?? 70) as number);
+  const prepOverloadReduction = Math.max(0, Math.round((prepOrchestration.summary.readinessScore || 0) - (prepActiveBlockersCount * 10)));
   const blendedPrepProgress = Math.max(prepProgress, generatedPrepProgress);
   const prepRecommendationsAvailable = plannedSlots > 0;
   const prepPlanMissing = plannedSlots > 0 && !prepSessionPlanned && !prepSessionCompleted;
@@ -3727,6 +3757,32 @@ const NutritionMealPlanner = () => {
     streak.currentStreak,
   ]);
   const visibleCoachInsights = nutritionCoachAnalysis.insights.filter((insight) => !dismissedCoachInsightIds.includes(insight.id));
+  useEffect(() => {
+    const state = loadActiveCampaignState(user?.id);
+    if (state) {
+      setActiveCampaignId(state.campaignId);
+      setActiveCampaignStartedAt(state.startedAt);
+    }
+  }, [user?.id]);
+
+  useEffect(() => {
+    if (!activeCampaignId || !activeCampaignStartedAt) return;
+    saveActiveCampaignState({ campaignId: activeCampaignId, startedAt: activeCampaignStartedAt }, user?.id);
+  }, [activeCampaignId, activeCampaignStartedAt, user?.id]);
+
+  const activeCampaignProgress = useMemo(() => {
+    if (!activeCampaignId || !activeCampaignStartedAt) return null;
+    return evaluateCampaignProgress(activeCampaignId, {
+      plannedBreakfasts,
+      prepTasksCompleted,
+      groceryItemsResolved: groceryCompletedCount,
+      pantryIngredientsUsed,
+      leftoverFriendlyMeals,
+      proteinGoalDays: proteinGoalHitDays,
+      semanticVarietyScore,
+      prepOverloadReduction,
+    }, activeCampaignStartedAt);
+  }, [activeCampaignId, activeCampaignStartedAt, plannedBreakfasts, prepTasksCompleted, groceryCompletedCount, pantryIngredientsUsed, leftoverFriendlyMeals, proteinGoalHitDays, semanticVarietyScore, prepOverloadReduction]);
   const handleDismissCoachInsight = (insightId: string) => {
     setDismissedCoachInsightIds((prev) => prev.includes(insightId) ? prev : [...prev, insightId]);
   };
@@ -5181,6 +5237,19 @@ const NutritionMealPlanner = () => {
                 onOpenPlanner={() => setActiveTab('planner')}
                 onOpenGrocery={() => setActiveTab('grocery')}
                 onOpenPrep={() => setActiveTab('prep')}
+              />
+              <NutritionCampaignPanel
+                activeCampaignId={activeCampaignId}
+                progress={activeCampaignProgress}
+                onActivateCampaign={(campaignId) => {
+                  setActiveCampaignId(campaignId);
+                  setActiveCampaignStartedAt(new Date().toISOString());
+                }}
+                onClearCampaign={() => {
+                  setActiveCampaignId(null);
+                  setActiveCampaignStartedAt(null);
+                  saveActiveCampaignState(null, user?.id);
+                }}
               />
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
               <Card>

--- a/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
+++ b/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Trophy, Sparkles } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { Badge } from '@/components/ui/badge';
+import { NUTRITION_CAMPAIGN_CATALOG } from '@/components/meal-planner/campaigns/nutritionCampaignCatalog';
+import { NutritionCampaignProgress } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+
+type Props = {
+  activeCampaignId: string | null;
+  progress: NutritionCampaignProgress | null;
+  onActivateCampaign: (campaignId: string) => void;
+  onClearCampaign: () => void;
+};
+
+const NutritionCampaignPanel: React.FC<Props> = ({ activeCampaignId, progress, onActivateCampaign, onClearCampaign }) => {
+  const activeCampaign = NUTRITION_CAMPAIGN_CATALOG.find((item) => item.id === activeCampaignId) || null;
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2"><Trophy className="w-5 h-5 text-emerald-600" /> Nutrition Campaign Journey</CardTitle>
+          <CardDescription>Guided weekly planning missions layered on top of your existing planner intelligence.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {activeCampaign && progress ? (
+            <div className="space-y-4">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <p className="font-semibold">{activeCampaign.title}</p>
+                  <p className="text-sm text-gray-600">{activeCampaign.narrative}</p>
+                </div>
+                <Badge variant="secondary">{progress.completedMissions}/{progress.totalMissions} missions</Badge>
+              </div>
+              <Progress value={progress.completionPct} />
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {progress.missionProgress.map((item) => (
+                  <div key={item.mission.id} className="rounded-lg border p-3">
+                    <p className="text-sm font-medium">{item.mission.title}</p>
+                    <p className="text-xs text-gray-600">{item.mission.description}</p>
+                    <p className="text-xs mt-1">{item.value}/{item.target}</p>
+                    <Progress value={item.progressPct} className="mt-2" />
+                  </div>
+                ))}
+              </div>
+              {progress.complete && (
+                <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800 flex items-start gap-2">
+                  <Sparkles className="w-4 h-4 mt-0.5" />
+                  <span>{activeCampaign.rewardCopy}</span>
+                </div>
+              )}
+              <Button variant="outline" size="sm" onClick={onClearCampaign}>End Active Campaign</Button>
+            </div>
+          ) : (
+            <p className="text-sm text-gray-600">Choose a campaign to start a guided nutrition journey.</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Suggested Campaigns</CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {NUTRITION_CAMPAIGN_CATALOG.map((campaign) => (
+            <div key={campaign.id} className="rounded-lg border p-3">
+              <div className="flex items-center justify-between gap-2">
+                <p className="font-medium text-sm">{campaign.title}</p>
+                <Badge variant="outline">{campaign.durationDays} days</Badge>
+              </div>
+              <p className="text-xs text-gray-600 mt-1">{campaign.description}</p>
+              <Button className="mt-3" size="sm" variant={activeCampaignId === campaign.id ? 'secondary' : 'default'} onClick={() => onActivateCampaign(campaign.id)}>
+                {activeCampaignId === campaign.id ? 'Active' : 'Start Campaign'}
+              </Button>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default NutritionCampaignPanel;

--- a/client/src/components/meal-planner/campaigns/nutritionCampaignCatalog.ts
+++ b/client/src/components/meal-planner/campaigns/nutritionCampaignCatalog.ts
@@ -1,0 +1,101 @@
+import { NutritionCampaignDefinition } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+
+export const NUTRITION_CAMPAIGN_CATALOG: NutritionCampaignDefinition[] = [
+  {
+    id: 'meal-prep-reset-7-day',
+    title: '7-Day Meal Prep Reset',
+    description: 'Rebuild weekly momentum with a prep-first rhythm.',
+    durationDays: 7,
+    theme: 'meal-prep',
+    narrative: 'Build confidence by stabilizing prep touchpoints and reducing decision fatigue.',
+    goals: ['Prep consistency', 'Weekly readiness', 'Reduced prep overload'],
+    missions: [
+      { id: 'prep-3', title: 'Complete 3 prep tasks', description: 'Finish at least 3 prep mission tasks this week.', metric: 'prep_tasks_completed', target: 3 },
+      { id: 'breakfast-5', title: 'Plan 5 breakfasts', description: 'Set a consistent morning baseline.', metric: 'planned_breakfasts', target: 5 },
+      { id: 'reduce-overload', title: 'Reduce prep overload', description: 'Improve overload management by at least 20 points.', metric: 'prep_overload_reduction', target: 20 },
+    ],
+    progressRules: [
+      { metric: 'prep_tasks_completed', description: 'Tracks checked prep session tasks and generated prep completions.' },
+      { metric: 'prep_overload_reduction', description: 'Uses readiness + prep blockage trend to estimate overload reduction.' },
+    ],
+    rewardCopy: 'Reset complete. Your planning system is now mission-ready for next week.',
+    plannerIntegrationSignals: ['prep orchestration', 'readiness score', 'weekly meals'],
+  },
+  {
+    id: 'protein-consistency-week',
+    title: 'Protein Consistency Week',
+    description: 'Build predictable protein coverage across the week.',
+    durationDays: 7,
+    theme: 'protein',
+    narrative: 'Move from occasional high-protein days to a sustained daily pattern.',
+    goals: ['Protein coverage', 'Breakfast anchor habits', 'Adherence consistency'],
+    missions: [
+      { id: 'protein-days-4', title: 'Hit protein goal 4 days', description: 'Reach daily protein target on at least 4 days.', metric: 'protein_goal_days', target: 4 },
+      { id: 'breakfast-protein', title: 'Plan 5 breakfasts', description: 'Use breakfast as protein consistency anchor.', metric: 'planned_breakfasts', target: 5 },
+      { id: 'variety-65', title: 'Maintain semantic variety', description: 'Keep flavor and cuisine variety healthy.', metric: 'semantic_variety_score', target: 65 },
+    ],
+    progressRules: [
+      { metric: 'protein_goal_days', description: 'Uses nutrition coach daily protein goal coverage.' },
+      { metric: 'semantic_variety_score', description: 'Uses semantic objective variety score when available.' },
+    ],
+    rewardCopy: 'Consistency unlocked. Your protein pattern is now resilient and repeatable.',
+    plannerIntegrationSignals: ['nutrition coach scores', 'weekly meals', 'semantic intelligence'],
+  },
+  {
+    id: 'pantry-power-week',
+    title: 'Pantry Power Week',
+    description: 'Convert pantry inventory into high-leverage meals.',
+    durationDays: 7,
+    theme: 'pantry',
+    narrative: 'Turn what you already have into fewer grocery gaps and smoother prep.',
+    goals: ['Pantry utilization', 'Leftover intelligence', 'Waste reduction'],
+    missions: [
+      { id: 'pantry-use-3', title: 'Use 3 pantry ingredients', description: 'Prioritize pantry items in planned meals.', metric: 'pantry_ingredients_used', target: 3 },
+      { id: 'leftover-2', title: 'Create 2 leftover-friendly meals', description: 'Plan meals that intentionally create smart leftovers.', metric: 'leftover_friendly_meals', target: 2 },
+      { id: 'grocery-resolve-6', title: 'Resolve 6 grocery items', description: 'Close out pending shopping blockers.', metric: 'grocery_items_resolved', target: 6 },
+    ],
+    progressRules: [
+      { metric: 'pantry_ingredients_used', description: 'Tracks overlap between pantry-tagged groceries and planned meal ingredient names.' },
+      { metric: 'leftover_friendly_meals', description: 'Uses leftover chain indicators from meal names/notes.' },
+    ],
+    rewardCopy: 'Pantry mastery achieved. You turned inventory into planning advantage.',
+    plannerIntegrationSignals: ['grocery suggestions', 'pantry items', 'leftover-friendly meals'],
+  },
+  {
+    id: 'fresh-start-grocery-week', title: 'Fresh Start Grocery Week', description: 'Close grocery gaps fast and improve readiness.', durationDays: 7, theme: 'grocery',
+    narrative: 'Translate plan intent into stocked execution.', goals: ['Grocery completion','Readiness'],
+    missions: [
+      { id: 'groc6', title: 'Resolve 6 grocery items', description: 'Mark six pending items complete.', metric: 'grocery_items_resolved', target: 6 },
+      { id: 'prep3', title: 'Complete 3 prep tasks', description: 'Use fresh groceries in prep sessions.', metric: 'prep_tasks_completed', target: 3 },
+    ],
+    progressRules: [{ metric: 'grocery_items_resolved', description: 'Uses grocery list completion state.' }], rewardCopy: 'Fresh start achieved. Your week is stocked and actionable.', plannerIntegrationSignals: ['grocery suggestions','readiness score'],
+  },
+  {
+    id: 'recovery-comfort-week', title: 'Recovery & Comfort Week', description: 'Support recovery with lower-friction nutrition.', durationDays: 7, theme: 'recovery',
+    narrative: 'Focus on consistency, comfort, and manageable prep load.', goals: ['Sustainable adherence','Prep relief'],
+    missions: [
+      { id: 'protein3', title: 'Hit protein goal 3 days', description: 'Support recovery targets.', metric: 'protein_goal_days', target: 3 },
+      { id: 'overload15', title: 'Reduce prep overload', description: 'Lower prep pressure by 15 points.', metric: 'prep_overload_reduction', target: 15 },
+    ],
+    progressRules: [{ metric: 'prep_overload_reduction', description: 'Estimated from readiness and active blockers.' }], rewardCopy: 'Recovery rhythm set. You protected adherence with smart pacing.', plannerIntegrationSignals: ['nutrition coach scores','readiness'],
+  },
+  {
+    id: 'smart-leftovers-challenge', title: 'Smart Leftovers Challenge', description: 'Create chain-friendly meals that save effort.', durationDays: 7, theme: 'leftovers',
+    narrative: 'Use planned leftovers to compress prep and reduce waste.', goals: ['Leftover reuse','Pantry leverage'],
+    missions: [
+      { id: 'left2', title: 'Create 2 leftover-friendly meals', description: 'Plan at least two leftover-aware meals.', metric: 'leftover_friendly_meals', target: 2 },
+      { id: 'pantry2', title: 'Use 2 pantry ingredients', description: 'Blend pantry items into leftover flow.', metric: 'pantry_ingredients_used', target: 2 },
+    ],
+    progressRules: [{ metric: 'leftover_friendly_meals', description: 'Inferred from meal naming patterns and reuse signals.' }], rewardCopy: 'Challenge complete. Your leftovers now work like a strategy layer.', plannerIntegrationSignals: ['weekly meals','semantic intelligence'],
+  },
+  {
+    id: 'budget-friendly-nutrition-sprint', title: 'Budget-Friendly Nutrition Sprint', description: 'Hit nutrition targets while reducing shopping drag.', durationDays: 7, theme: 'budget',
+    narrative: 'Balance cost-awareness with mission-grade nutrition coverage.', goals: ['Budget adherence','Protein consistency','Pantry use'],
+    missions: [
+      { id: 'pantry3', title: 'Use 3 pantry ingredients', description: 'Prioritize ingredients already on hand.', metric: 'pantry_ingredients_used', target: 3 },
+      { id: 'protein3b', title: 'Hit protein goal 3 days', description: 'Maintain nutrition floor while budgeting.', metric: 'protein_goal_days', target: 3 },
+      { id: 'groc4', title: 'Resolve 4 grocery items', description: 'Finish critical grocery items only.', metric: 'grocery_items_resolved', target: 4 },
+    ],
+    progressRules: [{ metric: 'pantry_ingredients_used', description: 'Measures pantry-assisted meal coverage.' }], rewardCopy: 'Sprint complete. You proved affordability and nutrition can compound.', plannerIntegrationSignals: ['pantry items','grocery completion','nutrition coach'],
+  }
+];

--- a/client/src/components/meal-planner/campaigns/nutritionCampaignEngine.ts
+++ b/client/src/components/meal-planner/campaigns/nutritionCampaignEngine.ts
@@ -1,0 +1,54 @@
+import { NUTRITION_CAMPAIGN_CATALOG } from '@/components/meal-planner/campaigns/nutritionCampaignCatalog';
+import {
+  NutritionCampaignMissionMetric,
+  NutritionCampaignProgress,
+  NutritionCampaignSignals,
+} from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+
+const metricValue = (signals: NutritionCampaignSignals, metric: NutritionCampaignMissionMetric): number => {
+  switch (metric) {
+    case 'planned_breakfasts': return signals.plannedBreakfasts;
+    case 'prep_tasks_completed': return signals.prepTasksCompleted;
+    case 'grocery_items_resolved': return signals.groceryItemsResolved;
+    case 'pantry_ingredients_used': return signals.pantryIngredientsUsed;
+    case 'leftover_friendly_meals': return signals.leftoverFriendlyMeals;
+    case 'protein_goal_days': return signals.proteinGoalDays;
+    case 'semantic_variety_score': return signals.semanticVarietyScore;
+    case 'prep_overload_reduction': return signals.prepOverloadReduction;
+    default: return 0;
+  }
+};
+
+export const evaluateCampaignProgress = (
+  campaignId: string,
+  signals: NutritionCampaignSignals,
+  startedAt: string,
+): NutritionCampaignProgress | null => {
+  const campaign = NUTRITION_CAMPAIGN_CATALOG.find((item) => item.id === campaignId);
+  if (!campaign) return null;
+
+  const missionProgress = campaign.missions.map((mission) => {
+    const value = metricValue(signals, mission.metric);
+    const progressPct = Math.min(100, Math.round((value / mission.target) * 100));
+    return {
+      mission,
+      value,
+      target: mission.target,
+      progressPct,
+      completed: value >= mission.target,
+    };
+  });
+
+  const completedMissions = missionProgress.filter((mission) => mission.completed).length;
+  const completionPct = Math.round((completedMissions / campaign.missions.length) * 100);
+
+  return {
+    campaignId: campaign.id,
+    startedAt,
+    missionProgress,
+    completedMissions,
+    totalMissions: campaign.missions.length,
+    completionPct,
+    complete: completedMissions === campaign.missions.length,
+  };
+};

--- a/client/src/components/meal-planner/campaigns/nutritionCampaignProgress.ts
+++ b/client/src/components/meal-planner/campaigns/nutritionCampaignProgress.ts
@@ -1,0 +1,32 @@
+export type ActiveNutritionCampaignState = {
+  campaignId: string;
+  startedAt: string;
+};
+
+export const getCampaignStorageKey = (userId?: string | null) => `nutrition-campaign-active-v1:${userId || 'anon'}`;
+
+export const loadActiveCampaignState = (userId?: string | null): ActiveNutritionCampaignState | null => {
+  try {
+    const raw = localStorage.getItem(getCampaignStorageKey(userId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed?.campaignId || !parsed?.startedAt) return null;
+    return parsed;
+  } catch (error) {
+    console.error('Unable to load active nutrition campaign state:', error);
+    return null;
+  }
+};
+
+export const saveActiveCampaignState = (state: ActiveNutritionCampaignState | null, userId?: string | null) => {
+  try {
+    const key = getCampaignStorageKey(userId);
+    if (!state) {
+      localStorage.removeItem(key);
+      return;
+    }
+    localStorage.setItem(key, JSON.stringify(state));
+  } catch (error) {
+    console.error('Unable to save active nutrition campaign state:', error);
+  }
+};

--- a/client/src/components/meal-planner/campaigns/nutritionCampaignTypes.ts
+++ b/client/src/components/meal-planner/campaigns/nutritionCampaignTypes.ts
@@ -1,0 +1,74 @@
+export type NutritionCampaignTheme =
+  | 'meal-prep'
+  | 'protein'
+  | 'pantry'
+  | 'grocery'
+  | 'recovery'
+  | 'leftovers'
+  | 'budget';
+
+export type NutritionCampaignMissionMetric =
+  | 'planned_breakfasts'
+  | 'prep_tasks_completed'
+  | 'grocery_items_resolved'
+  | 'pantry_ingredients_used'
+  | 'leftover_friendly_meals'
+  | 'protein_goal_days'
+  | 'semantic_variety_score'
+  | 'prep_overload_reduction';
+
+export type NutritionCampaignMission = {
+  id: string;
+  title: string;
+  description: string;
+  metric: NutritionCampaignMissionMetric;
+  target: number;
+};
+
+export type NutritionCampaignProgressRule = {
+  metric: NutritionCampaignMissionMetric;
+  description: string;
+};
+
+export type NutritionCampaignDefinition = {
+  id: string;
+  title: string;
+  description: string;
+  durationDays: number;
+  theme: NutritionCampaignTheme;
+  narrative: string;
+  goals: string[];
+  missions: NutritionCampaignMission[];
+  progressRules: NutritionCampaignProgressRule[];
+  rewardCopy: string;
+  plannerIntegrationSignals: string[];
+};
+
+export type NutritionCampaignSignals = {
+  plannedBreakfasts: number;
+  prepTasksCompleted: number;
+  groceryItemsResolved: number;
+  pantryIngredientsUsed: number;
+  leftoverFriendlyMeals: number;
+  proteinGoalDays: number;
+  semanticVarietyScore: number;
+  prepOverloadReduction: number;
+};
+
+export type NutritionCampaignMissionProgress = {
+  mission: NutritionCampaignMission;
+  value: number;
+  target: number;
+  progressPct: number;
+  completed: boolean;
+};
+
+export type NutritionCampaignProgress = {
+  campaignId: string;
+  startedAt: string;
+  missionProgress: NutritionCampaignMissionProgress[];
+  completedMissions: number;
+  totalMissions: number;
+  completionPct: number;
+  complete: boolean;
+};


### PR DESCRIPTION
### Motivation
- Provide an additive campaign-style experience layer for the Nutrition Meal Planner to enable guided weekly programs, challenge flows, and mission-style progress without disturbing existing planner logic.
- Surface campaign progress and missions by reusing existing planner signals (meals, grocery, prep, readiness, nutrition coach, semantic intelligence) and persist active state locally for an MVP experience.
- Keep changes strictly additive, avoid modifying existing planner algorithms (no rewrites to `NutritionMealPlanner` core logic) and avoid backend schema changes.

### Description
- Added a new campaign foundation under `client/src/components/meal-planner/campaigns/` including typed contracts, a catalog, an engine, persistence utilities, and a panel UI: `nutritionCampaignTypes.ts`, `nutritionCampaignCatalog.ts`, `nutritionCampaignEngine.ts`, `nutritionCampaignProgress.ts`, and `NutritionCampaignPanel.tsx`.
- Implemented a campaign catalog with multiple 7-day examples (Meal Prep Reset, Protein Consistency Week, Pantry Power Week, Fresh Start Grocery Week, Recovery & Comfort, Smart Leftovers Challenge, Budget-Friendly Sprint) that include `id`, `title`, `description`, `durationDays`, `theme`, `goals`, `missions`, `progressRules`, `rewardCopy`, and `plannerIntegrationSignals`.
- Built a lightweight progress evaluator `evaluateCampaignProgress` that maps planner-derived signals to mission metrics and computes mission-level and campaign-level completion percentages using the new `NutritionCampaignSignals` type.
- Added localStorage-only active campaign persistence scoped per user (`getCampaignStorageKey` / `loadActiveCampaignState` / `saveActiveCampaignState`) with key format `nutrition-campaign-active-v1:<user|anon>` and integrated loading/saving in `NutritionMealPlanner` as an additive state (`activeCampaignId`, `activeCampaignStartedAt`).
- Integrated a mobile-friendly `NutritionCampaignPanel` into `NutritionMealPlanner` inside the **Analytics** tab below the `NutritionCoachPanel`, rendering active campaign progress, per-mission progress bars, celebration copy on completion, suggested campaign cards and controls to start/end a campaign; campaign signals are computed from existing planner data (planned breakfasts, prep task completions, grocery completion counts, pantry proxy, leftover detection, protein goal days, semantic variety fallback, prep-readiness proxy).
- Preserved all existing planner features (Smart Auto-Plan, AI Nutrition Coach, grocery/prep/readiness/analytics flows, adaptive planner persistence and semantic intelligence) and avoided any backend schema changes.

### Testing
- Ran `npm run build:client` and the production client build completed successfully (Vite build; warnings only about chunk sizes and unrelated dynamic imports). 
- Ran `npm run build:server` and the server build completed successfully (esbuild bundle created).
- No automated unit tests were added for this MVP; build outputs above were used to validate integration and that all new modules compile.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12163f4cb88325b6615cf087e22834)