### PR TITLE
Add WeeklyNutritionJourneyTimeline and integrate into NutritionCampaignPanel

### DIFF
--- a/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
+++ b/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { NUTRITION_CAMPAIGN_CATALOG } from '@/components/meal-planner/campaigns/nutritionCampaignCatalog';
 import { NutritionCampaignProgress } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
 import type { NutritionCampaignAdaptiveRecommendation } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+import WeeklyNutritionJourneyTimeline from '@/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline';
 
 type Props = {
   activeCampaignId: string | null;
@@ -68,6 +69,19 @@ const NutritionCampaignPanel: React.FC<Props> = ({ activeCampaignId, progress, o
                   <span>{activeCampaign.rewardCopy}</span>
                 </div>
               )}
+              <WeeklyNutritionJourneyTimeline
+                context={{
+                  phase: progress.phase,
+                  phaseNarrative: progress.phaseNarrative,
+                  momentum: progress.momentum,
+                  journeyStability: progress.journeyStability,
+                  transitionReason: progress.transitionReason,
+                  completionPct: progress.completionPct,
+                  completedMissions: progress.completedMissions,
+                  totalMissions: progress.totalMissions,
+                  completionSemantics: progress.completionSemantics,
+                }}
+              />
               <Button variant="outline" size="sm" onClick={onClearCampaign}>End Active Campaign</Button>
             </div>
           ) : (

--- a/client/src/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline.tsx
+++ b/client/src/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Sparkles, ShieldCheck, Activity, Brain } from 'lucide-react';
+import { deriveTimelineEvents } from './journeyTimelineEvents';
+import type { JourneyTimelineContext, JourneyTimelineEvent } from './journeyTimelineTypes';
+
+type Props = {
+  context: JourneyTimelineContext;
+};
+
+const toneClasses: Record<JourneyTimelineEvent['tone'], string> = {
+  neutral: 'border-slate-200 bg-white text-slate-800',
+  positive: 'border-emerald-200 bg-emerald-50 text-emerald-900',
+  warning: 'border-amber-200 bg-amber-50 text-amber-900',
+};
+
+const iconByType: Record<JourneyTimelineEvent['type'], React.ReactNode> = {
+  'semantic-event': <Brain className="h-4 w-4" />,
+  'recovery-event': <ShieldCheck className="h-4 w-4" />,
+  'momentum-event': <Sparkles className="h-4 w-4" />,
+  'continuity-event': <Activity className="h-4 w-4" />,
+  'prep-event': <Activity className="h-4 w-4" />,
+  'readiness-event': <ShieldCheck className="h-4 w-4" />,
+  'campaign-phase-event': <Sparkles className="h-4 w-4" />,
+  'sustainability-event': <ShieldCheck className="h-4 w-4" />,
+  'ai-coach-event': <Brain className="h-4 w-4" />,
+};
+
+const WeeklyNutritionJourneyTimeline: React.FC<Props> = ({ context }) => {
+  const events = React.useMemo(() => deriveTimelineEvents(context), [context]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Weekly Nutrition Journey Timeline</CardTitle>
+        <CardDescription>
+          Adaptive orchestration of campaign arcs, semantic cadence, continuity chains, readiness shifts, and AI coach interventions.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto pb-2">
+          <div className="flex min-w-[800px] gap-3">
+            {events.map((event) => (
+              <div key={event.id} className={`w-56 shrink-0 rounded-xl border p-3 shadow-sm transition-all hover:shadow ${toneClasses[event.tone]}`}>
+                <div className="mb-2 flex items-center justify-between gap-2">
+                  <Badge variant="outline" className="text-[10px] uppercase">Day {event.dayIndex + 1}</Badge>
+                  <span className="inline-flex items-center">{iconByType[event.type]}</span>
+                </div>
+                <p className="text-sm font-semibold">{event.title}</p>
+                <p className="mt-1 text-xs opacity-90">{event.detail}</p>
+                {event.tags?.length ? (
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {event.tags.slice(0, 2).map((tag) => (
+                      <Badge key={`${event.id}-${tag}`} variant="secondary" className="text-[10px]">{tag}</Badge>
+                    ))}
+                  </div>
+                ) : null}
+                {typeof event.score === 'number' && (
+                  <div className="mt-2 h-1.5 rounded-full bg-white/60">
+                    <div className="h-1.5 rounded-full bg-current" style={{ width: `${Math.max(8, Math.round(event.score * 100))}%` }} />
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default WeeklyNutritionJourneyTimeline;

--- a/client/src/components/meal-planner/journey-timeline/journeyTimelineCampaigns.ts
+++ b/client/src/components/meal-planner/journey-timeline/journeyTimelineCampaigns.ts
@@ -1,0 +1,44 @@
+import type { JourneyTimelineContext, JourneyTimelineEvent } from './journeyTimelineTypes';
+
+export const deriveCampaignTimelineEvents = (context: JourneyTimelineContext): JourneyTimelineEvent[] => {
+  const events: JourneyTimelineEvent[] = [];
+  if (context.phase) {
+    events.push({
+      id: 'campaign-phase',
+      dayIndex: 0,
+      type: 'campaign-phase-event',
+      title: `${String(context.phase).replace('-', ' ')} phase active`,
+      detail: context.phaseNarrative || 'Campaign journey phase is adapting to current planner signals.',
+      tone: 'neutral',
+      marker: 'phase',
+      phase: context.phase as any,
+      tags: ['campaign arc'],
+    });
+  }
+  if (context.transitionReason) {
+    events.push({
+      id: 'campaign-transition',
+      dayIndex: 1,
+      type: 'campaign-phase-event',
+      title: 'Campaign phase transition',
+      detail: context.transitionReason,
+      tone: 'positive',
+      marker: 'transition',
+      tags: ['explainability'],
+    });
+  }
+  if (typeof context.momentum === 'number') {
+    events.push({
+      id: 'campaign-momentum',
+      dayIndex: 3,
+      type: context.momentum >= 0.6 ? 'momentum-event' : 'recovery-event',
+      title: context.momentum >= 0.6 ? 'Momentum phase unlocked' : 'Recovery protection activated',
+      detail: `Momentum index is ${Math.round(context.momentum * 100)}%, driving adaptive mission pacing.`,
+      tone: context.momentum >= 0.6 ? 'positive' : 'warning',
+      marker: context.momentum >= 0.6 ? 'momentum' : 'recovery',
+      score: context.momentum,
+      tags: ['campaign arc', 'adaptive pacing'],
+    });
+  }
+  return events;
+};

--- a/client/src/components/meal-planner/journey-timeline/journeyTimelineContinuity.ts
+++ b/client/src/components/meal-planner/journey-timeline/journeyTimelineContinuity.ts
@@ -1,0 +1,19 @@
+import type { JourneyTimelineContext, JourneyTimelineEvent } from './journeyTimelineTypes';
+
+export const deriveContinuityTimelineEvents = (context: JourneyTimelineContext): JourneyTimelineEvent[] => {
+  const continuityStable = Boolean(context.completionSemantics?.continuityCompletion);
+  return [
+    {
+      id: 'continuity-chain',
+      dayIndex: 5,
+      type: 'continuity-event',
+      title: continuityStable ? 'Continuity chain reinforced' : 'Continuity chain rebuilding',
+      detail: continuityStable
+        ? 'Breakfast anchors, leftovers, and prep dependencies are aligned into stable clusters.'
+        : 'Planner is preserving low-friction anchors while continuity consistency improves.',
+      tone: continuityStable ? 'positive' : 'neutral',
+      marker: 'chain',
+      tags: ['breakfast chain', 'leftover links', 'prep dependency'],
+    },
+  ];
+};

--- a/client/src/components/meal-planner/journey-timeline/journeyTimelineEvents.ts
+++ b/client/src/components/meal-planner/journey-timeline/journeyTimelineEvents.ts
@@ -1,0 +1,31 @@
+import { deriveCampaignTimelineEvents } from './journeyTimelineCampaigns';
+import { deriveSemanticTimelineEvents } from './journeyTimelineSemantics';
+import { derivePrepTimelineEvents, deriveReadinessTimelineEvents } from './journeyTimelineReadiness';
+import { deriveContinuityTimelineEvents } from './journeyTimelineContinuity';
+import type { JourneyTimelineContext, JourneyTimelineEvent } from './journeyTimelineTypes';
+
+const CAP = 28;
+
+export const deriveTimelineEvents = (context: JourneyTimelineContext): JourneyTimelineEvent[] => {
+  const aiCoachEvents: JourneyTimelineEvent[] = (context.coachInsights || []).slice(0, 6).map((insight, index) => ({
+    id: `ai-coach-${insight.id}`,
+    dayIndex: index % 7,
+    type: 'ai-coach-event',
+    title: 'AI Coach observation',
+    detail: insight.description,
+    tone: insight.severity === 'warning' ? 'warning' : insight.severity === 'positive' ? 'positive' : 'neutral',
+    marker: 'coach',
+    tags: ['ai coach', insight.category || 'insight'],
+  }));
+
+  return [
+    ...deriveCampaignTimelineEvents(context),
+    ...deriveSemanticTimelineEvents(context),
+    ...deriveContinuityTimelineEvents(context),
+    ...derivePrepTimelineEvents(context),
+    ...deriveReadinessTimelineEvents(context),
+    ...aiCoachEvents,
+  ]
+    .sort((a, b) => a.dayIndex - b.dayIndex)
+    .slice(0, CAP);
+};

--- a/client/src/components/meal-planner/journey-timeline/journeyTimelineReadiness.ts
+++ b/client/src/components/meal-planner/journey-timeline/journeyTimelineReadiness.ts
@@ -1,0 +1,48 @@
+import type { JourneyTimelineContext, JourneyTimelineEvent } from './journeyTimelineTypes';
+
+export const derivePrepTimelineEvents = (context: JourneyTimelineContext): JourneyTimelineEvent[] => {
+  const recoveryComplete = Boolean(context.completionSemantics?.recoveryCompletion);
+  return [
+    {
+      id: 'prep-orchestration',
+      dayIndex: 2,
+      type: 'prep-event',
+      title: recoveryComplete ? 'Prep orchestration efficient' : 'Prep intensity adapted',
+      detail: recoveryComplete
+        ? 'Prep cadence stayed sustainable and protected recovery capacity.'
+        : 'Planner reduced prep overload while maintaining mission continuity.',
+      tone: recoveryComplete ? 'positive' : 'warning',
+      marker: 'prep',
+      tags: ['prep windows', 'orchestration'],
+    },
+  ];
+};
+
+export const deriveReadinessTimelineEvents = (context: JourneyTimelineContext): JourneyTimelineEvent[] => {
+  const stability = context.journeyStability ?? 0;
+  return [
+    {
+      id: 'readiness-shift',
+      dayIndex: 6,
+      type: 'readiness-event',
+      title: 'Readiness shift detected',
+      detail: `Readiness and sustainability confidence tracked at ${Math.round(stability * 100)}% journey stability.`,
+      tone: stability >= 0.6 ? 'positive' : 'neutral',
+      marker: 'readiness',
+      score: stability,
+      tags: ['grocery readiness', 'weekly readiness'],
+    },
+    {
+      id: 'sustainability-protection',
+      dayIndex: 4,
+      type: 'sustainability-event',
+      title: context.completionSemantics?.sustainabilityCompletion ? 'Sustainability protection stable' : 'Sustainability protection period',
+      detail: context.completionSemantics?.sustainabilityCompletion
+        ? 'Current planning rhythm is maintaining sustainability guardrails.'
+        : 'Planner is proactively protecting sustainability during volatility and fatigue.',
+      tone: context.completionSemantics?.sustainabilityCompletion ? 'positive' : 'warning',
+      marker: 'sustainability',
+      tags: ['sustainability', 'stabilization'],
+    },
+  ];
+};

--- a/client/src/components/meal-planner/journey-timeline/journeyTimelineSemantics.ts
+++ b/client/src/components/meal-planner/journey-timeline/journeyTimelineSemantics.ts
@@ -1,0 +1,34 @@
+import type { JourneyTimelineContext, JourneyTimelineEvent } from './journeyTimelineTypes';
+
+export const deriveSemanticTimelineEvents = (context: JourneyTimelineContext): JourneyTimelineEvent[] => {
+  const semanticReset = Boolean(context.completionSemantics && !context.completionSemantics.semanticResetCompletion);
+  const events: JourneyTimelineEvent[] = [
+    {
+      id: 'semantic-cadence',
+      dayIndex: 2,
+      type: 'semantic-event',
+      title: semanticReset ? 'Semantic freshness reset' : 'Semantic cadence stabilized',
+      detail: semanticReset
+        ? 'Semantic fatigue signals rose, so the planner increased novelty and fresh/light meal rotation.'
+        : 'Semantic variety remains healthy with balanced cozy/heavy and fresh/light cadence.',
+      tone: semanticReset ? 'warning' : 'positive',
+      marker: semanticReset ? 'refresh' : 'cadence',
+      tags: ['semantic cadence', 'meal rhythm'],
+    },
+  ];
+
+  if (context.completionSemantics?.continuityCompletion) {
+    events.push({
+      id: 'semantic-continuity-support',
+      dayIndex: 4,
+      type: 'continuity-event',
+      title: 'Continuity stabilized adherence',
+      detail: 'Repeated anchors and leftover-friendly sequencing reinforced consistency.',
+      tone: 'positive',
+      marker: 'anchor',
+      tags: ['continuity chain', 'stability anchor'],
+    });
+  }
+
+  return events;
+};

--- a/client/src/components/meal-planner/journey-timeline/journeyTimelineTypes.ts
+++ b/client/src/components/meal-planner/journey-timeline/journeyTimelineTypes.ts
@@ -1,0 +1,52 @@
+import type { CampaignJourneyPhase } from '@/components/meal-planner/campaigns/adaptiveCampaignPhases';
+
+export type JourneyTimelineEventType =
+  | 'semantic-event'
+  | 'recovery-event'
+  | 'momentum-event'
+  | 'continuity-event'
+  | 'prep-event'
+  | 'readiness-event'
+  | 'campaign-phase-event'
+  | 'sustainability-event'
+  | 'ai-coach-event';
+
+export type JourneyTimelineTone = 'neutral' | 'positive' | 'warning';
+
+export type JourneyTimelineEvent = {
+  id: string;
+  dayIndex: number;
+  type: JourneyTimelineEventType;
+  title: string;
+  detail: string;
+  tone: JourneyTimelineTone;
+  marker?: string;
+  phase?: CampaignJourneyPhase;
+  score?: number;
+  tags?: string[];
+};
+
+export type JourneyTimelineContext = {
+  weekStartLabel?: string;
+  phase?: CampaignJourneyPhase | string;
+  phaseNarrative?: string;
+  momentum?: number;
+  journeyStability?: number;
+  transitionReason?: string;
+  completionPct?: number;
+  completedMissions?: number;
+  totalMissions?: number;
+  completionSemantics?: {
+    sustainabilityCompletion: boolean;
+    recoveryCompletion: boolean;
+    continuityCompletion: boolean;
+    stabilizationCompletion: boolean;
+    semanticResetCompletion: boolean;
+  };
+  coachInsights?: Array<{
+    id: string;
+    description: string;
+    severity?: 'positive' | 'neutral' | 'warning';
+    category?: string;
+  }>;
+};


### PR DESCRIPTION
### Motivation
- Surface adaptive, explainable weekly journey events inside the Nutrition Campaign panel so users can see campaign phase, momentum, continuity, readiness and AI-coach insights at a glance.

### Description
- Import and render `WeeklyNutritionJourneyTimeline` inside `NutritionCampaignPanel` and pass the campaign progress as a `context` prop.
- Add a new `WeeklyNutritionJourneyTimeline` component that renders a horizontal timeline of derived events with icons, tones, tags, and mini scores.
- Add several event-derivation modules: `journeyTimelineEvents`, `journeyTimelineCampaigns`, `journeyTimelineSemantics`, `journeyTimelineContinuity`, and `journeyTimelineReadiness` to compute timeline events from `JourneyTimelineContext`.
- Add `journeyTimelineTypes.ts` to define `JourneyTimelineEvent` and `JourneyTimelineContext` shapes used across the timeline code.

### Testing
- Ran TypeScript type checking with `tsc --noEmit`, which completed successfully.
- Ran unit tests with `npm test`, and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13203a42148325a098f93537c0fc27)