### PR TITLE
Fix weekly journey timeline initialization crash

### DIFF
--- a/client/src/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline.tsx
+++ b/client/src/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline.tsx
@@ -27,7 +27,7 @@ const iconByType: Record<JourneyTimelineEvent['type'], React.ReactNode> = {
   'ai-coach-event': <Brain className="h-4 w-4" />,
 };
 
-const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+const weekDays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
 const WeeklyNutritionJourneyTimeline: React.FC<Props> = ({ context }) => {
   const [expandedIds, setExpandedIds] = React.useState<Record<string, boolean>>(() => {
@@ -66,7 +66,7 @@ const WeeklyNutritionJourneyTimeline: React.FC<Props> = ({ context }) => {
             {eventsByDay.map((dayEvents, dayIndex) => (
               <div key={dayIndex} className="relative rounded-xl border bg-slate-50/70 p-2">
                 <div className="mb-2 flex items-center justify-between">
-                  <Badge variant="outline" className="text-[10px] uppercase">{days[dayIndex]}</Badge>
+                  <Badge variant="outline" className="text-[10px] uppercase">{weekDays[dayIndex]}</Badge>
                   <span className="text-[10px] text-slate-500">{dayEvents.length} events</span>
                 </div>
 


### PR DESCRIPTION
### Motivation
- Resolve a runtime crash caused by leftover merge artifacts in the weekly timeline render path which led to an initialization collision and the error `Cannot access 'xs' before initialization`.

### Description
- Made a minimal change in `client/src/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline.tsx` by renaming `days` to `weekDays` and keeping the single 7-column daily render path that relies on memoized `events` and `eventsByDay`, while preserving expand/collapse `localStorage` behavior and all event UI (icons, badges, score bars, explainability).

### Testing
- Ran `npm run build:client` which completed successfully (Vite warnings only) and `npm run build:server` which completed successfully and produced `server/dist/index.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a132bebbcf08325a4c1d4da91bb6507)