### PR TITLE
Add adaptive campaign intelligence, mission scaling, narratives, and ranking

### DIFF
--- a/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
+++ b/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
@@ -6,15 +6,17 @@ import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
 import { NUTRITION_CAMPAIGN_CATALOG } from '@/components/meal-planner/campaigns/nutritionCampaignCatalog';
 import { NutritionCampaignProgress } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+import type { NutritionCampaignAdaptiveRecommendation } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
 
 type Props = {
   activeCampaignId: string | null;
   progress: NutritionCampaignProgress | null;
   onActivateCampaign: (campaignId: string) => void;
   onClearCampaign: () => void;
+  adaptiveRecommendationsByCampaignId?: Record<string, NutritionCampaignAdaptiveRecommendation>;
 };
 
-const NutritionCampaignPanel: React.FC<Props> = ({ activeCampaignId, progress, onActivateCampaign, onClearCampaign }) => {
+const NutritionCampaignPanel: React.FC<Props> = ({ activeCampaignId, progress, onActivateCampaign, onClearCampaign, adaptiveRecommendationsByCampaignId }) => {
   const activeCampaign = NUTRITION_CAMPAIGN_CATALOG.find((item) => item.id === activeCampaignId) || null;
 
   return (
@@ -31,6 +33,9 @@ const NutritionCampaignPanel: React.FC<Props> = ({ activeCampaignId, progress, o
                 <div>
                   <p className="font-semibold">{activeCampaign.title}</p>
                   <p className="text-sm text-gray-600">{activeCampaign.narrative}</p>
+                  {activeCampaignId && adaptiveRecommendationsByCampaignId?.[activeCampaignId]?.narrative && (
+                    <p className="text-xs text-emerald-700 mt-1">{adaptiveRecommendationsByCampaignId[activeCampaignId].narrative}</p>
+                  )}
                 </div>
                 <Badge variant="secondary">{progress.completedMissions}/{progress.totalMissions} missions</Badge>
               </div>
@@ -70,6 +75,14 @@ const NutritionCampaignPanel: React.FC<Props> = ({ activeCampaignId, progress, o
                 <p className="font-medium text-sm">{campaign.title}</p>
                 <Badge variant="outline">{campaign.durationDays} days</Badge>
               </div>
+              {adaptiveRecommendationsByCampaignId?.[campaign.id] && (
+                <div className="mt-2 flex flex-wrap gap-1">
+                  <Badge variant="secondary">Fit {adaptiveRecommendationsByCampaignId[campaign.id].fitScore}</Badge>
+                  {adaptiveRecommendationsByCampaignId[campaign.id].fitReasons.slice(0, 2).map((reason) => (
+                    <Badge key={`${campaign.id}-${reason}`} variant="outline" className="text-[10px]">{reason}</Badge>
+                  ))}
+                </div>
+              )}
               <p className="text-xs text-gray-600 mt-1">{campaign.description}</p>
               <Button className="mt-3" size="sm" variant={activeCampaignId === campaign.id ? 'secondary' : 'default'} onClick={() => onActivateCampaign(campaign.id)}>
                 {activeCampaignId === campaign.id ? 'Active' : 'Start Campaign'}

--- a/client/src/components/meal-planner/campaigns/adaptiveCampaignEngine.ts
+++ b/client/src/components/meal-planner/campaigns/adaptiveCampaignEngine.ts
@@ -1,0 +1,52 @@
+import { NUTRITION_CAMPAIGN_CATALOG } from '@/components/meal-planner/campaigns/nutritionCampaignCatalog';
+import type { NutritionCampaignDefinition, NutritionCampaignSignals } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+import type { AdaptiveNutritionIdentity } from '@/components/meal-planner/personality-modeling/personalityTypes';
+import { rankAdaptiveCampaigns } from './adaptiveCampaignRecommendations';
+import { deriveAdaptiveMissionTargets, deriveCampaignDifficulty, deriveCampaignIntensity, deriveCampaignPacing, type AdaptiveCampaignProfile } from './adaptiveCampaignScaling';
+import { deriveCampaignNarrative } from './adaptiveCampaignNarratives';
+
+export type AdaptiveCampaignContext = {
+  signals?: Partial<NutritionCampaignSignals>;
+  personality?: AdaptiveNutritionIdentity | null;
+  sustainabilityScore?: number;
+  readinessScore?: number;
+};
+
+export const deriveAdaptiveCampaignProfile = (context: AdaptiveCampaignContext): AdaptiveCampaignProfile => {
+  const personality = context.personality;
+  return {
+    prepTolerance: personality ? 1 - personality.personality.prepHeavyDinnerFatigue : 0.55,
+    continuitySuccess: personality ? (personality.personality.repetitiveBreakfastPreference * 0.45 + personality.personality.lunchContinuitySuccess * 0.55) : 0.55,
+    fatigueSensitivity: personality?.boredom.continuityFatigueRisk ?? 0.45,
+    volatilityLevel: personality?.scheduleVolatility.scheduleVolatility ?? 0.35,
+    adherenceStrength: personality ? (personality.recoveryComfort.fallbackMealEffectiveness * 0.5 + personality.personality.lateWeekCookingAdherence * 0.5) : 0.55,
+    sustainabilityScore: context.sustainabilityScore ?? 0.6,
+    readinessScore: context.readinessScore ?? 0.55,
+    semanticFatigue: context.signals?.semanticVarietyScore ? Math.max(0, (70 - context.signals.semanticVarietyScore) / 70) : 0.4,
+  };
+};
+
+export const deriveAdaptiveCampaignView = (context: AdaptiveCampaignContext): {
+  profile: AdaptiveCampaignProfile;
+  rankedCampaigns: Array<NutritionCampaignDefinition & { fitScore: number; fitReasons: string[] }>;
+  missionTargetsByCampaignId: Record<string, Record<string, number>>;
+  narrative: string;
+  pacing: ReturnType<typeof deriveCampaignPacing>;
+  difficulty: number;
+  intensity: ReturnType<typeof deriveCampaignIntensity>;
+} => {
+  const profile = deriveAdaptiveCampaignProfile(context);
+  const rankedCampaigns = rankAdaptiveCampaigns(NUTRITION_CAMPAIGN_CATALOG, profile);
+  const missionTargetsByCampaignId = Object.fromEntries(
+    NUTRITION_CAMPAIGN_CATALOG.map((campaign) => [campaign.id, deriveAdaptiveMissionTargets(campaign, profile)]),
+  );
+  return {
+    profile,
+    rankedCampaigns,
+    missionTargetsByCampaignId,
+    narrative: deriveCampaignNarrative(profile),
+    pacing: deriveCampaignPacing(profile),
+    difficulty: deriveCampaignDifficulty(profile),
+    intensity: deriveCampaignIntensity(profile),
+  };
+};

--- a/client/src/components/meal-planner/campaigns/adaptiveCampaignNarratives.ts
+++ b/client/src/components/meal-planner/campaigns/adaptiveCampaignNarratives.ts
@@ -1,0 +1,24 @@
+import type { AdaptiveCampaignProfile } from './adaptiveCampaignScaling';
+
+export const deriveCampaignRecoveryFocus = (profile: AdaptiveCampaignProfile): number => {
+  const instabilityLoad = profile.volatilityLevel * 0.45;
+  const fatigueLoad = profile.fatigueSensitivity * 0.35;
+  const prepStress = (1 - profile.prepTolerance) * 0.2;
+  return Math.min(1, Math.max(0, instabilityLoad + fatigueLoad + prepStress));
+};
+
+export const deriveCampaignMood = (profile: AdaptiveCampaignProfile): 'recovery' | 'stabilization' | 'momentum' | 'variety-refresh' => {
+  if (profile.semanticFatigue >= 0.65) return 'variety-refresh';
+  const recoveryFocus = deriveCampaignRecoveryFocus(profile);
+  if (recoveryFocus >= 0.68) return 'recovery';
+  if (profile.continuitySuccess >= 0.62 && profile.adherenceStrength >= 0.6) return 'momentum';
+  return 'stabilization';
+};
+
+export const deriveCampaignNarrative = (profile: AdaptiveCampaignProfile): string => {
+  const mood = deriveCampaignMood(profile);
+  if (mood === 'recovery') return 'Recovery-focused week';
+  if (mood === 'variety-refresh') return 'Semantic variety refresh';
+  if (mood === 'momentum') return profile.continuitySuccess > 0.72 ? 'Comfort continuity reset' : 'Low-friction sustainability sprint';
+  return profile.prepTolerance < 0.45 ? 'Low-friction sustainability sprint' : 'Fresh/light stabilization week';
+};

--- a/client/src/components/meal-planner/campaigns/adaptiveCampaignRecommendations.ts
+++ b/client/src/components/meal-planner/campaigns/adaptiveCampaignRecommendations.ts
@@ -1,0 +1,50 @@
+import type { NutritionCampaignDefinition } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+import type { AdaptiveCampaignProfile } from './adaptiveCampaignScaling';
+import { deriveCampaignMood, deriveCampaignRecoveryFocus } from './adaptiveCampaignNarratives';
+
+export const deriveCampaignRecommendationReasons = (
+  campaign: NutritionCampaignDefinition,
+  profile: AdaptiveCampaignProfile,
+): string[] => {
+  const reasons: string[] = [];
+  if (profile.continuitySuccess >= 0.65) reasons.push('High continuity fit');
+  if (profile.prepTolerance < 0.45 || profile.fatigueSensitivity > 0.62) reasons.push('Low prep intensity');
+  if (deriveCampaignRecoveryFocus(profile) > 0.62) reasons.push('Recovery-friendly');
+  if (profile.semanticFatigue >= 0.62) reasons.push('Freshness reset');
+  if (campaign.theme === 'recovery' && profile.volatilityLevel > 0.55) reasons.push('Comfort stabilization');
+  return reasons.slice(0, 4);
+};
+
+export const calculateCampaignFitScore = (
+  campaign: NutritionCampaignDefinition,
+  profile: AdaptiveCampaignProfile,
+): number => {
+  const mood = deriveCampaignMood(profile);
+  const themeBoost = (
+    (campaign.theme === 'recovery' && mood === 'recovery') ||
+    (campaign.theme === 'meal-prep' && profile.prepTolerance >= 0.55) ||
+    (campaign.theme === 'leftovers' && profile.continuitySuccess >= 0.6) ||
+    (campaign.theme === 'pantry' && profile.sustainabilityScore >= 0.58)
+  ) ? 0.14 : 0;
+
+  const profileScore =
+    (profile.adherenceStrength * 0.2) +
+    ((1 - profile.volatilityLevel) * 0.15) +
+    (profile.sustainabilityScore * 0.2) +
+    (profile.continuitySuccess * 0.2) +
+    ((1 - profile.fatigueSensitivity) * 0.1) +
+    ((1 - profile.semanticFatigue) * 0.15);
+
+  return Math.round(Math.min(100, (profileScore + themeBoost) * 100));
+};
+
+export const rankAdaptiveCampaigns = (
+  campaigns: NutritionCampaignDefinition[],
+  profile: AdaptiveCampaignProfile,
+): Array<NutritionCampaignDefinition & { fitScore: number; fitReasons: string[] }> => {
+  return campaigns.map((campaign) => ({
+    ...campaign,
+    fitScore: calculateCampaignFitScore(campaign, profile),
+    fitReasons: deriveCampaignRecommendationReasons(campaign, profile),
+  })).sort((a, b) => b.fitScore - a.fitScore);
+};

--- a/client/src/components/meal-planner/campaigns/adaptiveCampaignScaling.ts
+++ b/client/src/components/meal-planner/campaigns/adaptiveCampaignScaling.ts
@@ -1,0 +1,97 @@
+import type { NutritionCampaignDefinition, NutritionCampaignMission, NutritionCampaignMissionMetric } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+
+export type AdaptiveCampaignProfile = {
+  prepTolerance: number;
+  continuitySuccess: number;
+  fatigueSensitivity: number;
+  volatilityLevel: number;
+  adherenceStrength: number;
+  sustainabilityScore: number;
+  readinessScore: number;
+  semanticFatigue: number;
+};
+
+export type AdaptiveMissionTargets = Record<NutritionCampaignMissionMetric, number>;
+
+const clamp = (value: number, min = 0, max = 1): number => Math.min(max, Math.max(min, value));
+
+const clampTarget = (value: number): number => Math.max(1, Math.round(value));
+
+export const deriveCampaignDifficulty = (profile: AdaptiveCampaignProfile): number => {
+  const stability = 1 - profile.volatilityLevel;
+  const readiness = profile.readinessScore;
+  const sustainability = profile.sustainabilityScore;
+  return clamp((profile.adherenceStrength * 0.35) + (stability * 0.25) + (readiness * 0.2) + (sustainability * 0.2));
+};
+
+export const deriveCampaignPacing = (profile: AdaptiveCampaignProfile): 'slow' | 'steady' | 'accelerated' => {
+  const paceScore = (1 - profile.fatigueSensitivity) * 0.4 + profile.adherenceStrength * 0.35 + (1 - profile.volatilityLevel) * 0.25;
+  if (paceScore < 0.45) return 'slow';
+  if (paceScore < 0.72) return 'steady';
+  return 'accelerated';
+};
+
+export const deriveCampaignIntensity = (profile: AdaptiveCampaignProfile): 'low' | 'moderate' | 'high' => {
+  const score = deriveCampaignDifficulty(profile) * 0.6 + profile.prepTolerance * 0.2 + (1 - profile.semanticFatigue) * 0.2;
+  if (score < 0.45) return 'low';
+  if (score < 0.72) return 'moderate';
+  return 'high';
+};
+
+export const deriveAdaptiveMissionTargets = (
+  campaign: NutritionCampaignDefinition,
+  profile: AdaptiveCampaignProfile,
+): AdaptiveMissionTargets => {
+  const difficulty = deriveCampaignDifficulty(profile);
+  const complexityTargets = deriveMissionComplexityTargets(profile);
+
+  return campaign.missions.reduce((acc, mission) => {
+    acc[mission.metric] = scaleCampaignMissionDifficulty(mission, profile, difficulty, complexityTargets);
+    return acc;
+  }, {
+    planned_breakfasts: 0,
+    prep_tasks_completed: 0,
+    grocery_items_resolved: 0,
+    pantry_ingredients_used: 0,
+    leftover_friendly_meals: 0,
+    protein_goal_days: 0,
+    semantic_variety_score: 0,
+    prep_overload_reduction: 0,
+  } as AdaptiveMissionTargets);
+};
+
+export const deriveMissionComplexityTargets = (profile: AdaptiveCampaignProfile): { lowFrictionBias: number; continuityBias: number; varietyBias: number } => ({
+  lowFrictionBias: clamp((1 - profile.prepTolerance) * 0.55 + profile.fatigueSensitivity * 0.45, 0.75, 1.35),
+  continuityBias: clamp(profile.continuitySuccess * 0.6 + profile.adherenceStrength * 0.4, 0.85, 1.4),
+  varietyBias: clamp(profile.semanticFatigue * 0.7 + (1 - profile.volatilityLevel) * 0.3, 0.85, 1.5),
+});
+
+export const scaleCampaignMissionDifficulty = (
+  mission: NutritionCampaignMission,
+  profile: AdaptiveCampaignProfile,
+  difficulty = deriveCampaignDifficulty(profile),
+  complexityTargets = deriveMissionComplexityTargets(profile),
+): number => {
+  const stableMultiplier = clamp(0.85 + difficulty * 0.45, 0.8, 1.35);
+
+  switch (mission.metric) {
+    case 'planned_breakfasts':
+      return clampTarget(mission.target * stableMultiplier * complexityTargets.continuityBias);
+    case 'prep_tasks_completed':
+      return clampTarget(mission.target * stableMultiplier * (1 / complexityTargets.lowFrictionBias));
+    case 'grocery_items_resolved':
+      return clampTarget(mission.target * clamp(0.9 + profile.readinessScore * 0.3, 0.8, 1.25));
+    case 'pantry_ingredients_used':
+      return clampTarget(mission.target * clamp(0.9 + profile.sustainabilityScore * 0.35, 0.8, 1.3));
+    case 'leftover_friendly_meals':
+      return clampTarget(mission.target * clamp(0.9 + profile.continuitySuccess * 0.35, 0.85, 1.35));
+    case 'protein_goal_days':
+      return clampTarget(mission.target * stableMultiplier);
+    case 'semantic_variety_score':
+      return clampTarget(mission.target * complexityTargets.varietyBias);
+    case 'prep_overload_reduction':
+      return clampTarget(mission.target * clamp(1 + profile.fatigueSensitivity * 0.25 + profile.volatilityLevel * 0.2, 1, 1.4));
+    default:
+      return mission.target;
+  }
+};

--- a/client/src/components/meal-planner/campaigns/nutritionCampaignEngine.ts
+++ b/client/src/components/meal-planner/campaigns/nutritionCampaignEngine.ts
@@ -4,6 +4,7 @@ import {
   NutritionCampaignProgress,
   NutritionCampaignSignals,
 } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+import { deriveAdaptiveMissionTargets, type AdaptiveCampaignProfile } from '@/components/meal-planner/campaigns/adaptiveCampaignScaling';
 
 const metricValue = (signals: NutritionCampaignSignals, metric: NutritionCampaignMissionMetric): number => {
   switch (metric) {
@@ -23,19 +24,23 @@ export const evaluateCampaignProgress = (
   campaignId: string,
   signals: NutritionCampaignSignals,
   startedAt: string,
+  adaptiveProfile?: AdaptiveCampaignProfile,
 ): NutritionCampaignProgress | null => {
   const campaign = NUTRITION_CAMPAIGN_CATALOG.find((item) => item.id === campaignId);
   if (!campaign) return null;
 
+  const adaptiveTargets = adaptiveProfile ? deriveAdaptiveMissionTargets(campaign, adaptiveProfile) : null;
+
   const missionProgress = campaign.missions.map((mission) => {
     const value = metricValue(signals, mission.metric);
-    const progressPct = Math.min(100, Math.round((value / mission.target) * 100));
+    const target = adaptiveTargets?.[mission.metric] ?? mission.target;
+    const progressPct = Math.min(100, Math.round((value / target) * 100));
     return {
       mission,
       value,
-      target: mission.target,
+      target,
       progressPct,
-      completed: value >= mission.target,
+      completed: value >= target,
     };
   });
 

--- a/client/src/components/meal-planner/campaigns/nutritionCampaignTypes.ts
+++ b/client/src/components/meal-planner/campaigns/nutritionCampaignTypes.ts
@@ -72,3 +72,12 @@ export type NutritionCampaignProgress = {
   completionPct: number;
   complete: boolean;
 };
+
+
+export type NutritionCampaignAdaptiveRecommendation = {
+  fitScore: number;
+  fitReasons: string[];
+  narrative?: string;
+  pacing?: 'slow' | 'steady' | 'accelerated';
+  intensity?: 'low' | 'moderate' | 'high';
+};


### PR DESCRIPTION
### Motivation
- Evolve static nutrition campaign cards into adaptive, personalized journeys that use existing personality, semantic, sustainability, readiness, and longitudinal signals. 
- Keep changes additive and preserve all current planner behavior, Smart Auto-Plan, AI Coach, semantic intelligence, longitudinal adaptation, personality modeling, localStorage persistence, and existing campaign catalog fallback. 

### Description
- New adaptive modules were added under `client/src/components/meal-planner/campaigns/`: `adaptiveCampaignEngine.ts` (orchestration), `adaptiveCampaignScaling.ts` (profile, difficulty, pacing, intensity, mission scaling), `adaptiveCampaignNarratives.ts` (mood/narrative/recovery focus), and `adaptiveCampaignRecommendations.ts` (fit scoring, ranking, reasons). 
- `evaluateCampaignProgress` in `nutritionCampaignEngine.ts` now accepts an optional adaptive profile and uses `deriveAdaptiveMissionTargets()` when provided, while falling back to catalog targets when not. 
- `NutritionCampaignPanel.tsx` and `nutritionCampaignTypes.ts` were extended to surface optional adaptive recommendation metadata (fit score, reasons, narrative, pacing, intensity) and render fit badges and an adaptive subtitle without rewriting the panel structure. 
- All persistence and planner integration were left intact (no backend schema changes and `NutritionMealPlanner` was not modified). 

### Testing
- Ran `npm run build:client` which completed successfully. 
- Ran `npm run build:server` which completed successfully. 
- Ran full project TypeScript check with `npx tsc -p tsconfig.json --noEmit` which failed due to extensive pre-existing repository-wide type errors unrelated to the newly added campaign modules. 
- Targeted `tsc` attempts for module-level checks surfaced import/JSX resolution limitations in the test environment, so full-type validation was deferred to repo-wide `tsc` (see above failure which is unrelated to these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a124ad60908832594149c489d9e8c22)