### PR TITLE
Fix "Cannot access before initialization" crash in nutrition campaign panel

### DIFF
--- a/client/src/components/meal-planner/auto-planner/autoPlannerMetrics.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerMetrics.ts
@@ -1,0 +1,74 @@
+import { getMealsForSlot } from '../planner-graph/plannerGraphUtils';
+import { extractMealIngredients } from '../planner-graph/plannerMealExtraction';
+import { calculateMealComplexity } from '../planner-graph/plannerComplexity';
+
+export const detectRepeatedProteins = (meals: any[]) => {
+  const map = new Map<string, number>();
+  meals.forEach((m) => {
+    const key = String(m?.primaryProtein || m?.proteinSource || '').toLowerCase();
+    if (!key) return;
+    map.set(key, (map.get(key) || 0) + 1);
+  });
+  return Array.from(map.entries()).filter(([, count]) => count >= 3);
+};
+
+export const detectIngredientOveruse = (meals: any[]) => {
+  const map = new Map<string, number>();
+  meals.forEach((meal) => extractMealIngredients(meal).forEach((i: any) => {
+    const k = String(i?.name || '').toLowerCase().trim();
+    if (!k) return;
+    map.set(k, (map.get(k) || 0) + 1);
+  }));
+  return Array.from(map.entries()).filter(([, count]) => count >= 4);
+};
+
+export const calculateMealFatigueScore = (meals: any[]) => {
+  const repeatedProteins = detectRepeatedProteins(meals).length;
+  const ingredientOveruse = detectIngredientOveruse(meals).length;
+  const uniqueNames = new Set(meals.map((m) => String(m?.name || '').toLowerCase()).filter(Boolean)).size;
+  const namePenalty = meals.length ? Math.max(0, 100 - Math.round((uniqueNames / meals.length) * 100)) : 0;
+  return Math.max(0, Math.min(100, repeatedProteins * 10 + ingredientOveruse * 7 + namePenalty));
+};
+
+export const calculateDailyPrepStress = (dayMeals: any[]) =>
+  dayMeals.reduce((acc, meal) => acc + Math.max(1, calculateMealComplexity(meal)), 0);
+
+export const calculateIngredientOverlapScore = (meals: any[]) => {
+  const counts = new Map<string, number>();
+  meals.forEach((m) => extractMealIngredients(m).forEach((i: any) => {
+    const k = String(i?.name || '').toLowerCase().trim();
+    if (!k) return;
+    counts.set(k, (counts.get(k) || 0) + 1);
+  }));
+  const reused = Array.from(counts.values()).filter((count) => count > 1).length;
+  return Math.round((reused / Math.max(1, counts.size)) * 100);
+};
+
+export const calculateGroceryFragmentation = (meals: any[]) => {
+  const counts = new Map<string, number>();
+  meals.forEach((m) => extractMealIngredients(m).forEach((i: any) => {
+    const k = String(i?.name || '').toLowerCase().trim();
+    if (!k) return;
+    counts.set(k, (counts.get(k) || 0) + 1);
+  }));
+  const oneOff = Array.from(counts.values()).filter((count) => count === 1).length;
+  return Math.round((oneOff / Math.max(1, counts.size)) * 100);
+};
+
+export const calculatePantryReuseEfficiency = (meals: any[]) => {
+  const pantry = meals.filter((m) => m?.source === 'pantry' || m?.isPantryItem).length;
+  return Math.round((pantry / Math.max(1, meals.length)) * 100);
+};
+
+export const calculateWeeklyPlannerStress = (
+  weeklyMeals: Record<string, any>,
+  weekDays: readonly string[],
+  mealTypes: readonly string[],
+) => {
+  const dayStress = weekDays.map((day) =>
+    calculateDailyPrepStress(mealTypes.flatMap((mealType) => getMealsForSlot(weeklyMeals, day, mealType))),
+  );
+  const max = Math.max(0, ...dayStress);
+  const avg = dayStress.reduce((a, b) => a + b, 0) / Math.max(1, dayStress.length);
+  return Math.round(Math.max(0, max - avg));
+};

--- a/client/src/components/meal-planner/auto-planner/autoPlannerOptimizationEngine.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerOptimizationEngine.ts
@@ -4,77 +4,32 @@ import { type AutoPlannerMode, type AutoPlannerPriorities } from './autoPlannerT
 import { calculateRelationshipEfficiencyScore } from '../meal-relationships/relationshipGraph';
 import { scoreRelationshipDrivenWeek, deriveRelationshipDrivenRecommendations } from '../meal-relationships/relationshipDrivenPlanning';
 import { getMealsForSlot } from '../planner-graph/plannerGraphUtils';
-import { extractMealIngredients } from '../planner-graph/plannerMealExtraction';
-import { calculateMealComplexity } from '../planner-graph/plannerComplexity';
 import { evaluatePlannerObjectives } from '../planner-objectives/plannerObjectiveEngine';
+import {
+  detectRepeatedProteins,
+  detectIngredientOveruse,
+  calculateMealFatigueScore,
+  calculateDailyPrepStress,
+  calculateIngredientOverlapScore,
+  calculateGroceryFragmentation,
+  calculatePantryReuseEfficiency,
+  calculateWeeklyPlannerStress,
+} from './autoPlannerMetrics';
+
+export {
+  detectRepeatedProteins,
+  detectIngredientOveruse,
+  calculateMealFatigueScore,
+  calculateDailyPrepStress,
+  calculateIngredientOverlapScore,
+  calculateGroceryFragmentation,
+  calculatePantryReuseEfficiency,
+  calculateWeeklyPlannerStress,
+};
 
 const gatherMeals = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => (
   weekDays.flatMap((day) => mealTypes.flatMap((mealType) => getMealsForSlot(weeklyMeals, day, mealType))).filter(Boolean)
 );
-
-export const detectRepeatedProteins = (meals: any[]) => {
-  const map = new Map<string, number>();
-  meals.forEach((m) => {
-    const key = String(m?.primaryProtein || m?.proteinSource || '').toLowerCase();
-    if (!key) return;
-    map.set(key, (map.get(key) || 0) + 1);
-  });
-  return Array.from(map.entries()).filter(([, count]) => count >= 3);
-};
-
-export const detectIngredientOveruse = (meals: any[]) => {
-  const map = new Map<string, number>();
-  meals.forEach((meal) => extractMealIngredients(meal).forEach((i: any) => {
-    const k = String(i?.name || '').toLowerCase().trim();
-    if (!k) return;
-    map.set(k, (map.get(k) || 0) + 1);
-  }));
-  return Array.from(map.entries()).filter(([, count]) => count >= 4);
-};
-
-export const calculateMealFatigueScore = (meals: any[]) => {
-  const repeatedProteins = detectRepeatedProteins(meals).length;
-  const ingredientOveruse = detectIngredientOveruse(meals).length;
-  const uniqueNames = new Set(meals.map((m) => String(m?.name || '').toLowerCase()).filter(Boolean)).size;
-  const namePenalty = meals.length ? Math.max(0, 100 - Math.round((uniqueNames / meals.length) * 100)) : 0;
-  return Math.max(0, Math.min(100, repeatedProteins * 10 + ingredientOveruse * 7 + namePenalty));
-};
-
-export const calculateDailyPrepStress = (dayMeals: any[]) => dayMeals.reduce((acc, meal) => acc + Math.max(1, calculateMealComplexity(meal)), 0);
-
-export const calculateIngredientOverlapScore = (meals: any[]) => {
-  const counts = new Map<string, number>();
-  meals.forEach((m) => extractMealIngredients(m).forEach((i: any) => {
-    const k = String(i?.name || '').toLowerCase().trim();
-    if (!k) return;
-    counts.set(k, (counts.get(k) || 0) + 1);
-  }));
-  const reused = Array.from(counts.values()).filter((count) => count > 1).length;
-  return Math.round((reused / Math.max(1, counts.size)) * 100);
-};
-
-export const calculateGroceryFragmentation = (meals: any[]) => {
-  const counts = new Map<string, number>();
-  meals.forEach((m) => extractMealIngredients(m).forEach((i: any) => {
-    const k = String(i?.name || '').toLowerCase().trim();
-    if (!k) return;
-    counts.set(k, (counts.get(k) || 0) + 1);
-  }));
-  const oneOff = Array.from(counts.values()).filter((count) => count === 1).length;
-  return Math.round((oneOff / Math.max(1, counts.size)) * 100);
-};
-
-export const calculatePantryReuseEfficiency = (meals: any[]) => {
-  const pantry = meals.filter((m) => m?.source === 'pantry' || m?.isPantryItem).length;
-  return Math.round((pantry / Math.max(1, meals.length)) * 100);
-};
-
-export const calculateWeeklyPlannerStress = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
-  const dayStress = weekDays.map((day) => calculateDailyPrepStress(mealTypes.flatMap((mealType) => getMealsForSlot(weeklyMeals, day, mealType))));
-  const max = Math.max(0, ...dayStress);
-  const avg = dayStress.reduce((a, b) => a + b, 0) / Math.max(1, dayStress.length);
-  return Math.round(Math.max(0, max - avg));
-};
 
 export const calculateWeeklyOptimizationScore = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
   const meals = gatherMeals(weeklyMeals, weekDays, mealTypes);

--- a/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
+++ b/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
@@ -9,7 +9,7 @@ import { NutritionCampaignProgress } from '@/components/meal-planner/campaigns/n
 import type { NutritionCampaignAdaptiveRecommendation } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
 
 const WeeklyNutritionJourneyTimeline = React.lazy(() => import('@/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline'));
-const ENABLE_JOURNEY_TIMELINE = true;
+const ENABLE_JOURNEY_TIMELINE = false;
 
 class TimelineErrorBoundary extends React.Component<React.PropsWithChildren, { hasError: boolean }> {
   state = { hasError: false };

--- a/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
+++ b/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
@@ -9,7 +9,7 @@ import { NutritionCampaignProgress } from '@/components/meal-planner/campaigns/n
 import type { NutritionCampaignAdaptiveRecommendation } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
 
 const WeeklyNutritionJourneyTimeline = React.lazy(() => import('@/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline'));
-const ENABLE_JOURNEY_TIMELINE = false;
+const ENABLE_JOURNEY_TIMELINE = true;
 
 class TimelineErrorBoundary extends React.Component<React.PropsWithChildren, { hasError: boolean }> {
   state = { hasError: false };

--- a/client/src/components/meal-planner/planner-objectives/plannerObjectiveScoring.ts
+++ b/client/src/components/meal-planner/planner-objectives/plannerObjectiveScoring.ts
@@ -2,7 +2,7 @@ import { calculateWeeklyScores } from '../auto-planner/autoPlannerScoring';
 import { calculateRelationshipEfficiencyScore } from '../meal-relationships/relationshipGraph';
 import { scoreRelationshipDrivenWeek } from '../meal-relationships/relationshipDrivenPlanning';
 import { calculateRecoverySpacing, analyzeWeeklyVarietyRhythm } from '../auto-planner/autoPlannerTradeoffAnalysis';
-import { calculateWeeklyPlannerStress, calculateGroceryFragmentation, calculateIngredientOverlapScore, calculatePantryReuseEfficiency, calculateMealFatigueScore } from '../auto-planner/autoPlannerOptimizationEngine';
+import { calculateWeeklyPlannerStress, calculateGroceryFragmentation, calculateIngredientOverlapScore, calculatePantryReuseEfficiency, calculateMealFatigueScore } from '../auto-planner/autoPlannerMetrics';
 import { calculateFreshnessFlowScore, calculateTemporalFlowScore } from '../auto-planner/autoPlannerRhythmEngine';
 import { getMealsForSlot } from '../planner-graph/plannerGraphUtils';
 import type { ObjectiveContribution, PlannerObjectiveMetrics, PlannerObjectiveProfile } from './plannerObjectiveTypes';


### PR DESCRIPTION
## Root cause

Three-way circular import was causing a JavaScript TDZ (Temporal Dead Zone) crash at runtime, minified in the error as `vs`:

```
plannerObjectiveEngine
  → plannerObjectiveScoring
    → autoPlannerOptimizationEngine
      → plannerObjectiveEngine  ← cycle!
```

When the module loader hit this cycle, a `const` export hadn't been initialized yet — hence "Cannot access 'vs' before initialization".

## Fix

Extracted the pure metric functions (`calculateMealFatigueScore`, `calculateWeeklyPlannerStress`, `calculateIngredientOverlapScore`, `calculateGroceryFragmentation`, `calculatePantryReuseEfficiency`, `detectRepeatedProteins`, `detectIngredientOveruse`, `calculateDailyPrepStress`) into a new `autoPlannerMetrics.ts` file that has **no dependency** on `plannerObjectiveEngine`.

Both `autoPlannerOptimizationEngine` and `plannerObjectiveScoring` now import from `autoPlannerMetrics` — the cycle is broken. `autoPlannerOptimizationEngine` re-exports the functions for backwards compatibility so no other files need changes.

`ENABLE_JOURNEY_TIMELINE` is set back to `true` — the timeline is fully enabled.

## Files changed

- `auto-planner/autoPlannerMetrics.ts` — new file with extracted metric functions
- `auto-planner/autoPlannerOptimizationEngine.ts` — imports from autoPlannerMetrics, re-exports for compatibility
- `planner-objectives/plannerObjectiveScoring.ts` — imports from autoPlannerMetrics instead of autoPlannerOptimizationEngine
- `campaigns/NutritionCampaignPanel.tsx` — `ENABLE_JOURNEY_TIMELINE = true`

## Test plan

- [ ] Navigate to the meal planner nutrition campaign section — no white-screen crash
- [ ] Activate a campaign — Weekly Nutrition Journey Timeline renders correctly
- [ ] `npm run build:client` passes with no errors ✅

https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e)_