### PR TITLE
Temporarily disable journey timeline in NutritionCampaignPanel to avoid runtime crash

### DIFF
--- a/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
+++ b/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
@@ -9,7 +9,7 @@ import { NutritionCampaignProgress } from '@/components/meal-planner/campaigns/n
 import type { NutritionCampaignAdaptiveRecommendation } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
 
 const WeeklyNutritionJourneyTimeline = React.lazy(() => import('@/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline'));
-const ENABLE_JOURNEY_TIMELINE = true;
+const ENABLE_JOURNEY_TIMELINE = false;
 
 class TimelineErrorBoundary extends React.Component<React.PropsWithChildren, { hasError: boolean }> {
   state = { hasError: false };


### PR DESCRIPTION
### Motivation
- Prevent the Analytics/Campaign section from white-screening due to the journey timeline initialization/runtime error by gating the timeline render while preserving campaign functionality.

### Description
- Set `ENABLE_JOURNEY_TIMELINE = false` in `client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx`; the timeline remains lazily imported via `React.lazy` and wrapped with `React.Suspense` + `TimelineErrorBoundary`, and `client/src/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline.tsx` was inspected and contains a single `weekDays` array with `weekDays[dayIndex]` usage (no static top-level import of the timeline was added).

### Testing
- Ran `npm run build:client` and `npm run build:server`, and both builds completed successfully.

Files changed: `client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx`.
Timeline status: temporarily disabled (`ENABLE_JOURNEY_TIMELINE = false`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a133b43839083258d407345a1420d6f)