### PR TITLE
Multi-stage adaptive campaign journey arcs for Nutrition Planner

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -3781,7 +3781,7 @@ const NutritionMealPlanner = () => {
       proteinGoalDays: proteinGoalHitDays,
       semanticVarietyScore,
       prepOverloadReduction,
-    }, activeCampaignStartedAt);
+    }, activeCampaignStartedAt, undefined, user?.id);
   }, [activeCampaignId, activeCampaignStartedAt, plannedBreakfasts, prepTasksCompleted, groceryCompletedCount, pantryIngredientsUsed, leftoverFriendlyMeals, proteinGoalHitDays, semanticVarietyScore, prepOverloadReduction]);
   const handleDismissCoachInsight = (insightId: string) => {
     setDismissedCoachInsightIds((prev) => prev.includes(insightId) ? prev : [...prev, insightId]);

--- a/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
+++ b/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
@@ -36,8 +36,13 @@ const NutritionCampaignPanel: React.FC<Props> = ({ activeCampaignId, progress, o
                   {activeCampaignId && adaptiveRecommendationsByCampaignId?.[activeCampaignId]?.narrative && (
                     <p className="text-xs text-emerald-700 mt-1">{adaptiveRecommendationsByCampaignId[activeCampaignId].narrative}</p>
                   )}
+                  {progress.phaseNarrative && <p className="text-xs text-blue-700 mt-1">{progress.phaseNarrative}</p>}
+                  {progress.transitionReason && <p className="text-xs text-amber-700 mt-1">{progress.transitionReason}</p>}
                 </div>
+                <div className="flex flex-wrap items-center gap-2">
+                {progress.phase && <Badge variant="outline" className="capitalize">{progress.phase.replace('-', ' ')} phase</Badge>}
                 <Badge variant="secondary">{progress.completedMissions}/{progress.totalMissions} missions</Badge>
+              </div>
               </div>
               <Progress value={progress.completionPct} />
               <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
@@ -50,6 +55,13 @@ const NutritionCampaignPanel: React.FC<Props> = ({ activeCampaignId, progress, o
                   </div>
                 ))}
               </div>
+              {progress.completionSemantics && (
+                <div className="rounded-lg border border-blue-200 bg-blue-50 p-3 text-xs text-blue-900">
+                  <p className="font-medium mb-1">Adaptive completion semantics</p>
+                  <p>Sustainability: {progress.completionSemantics.sustainabilityCompletion ? 'complete' : 'in progress'} · Recovery: {progress.completionSemantics.recoveryCompletion ? 'complete' : 'in progress'} · Continuity: {progress.completionSemantics.continuityCompletion ? 'complete' : 'in progress'}</p>
+                  {typeof progress.momentum === 'number' && <p className="mt-1">Momentum: {Math.round(progress.momentum * 100)}% · Stability: {Math.round((progress.journeyStability || 0) * 100)}%</p>}
+                </div>
+              )}
               {progress.complete && (
                 <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800 flex items-start gap-2">
                   <Sparkles className="w-4 h-4 mt-0.5" />

--- a/client/src/components/meal-planner/campaigns/adaptiveCampaignArcs.ts
+++ b/client/src/components/meal-planner/campaigns/adaptiveCampaignArcs.ts
@@ -1,0 +1,58 @@
+import type { NutritionCampaignMissionMetric, NutritionCampaignSignals } from './nutritionCampaignTypes';
+import type { AdaptiveCampaignProfile } from './adaptiveCampaignScaling';
+import { deriveCampaignPhase, deriveCampaignPhaseIntensity, type CampaignJourneyPhase, type CampaignTrajectory } from './adaptiveCampaignPhases';
+
+export const deriveCampaignTrajectory = (
+  signals: NutritionCampaignSignals,
+  profile?: AdaptiveCampaignProfile,
+): CampaignTrajectory => {
+  const adherenceTrajectory = profile?.adherenceStrength ?? Math.min(1, (signals.proteinGoalDays + signals.plannedBreakfasts / 2) / 9);
+  const fatigueTrajectory = profile?.fatigueSensitivity ?? Math.max(0, 1 - (signals.prepOverloadReduction / 100));
+  const prepStability = profile?.prepTolerance ?? Math.min(1, signals.prepTasksCompleted / 6);
+  const semanticFatigue = profile?.semanticFatigue ?? Math.max(0, (70 - signals.semanticVarietyScore) / 70);
+  const continuitySuccess = profile?.continuitySuccess ?? Math.min(1, signals.leftoverFriendlyMeals / 5);
+  const readinessTrend = profile?.readinessScore ?? Math.min(1, (signals.plannedBreakfasts + signals.groceryItemsResolved / 3) / 9);
+  const sustainabilityTrend = profile?.sustainabilityScore ?? Math.min(1, (signals.prepOverloadReduction + signals.pantryIngredientsUsed * 8) / 100);
+  const volatilityPattern = profile?.volatilityLevel ?? Number((1 - prepStability * 0.6 - continuitySuccess * 0.4).toFixed(2));
+  const missionCompletionConsistency = Math.min(1, (signals.prepTasksCompleted + signals.proteinGoalDays + signals.groceryItemsResolved / 2) / 12);
+
+  return { adherenceTrajectory, fatigueTrajectory, prepStability, semanticFatigue, continuitySuccess, readinessTrend, sustainabilityTrend, volatilityPattern, missionCompletionConsistency };
+};
+
+export const deriveCampaignArc = (trajectory: CampaignTrajectory): {
+  phase: CampaignJourneyPhase;
+  intensity: number;
+  trajectory: CampaignTrajectory;
+} => {
+  const phase = deriveCampaignPhase(trajectory);
+  return { phase, intensity: deriveCampaignPhaseIntensity(phase), trajectory };
+};
+
+export const derivePhaseMissionModifiers = (phase: CampaignJourneyPhase): Partial<Record<NutritionCampaignMissionMetric, number>> => {
+  switch (phase) {
+    case 'recovery':
+    case 'sustainability-protection':
+      return { prep_tasks_completed: 0.8, prep_overload_reduction: 1.15, pantry_ingredients_used: 1.1 };
+    case 'momentum':
+      return { leftover_friendly_meals: 1.15, protein_goal_days: 1.1, planned_breakfasts: 1.1 };
+    case 'escalation':
+      return { prep_tasks_completed: 1.2, grocery_items_resolved: 1.15, protein_goal_days: 1.2 };
+    case 'reset':
+      return { semantic_variety_score: 1.2, leftover_friendly_meals: 0.9, planned_breakfasts: 0.95 };
+    case 'stabilization':
+      return { prep_tasks_completed: 0.9, planned_breakfasts: 1.0, prep_overload_reduction: 1.05 };
+    default:
+      return {};
+  }
+};
+
+export const derivePhaseAwareMissionTargets = (
+  baseTargets: Record<string, number>,
+  phase: CampaignJourneyPhase,
+): Record<string, number> => {
+  const modifiers = derivePhaseMissionModifiers(phase);
+  return Object.fromEntries(Object.entries(baseTargets).map(([metric, target]) => {
+    const modifier = modifiers[metric as NutritionCampaignMissionMetric] ?? 1;
+    return [metric, Math.max(1, Math.round(target * modifier))];
+  }));
+};

--- a/client/src/components/meal-planner/campaigns/adaptiveCampaignJourney.ts
+++ b/client/src/components/meal-planner/campaigns/adaptiveCampaignJourney.ts
@@ -1,0 +1,74 @@
+import type { CampaignJourneyPhase, CampaignTrajectory } from './adaptiveCampaignPhases';
+import { deriveCampaignArc, deriveCampaignTrajectory } from './adaptiveCampaignArcs';
+import { derivePhaseTransitionReason, shouldTransitionCampaignPhase, calculateCampaignMomentum } from './adaptiveCampaignTransitions';
+import type { AdaptiveCampaignProfile } from './adaptiveCampaignScaling';
+import type { NutritionCampaignSignals } from './nutritionCampaignTypes';
+
+export type CampaignJourneyHistoryEntry = {
+  phase: CampaignJourneyPhase;
+  reason: string;
+  occurredAt: string;
+  momentum: number;
+};
+export type CampaignJourneyState = {
+  phase: CampaignJourneyPhase;
+  momentum: number;
+  narrative: string;
+  trajectory: CampaignTrajectory;
+  history: CampaignJourneyHistoryEntry[];
+};
+
+const CAP = 24;
+const historyKey = (campaignId: string, userId?: string | null) => `nutrition-campaign-journey-v1:${campaignId}:${userId || 'anon'}`;
+
+export const appendCampaignJourneyHistory = (history: CampaignJourneyHistoryEntry[], entry: CampaignJourneyHistoryEntry): CampaignJourneyHistoryEntry[] => [...history, entry].slice(-CAP);
+export const calculateCampaignJourneyStability = (history: CampaignJourneyHistoryEntry[]): number => {
+  if (history.length < 2) return 1;
+  const transitions = history.reduce((count, item, index) => index === 0 ? count : count + Number(item.phase !== history[index - 1].phase), 0);
+  return Number(Math.max(0, 1 - transitions / Math.max(1, history.length - 1)).toFixed(2));
+};
+export const deriveCampaignJourneySummary = (history: CampaignJourneyHistoryEntry[]) => ({
+  completedPhases: Array.from(new Set(history.map((item) => item.phase))),
+  recoveryInterventions: history.filter((item) => item.phase === 'recovery' || item.phase === 'sustainability-protection').length,
+  stabilizationStreaks: history.filter((item) => item.phase === 'stabilization').length,
+  momentumStreaks: history.filter((item) => item.phase === 'momentum' || item.phase === 'escalation').length,
+  sustainabilityRescues: history.filter((item) => item.reason.toLowerCase().includes('sustainability')).length,
+});
+
+export const deriveCampaignArcNarrative = (phase: CampaignJourneyPhase): string => ({ onboarding: 'Building your planning foundation.', stabilization: 'Stabilizing your planning rhythm.', recovery: 'Recovery cadence engaged.', momentum: 'Momentum is building.', escalation: 'Escalating with confidence and consistency.', maintenance: 'Maintaining your sustainable baseline.', reset: 'Refreshing semantic variety.', 'sustainability-protection': 'Protecting sustainability during fatigue.' }[phase]);
+export const deriveCampaignMomentumNarrative = (momentum: number): string => momentum >= 0.75 ? 'High momentum arc active.' : momentum >= 0.55 ? 'Momentum trend is improving.' : 'Momentum protected while rebuilding consistency.';
+export const deriveCampaignRecoveryNarrative = (trajectory: CampaignTrajectory): string => trajectory.fatigueTrajectory >= 0.65 ? 'Recovery protection active to reduce fatigue.' : 'Recovery guardrails available if fatigue rises.';
+
+export const deriveSustainabilityCompletion = (trajectory: CampaignTrajectory): boolean => trajectory.sustainabilityTrend >= 0.68 && trajectory.fatigueTrajectory <= 0.52;
+export const deriveRecoveryCompletion = (trajectory: CampaignTrajectory): boolean => trajectory.fatigueTrajectory <= 0.45 && trajectory.prepStability >= 0.56;
+export const deriveCampaignCompletionSemantics = (trajectory: CampaignTrajectory, missionCompletionPct: number) => ({
+  sustainabilityCompletion: deriveSustainabilityCompletion(trajectory),
+  recoveryCompletion: deriveRecoveryCompletion(trajectory),
+  continuityCompletion: trajectory.continuitySuccess >= 0.65,
+  stabilizationCompletion: trajectory.volatilityPattern <= 0.42,
+  semanticResetCompletion: trajectory.semanticFatigue <= 0.5,
+  missionCompletionPct,
+});
+
+export const evolveCampaignJourney = (args: {
+  campaignId: string;
+  signals: NutritionCampaignSignals;
+  profile?: AdaptiveCampaignProfile;
+  previousPhase?: CampaignJourneyPhase | null;
+  userId?: string | null;
+}): CampaignJourneyState => {
+  const trajectory = deriveCampaignTrajectory(args.signals, args.profile);
+  const arc = deriveCampaignArc(trajectory);
+  const stored = typeof localStorage === 'undefined' ? null : localStorage.getItem(historyKey(args.campaignId, args.userId));
+  const history: CampaignJourneyHistoryEntry[] = stored ? JSON.parse(stored) : [];
+  const shouldTransition = shouldTransitionCampaignPhase(args.previousPhase, arc.phase, trajectory);
+  const effectivePhase = shouldTransition ? arc.phase : (args.previousPhase || arc.phase);
+  const momentum = calculateCampaignMomentum(trajectory);
+  const reason = derivePhaseTransitionReason(args.previousPhase, effectivePhase, trajectory);
+  const nextHistory = shouldTransition
+    ? appendCampaignJourneyHistory(history, { phase: effectivePhase, reason, occurredAt: new Date().toISOString(), momentum })
+    : history;
+  if (typeof localStorage !== 'undefined') localStorage.setItem(historyKey(args.campaignId, args.userId), JSON.stringify(nextHistory));
+
+  return { phase: effectivePhase, momentum, trajectory, history: nextHistory, narrative: `${deriveCampaignArcNarrative(effectivePhase)} ${deriveCampaignMomentumNarrative(momentum)}` };
+};

--- a/client/src/components/meal-planner/campaigns/adaptiveCampaignPhases.ts
+++ b/client/src/components/meal-planner/campaigns/adaptiveCampaignPhases.ts
@@ -1,0 +1,46 @@
+export type CampaignJourneyPhase =
+  | 'onboarding'
+  | 'stabilization'
+  | 'recovery'
+  | 'momentum'
+  | 'escalation'
+  | 'maintenance'
+  | 'reset'
+  | 'sustainability-protection';
+
+export type CampaignTrajectory = {
+  adherenceTrajectory: number;
+  fatigueTrajectory: number;
+  prepStability: number;
+  semanticFatigue: number;
+  continuitySuccess: number;
+  readinessTrend: number;
+  sustainabilityTrend: number;
+  volatilityPattern: number;
+  missionCompletionConsistency: number;
+};
+
+export const deriveCampaignPhaseIntensity = (phase: CampaignJourneyPhase): number => {
+  switch (phase) {
+    case 'onboarding': return 0.45;
+    case 'stabilization': return 0.5;
+    case 'recovery': return 0.4;
+    case 'momentum': return 0.72;
+    case 'escalation': return 0.86;
+    case 'maintenance': return 0.62;
+    case 'reset': return 0.48;
+    case 'sustainability-protection': return 0.43;
+    default: return 0.55;
+  }
+};
+
+export const deriveCampaignPhase = (trajectory: CampaignTrajectory): CampaignJourneyPhase => {
+  if (trajectory.semanticFatigue >= 0.72) return 'reset';
+  if (trajectory.sustainabilityTrend <= 0.42 || trajectory.fatigueTrajectory >= 0.7) return 'sustainability-protection';
+  if (trajectory.fatigueTrajectory >= 0.62 || trajectory.prepStability <= 0.45) return 'recovery';
+  if (trajectory.volatilityPattern >= 0.6 || trajectory.missionCompletionConsistency <= 0.5) return 'stabilization';
+  if (trajectory.adherenceTrajectory >= 0.75 && trajectory.continuitySuccess >= 0.68 && trajectory.readinessTrend >= 0.65) return 'escalation';
+  if (trajectory.adherenceTrajectory >= 0.66) return 'momentum';
+  if (trajectory.missionCompletionConsistency >= 0.63) return 'maintenance';
+  return 'onboarding';
+};

--- a/client/src/components/meal-planner/campaigns/adaptiveCampaignTransitions.ts
+++ b/client/src/components/meal-planner/campaigns/adaptiveCampaignTransitions.ts
@@ -1,0 +1,41 @@
+import type { CampaignJourneyPhase, CampaignTrajectory } from './adaptiveCampaignPhases';
+
+export const calculateCampaignMomentum = (trajectory: CampaignTrajectory): number => {
+  const raw =
+    (trajectory.adherenceTrajectory * 0.3) +
+    (trajectory.continuitySuccess * 0.2) +
+    (trajectory.readinessTrend * 0.15) +
+    (trajectory.missionCompletionConsistency * 0.15) +
+    ((1 - trajectory.fatigueTrajectory) * 0.1) +
+    ((1 - trajectory.volatilityPattern) * 0.1);
+  return Number(Math.max(0, Math.min(1, raw)).toFixed(2));
+};
+
+export const shouldTransitionCampaignPhase = (
+  currentPhase: CampaignJourneyPhase | null | undefined,
+  nextPhase: CampaignJourneyPhase,
+  trajectory: CampaignTrajectory,
+): boolean => {
+  if (!currentPhase) return true;
+  if (currentPhase === nextPhase) return false;
+  const momentum = calculateCampaignMomentum(trajectory);
+  if (nextPhase === 'momentum' || nextPhase === 'escalation') return momentum >= 0.62;
+  if (nextPhase === 'recovery' || nextPhase === 'sustainability-protection') return trajectory.fatigueTrajectory >= 0.58 || trajectory.sustainabilityTrend <= 0.5;
+  return true;
+};
+
+export const derivePhaseTransitionReason = (
+  currentPhase: CampaignJourneyPhase | null | undefined,
+  nextPhase: CampaignJourneyPhase,
+  trajectory: CampaignTrajectory,
+): string => {
+  if (!currentPhase) return `Journey initialized in ${nextPhase}.`;
+  if (nextPhase === 'reset') return 'Semantic fatigue triggered a freshness reset.';
+  if (nextPhase === 'sustainability-protection') return 'Protecting sustainability during fatigue and overload.';
+  if (nextPhase === 'recovery') return 'Recovery cadence engaged from rising fatigue.';
+  if (nextPhase === 'stabilization') return 'Stabilization mode activated during volatility.';
+  if (nextPhase === 'momentum') return 'Momentum phase unlocked through consistent continuity.';
+  if (nextPhase === 'escalation') return 'High adherence and readiness unlocked escalation.';
+  if (nextPhase === 'maintenance') return 'Maintaining steady mission consistency.';
+  return `Transitioned from ${currentPhase} to ${nextPhase}.`;
+};

--- a/client/src/components/meal-planner/campaigns/nutritionCampaignEngine.ts
+++ b/client/src/components/meal-planner/campaigns/nutritionCampaignEngine.ts
@@ -5,6 +5,8 @@ import {
   NutritionCampaignSignals,
 } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
 import { deriveAdaptiveMissionTargets, type AdaptiveCampaignProfile } from '@/components/meal-planner/campaigns/adaptiveCampaignScaling';
+import { derivePhaseAwareMissionTargets } from '@/components/meal-planner/campaigns/adaptiveCampaignArcs';
+import { calculateCampaignJourneyStability, deriveCampaignCompletionSemantics, deriveCampaignJourneySummary, evolveCampaignJourney } from '@/components/meal-planner/campaigns/adaptiveCampaignJourney';
 
 const metricValue = (signals: NutritionCampaignSignals, metric: NutritionCampaignMissionMetric): number => {
   switch (metric) {
@@ -25,15 +27,18 @@ export const evaluateCampaignProgress = (
   signals: NutritionCampaignSignals,
   startedAt: string,
   adaptiveProfile?: AdaptiveCampaignProfile,
+  userId?: string | null,
 ): NutritionCampaignProgress | null => {
   const campaign = NUTRITION_CAMPAIGN_CATALOG.find((item) => item.id === campaignId);
   if (!campaign) return null;
 
   const adaptiveTargets = adaptiveProfile ? deriveAdaptiveMissionTargets(campaign, adaptiveProfile) : null;
+  const journey = evolveCampaignJourney({ campaignId, signals, profile: adaptiveProfile, userId });
+  const phaseTargets = adaptiveTargets ? derivePhaseAwareMissionTargets(adaptiveTargets, journey.phase) : null;
 
   const missionProgress = campaign.missions.map((mission) => {
     const value = metricValue(signals, mission.metric);
-    const target = adaptiveTargets?.[mission.metric] ?? mission.target;
+    const target = phaseTargets?.[mission.metric] ?? adaptiveTargets?.[mission.metric] ?? mission.target;
     const progressPct = Math.min(100, Math.round((value / target) * 100));
     return {
       mission,
@@ -47,6 +52,9 @@ export const evaluateCampaignProgress = (
   const completedMissions = missionProgress.filter((mission) => mission.completed).length;
   const completionPct = Math.round((completedMissions / campaign.missions.length) * 100);
 
+  const completionSemantics = deriveCampaignCompletionSemantics(journey.trajectory, completionPct);
+  const journeySummary = deriveCampaignJourneySummary(journey.history);
+
   return {
     campaignId: campaign.id,
     startedAt,
@@ -55,5 +63,11 @@ export const evaluateCampaignProgress = (
     totalMissions: campaign.missions.length,
     completionPct,
     complete: completedMissions === campaign.missions.length,
+    phase: journey.phase,
+    phaseNarrative: journey.narrative,
+    momentum: journey.momentum,
+    transitionReason: journeySummary.completedPhases.length ? journey.history[journey.history.length - 1]?.reason : undefined,
+    journeyStability: calculateCampaignJourneyStability(journey.history),
+    completionSemantics,
   };
 };

--- a/client/src/components/meal-planner/campaigns/nutritionCampaignTypes.ts
+++ b/client/src/components/meal-planner/campaigns/nutritionCampaignTypes.ts
@@ -63,6 +63,15 @@ export type NutritionCampaignMissionProgress = {
   completed: boolean;
 };
 
+export type NutritionCampaignCompletionSemantics = {
+  sustainabilityCompletion: boolean;
+  recoveryCompletion: boolean;
+  continuityCompletion: boolean;
+  stabilizationCompletion: boolean;
+  semanticResetCompletion: boolean;
+  missionCompletionPct: number;
+};
+
 export type NutritionCampaignProgress = {
   campaignId: string;
   startedAt: string;
@@ -71,6 +80,12 @@ export type NutritionCampaignProgress = {
   totalMissions: number;
   completionPct: number;
   complete: boolean;
+  phase?: string;
+  phaseNarrative?: string;
+  momentum?: number;
+  transitionReason?: string;
+  journeyStability?: number;
+  completionSemantics?: NutritionCampaignCompletionSemantics;
 };
 
 


### PR DESCRIPTION
### Motivation
- Evolve existing single-state adaptive campaigns into multi-stage adaptive nutrition journeys that change over time based on behavioral and semantic signals.
- Provide phase-aware mission mutation, narrative evolution, and lightweight journey history while preserving all current adaptive features and planner integrations.
- Keep changes additive and local-only (no backend schema changes and no rewrites of `NutritionMealPlanner`).

### Description
- Added a compact campaign arc framework with phase/trajectory derivation (`deriveCampaignArc`, `deriveCampaignPhase`, `deriveCampaignTrajectory`, `deriveCampaignPhaseIntensity`) in `client/src/components/meal-planner/campaigns/` (new files `adaptiveCampaignPhases.ts` and `adaptiveCampaignArcs.ts`).
- Implemented phase transition heuristics and momentum scoring (`shouldTransitionCampaignPhase`, `derivePhaseTransitionReason`, `calculateCampaignMomentum`) in `adaptiveCampaignTransitions.ts` and journey evolution, narrative and history helpers (`evolveCampaignJourney`, `deriveCampaignArcNarrative`, `deriveCampaignMomentumNarrative`, `appendCampaignJourneyHistory`, `deriveCampaignJourneySummary`, `calculateCampaignJourneyStability`, `deriveCampaignCompletionSemantics`) in `adaptiveCampaignJourney.ts`.
- Made mission targets phase-aware via `derivePhaseMissionModifiers` and `derivePhaseAwareMissionTargets`, and applied them additively in `evaluateCampaignProgress()` (modified `nutritionCampaignEngine.ts`) while extending types in `nutritionCampaignTypes.ts` to include journey fields and `NutritionCampaignCompletionSemantics`.
- Surface phase information and adaptive completion summaries in the existing UI by enhancing `NutritionCampaignPanel.tsx` with a phase badge, phase narrative, transition reason, and momentum/stability/completion semantics (UI structure preserved), and scope journey persistence by passing `user?.id` from `NutritionMealPlanner.tsx` into evaluation calls.

### Testing
- Ran `npm run build:client` which completed successfully (Vite build OK). 
- Ran `npm run build:server` which completed successfully (server bundle OK).
- Ran a targeted `npx tsc --noEmit` over the new/related campaign modules which reported path/JSX/alias style issues because it bypasses project resolution and therefore produced warnings in this environment. 
- Ran full `npx tsc -p tsconfig.json --noEmit` which failed due to pre-existing repository TypeScript errors unrelated to these changes (these failures are repo-wide and not caused by the added campaign modules).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130a238b7c83259efa49355ae0e144)