### PR TITLE
Lazy-load WeeklyNutritionJourneyTimeline with error boundary and localStorage guards

### DIFF
--- a/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
+++ b/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
@@ -7,7 +7,34 @@ import { Badge } from '@/components/ui/badge';
 import { NUTRITION_CAMPAIGN_CATALOG } from '@/components/meal-planner/campaigns/nutritionCampaignCatalog';
 import { NutritionCampaignProgress } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
 import type { NutritionCampaignAdaptiveRecommendation } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
-import WeeklyNutritionJourneyTimeline from '@/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline';
+
+const WeeklyNutritionJourneyTimeline = React.lazy(() => import('@/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline'));
+const ENABLE_JOURNEY_TIMELINE = true;
+
+class TimelineErrorBoundary extends React.Component<React.PropsWithChildren, { hasError: boolean }> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError(): { hasError: boolean } {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error('Journey timeline render failed', error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Card>
+          <CardContent className="pt-6 text-sm text-slate-600">
+            Journey timeline is temporarily unavailable.
+          </CardContent>
+        </Card>
+      );
+    }
+    return this.props.children;
+  }
+}
 
 type Props = {
   activeCampaignId: string | null;
@@ -69,19 +96,31 @@ const NutritionCampaignPanel: React.FC<Props> = ({ activeCampaignId, progress, o
                   <span>{activeCampaign.rewardCopy}</span>
                 </div>
               )}
-              <WeeklyNutritionJourneyTimeline
-                context={{
-                  phase: progress.phase,
-                  phaseNarrative: progress.phaseNarrative,
-                  momentum: progress.momentum,
-                  journeyStability: progress.journeyStability,
-                  transitionReason: progress.transitionReason,
-                  completionPct: progress.completionPct,
-                  completedMissions: progress.completedMissions,
-                  totalMissions: progress.totalMissions,
-                  completionSemantics: progress.completionSemantics,
-                }}
-              />
+              {ENABLE_JOURNEY_TIMELINE && (
+                <React.Suspense
+                  fallback={
+                    <Card>
+                      <CardContent className="pt-6 text-sm text-slate-600">Loading journey timeline…</CardContent>
+                    </Card>
+                  }
+                >
+                  <TimelineErrorBoundary>
+                    <WeeklyNutritionJourneyTimeline
+                      context={{
+                        phase: progress.phase,
+                        phaseNarrative: progress.phaseNarrative,
+                        momentum: progress.momentum,
+                        journeyStability: progress.journeyStability,
+                        transitionReason: progress.transitionReason,
+                        completionPct: progress.completionPct,
+                        completedMissions: progress.completedMissions,
+                        totalMissions: progress.totalMissions,
+                        completionSemantics: progress.completionSemantics,
+                      }}
+                    />
+                  </TimelineErrorBoundary>
+                </React.Suspense>
+              )}
               <Button variant="outline" size="sm" onClick={onClearCampaign}>End Active Campaign</Button>
             </div>
           ) : (

--- a/client/src/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline.tsx
+++ b/client/src/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline.tsx
@@ -27,11 +27,14 @@ const iconByType: Record<JourneyTimelineEvent['type'], React.ReactNode> = {
   'ai-coach-event': <Brain className="h-4 w-4" />,
 };
 
-const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+const weekDays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
 const WeeklyNutritionJourneyTimeline: React.FC<Props> = ({ context }) => {
   const [expandedIds, setExpandedIds] = React.useState<Record<string, boolean>>(() => {
     try {
+      if (typeof window === 'undefined' || !window.localStorage) {
+        return {};
+      }
       const cached = localStorage.getItem('chefsire.journeyTimeline.expanded');
       return cached ? JSON.parse(cached) : {};
     } catch {
@@ -47,7 +50,13 @@ const WeeklyNutritionJourneyTimeline: React.FC<Props> = ({ context }) => {
   const toggleExpanded = (id: string) => {
     setExpandedIds((prev) => {
       const next = { ...prev, [id]: !prev[id] };
-      localStorage.setItem('chefsire.journeyTimeline.expanded', JSON.stringify(next));
+      try {
+        if (typeof window !== 'undefined' && window.localStorage) {
+          localStorage.setItem('chefsire.journeyTimeline.expanded', JSON.stringify(next));
+        }
+      } catch {
+        // Ignore storage write failures to avoid runtime crashes.
+      }
       return next;
     });
   };
@@ -66,7 +75,7 @@ const WeeklyNutritionJourneyTimeline: React.FC<Props> = ({ context }) => {
             {eventsByDay.map((dayEvents, dayIndex) => (
               <div key={dayIndex} className="relative rounded-xl border bg-slate-50/70 p-2">
                 <div className="mb-2 flex items-center justify-between">
-                  <Badge variant="outline" className="text-[10px] uppercase">{days[dayIndex]}</Badge>
+                  <Badge variant="outline" className="text-[10px] uppercase">{weekDays[dayIndex]}</Badge>
                   <span className="text-[10px] text-slate-500">{dayEvents.length} events</span>
                 </div>
 


### PR DESCRIPTION
### Motivation

- Reduce initial bundle size by deferring the heavy journey timeline component and make timeline rendering more resilient to runtime errors.
- Prevent client/server runtime crashes caused by direct `localStorage` access in non-browser environments or when storage operations fail.

### Description

- Replace direct import of `WeeklyNutritionJourneyTimeline` with `React.lazy` and render it inside `React.Suspense` with a loading fallback and an `ENABLE_JOURNEY_TIMELINE` flag. 
- Add `TimelineErrorBoundary` to catch and log rendering errors and show a friendly fallback UI when the timeline fails. 
- Harden `WeeklyNutritionJourneyTimeline` by renaming `days` to `weekDays`, guarding reads and writes to `localStorage` with `typeof window` checks and `try/catch` to avoid exceptions in SSR or when storage is unavailable, and avoid writing on failures. 

### Testing

- Ran type checking and a full frontend build with `yarn build`, which completed successfully. 
- Executed the test suite with `yarn test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a132bebbcf08325a4c1d4da91bb6507)