### PR TITLE
Fix remaining TDZ circular imports, re-enable journey timeline

### DIFF
--- a/client/src/components/meal-planner/auto-planner/autoPlannerTradeoffAnalysis.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerTradeoffAnalysis.ts
@@ -1,8 +1,7 @@
 import { analyzeCalorieDistribution, analyzeProteinDistribution, calculateMacroBalanceScore } from './autoPlannerContextAnalysis';
-import { calculateGroceryFragmentation, calculateIngredientOverlapScore, calculateMealFatigueScore, calculatePantryReuseEfficiency, calculateWeeklyPlannerStress } from './autoPlannerOptimizationEngine';
+import { calculateGroceryFragmentation, calculateIngredientOverlapScore, calculateMealFatigueScore, calculatePantryReuseEfficiency, calculateWeeklyPlannerStress } from './autoPlannerMetrics';
 import { getMealsForSlot } from '../planner-graph/plannerGraphUtils';
 import { calculateMealComplexity } from '../planner-graph/plannerComplexity';
-import { evaluatePlannerObjectives } from '../planner-objectives/plannerObjectiveEngine';
 
 const gatherMeals = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => (
   weekDays.flatMap((day) => mealTypes.flatMap((mealType) => getMealsForSlot(weeklyMeals, day, mealType))).filter(Boolean)
@@ -76,11 +75,9 @@ export const calculateCompositeOptimizationScore = (weeklyMeals: Record<string, 
   const variety = analyzeWeeklyVarietyRhythm(weeklyMeals, weekDays, mealTypes);
   const tradeoffPenalty = calculateTradeoffPenalty(weeklyMeals, weekDays, mealTypes);
 
-  const legacy = Math.max(0, Math.min(100, Math.round(
+  return Math.max(0, Math.min(100, Math.round(
     macro * 0.2 + pantry * 0.12 + fragmentation * 0.14 + fatigue * 0.16 + weeklyBalance * 0.18 + variety * 0.2 - tradeoffPenalty * 0.12,
   )));
-  const unified = evaluatePlannerObjectives({ weeklyMeals, weekDays, mealTypes, mode: 'balanced' }).score;
-  return Math.round((unified * 0.7) + (legacy * 0.3));
 };
 
 export const deriveOptimizationTradeoffs = (before: Record<string, any>, after: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {

--- a/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
+++ b/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
@@ -9,7 +9,7 @@ import { NutritionCampaignProgress } from '@/components/meal-planner/campaigns/n
 import type { NutritionCampaignAdaptiveRecommendation } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
 
 const WeeklyNutritionJourneyTimeline = React.lazy(() => import('@/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline'));
-const ENABLE_JOURNEY_TIMELINE = false;
+const ENABLE_JOURNEY_TIMELINE = true;
 
 class TimelineErrorBoundary extends React.Component<React.PropsWithChildren, { hasError: boolean }> {
   state = { hasError: false };

--- a/client/src/components/meal-planner/ingredientNormalization.ts
+++ b/client/src/components/meal-planner/ingredientNormalization.ts
@@ -1,0 +1,48 @@
+const SAFE_DESCRIPTORS = new Set([
+  'boneless',
+  'skinless',
+  'fresh',
+  'frozen',
+  'raw',
+  'cooked',
+  'chopped',
+  'diced',
+  'sliced',
+  'minced',
+  'shredded',
+  'grated',
+  'whole',
+  'large',
+  'small',
+  'medium',
+  'extra',
+]);
+
+const singularizeToken = (token: string) => {
+  if (token.length <= 3) return token;
+  if (token.endsWith('ies')) return `${token.slice(0, -3)}y`;
+  if (token.endsWith('oes')) return token.slice(0, -2);
+  if (token.endsWith('ches') || token.endsWith('shes')) return token.slice(0, -2);
+  if (token.endsWith('s') && !token.endsWith('ss')) return token.slice(0, -1);
+  return token;
+};
+
+export const normalizeMealIngredient = (value: unknown) => {
+  const cleaned = String(value ?? '')
+    .toLowerCase()
+    .replace(/[()[\]{}]/g, ' ')
+    .replace(/[.,;:!]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!cleaned) return '';
+
+  const tokens = cleaned
+    .split(' ')
+    .map((token) => token.replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, ''))
+    .filter(Boolean)
+    .filter((token) => !SAFE_DESCRIPTORS.has(token))
+    .map(singularizeToken);
+
+  return tokens.join(' ').trim();
+};

--- a/client/src/components/meal-planner/meal-relationships/relationshipGraph.ts
+++ b/client/src/components/meal-planner/meal-relationships/relationshipGraph.ts
@@ -1,6 +1,6 @@
 import { getAllPlannerMeals } from '../planner-graph/plannerGraphUtils';
 import { extractMealIngredients } from '../planner-graph/plannerMealExtraction';
-import { normalizeMealIngredient } from '../plannerGroceryUtils';
+import { normalizeMealIngredient } from '../ingredientNormalization';
 import { MEAL_TYPES, WEEK_DAYS } from '../nutritionMealPlannerUtils';
 import { buildIngredientRelationshipGraph, detectReusableIngredientClusters } from './ingredientRelationships';
 import { buildLeftoverLifecycleGraph, detectMealCarryoverChains } from './leftoverLifecycle';

--- a/client/src/components/meal-planner/plannerGroceryUtils.ts
+++ b/client/src/components/meal-planner/plannerGroceryUtils.ts
@@ -2,6 +2,8 @@ import { MEAL_TYPES, WEEK_DAYS } from './nutritionMealPlannerUtils';
 import { getMealsForSlot } from './planner-graph/plannerGraphUtils';
 import { extractMealIngredients } from './planner-graph/plannerMealExtraction';
 import { buildMealRelationshipGraph } from './meal-relationships/relationshipGraph';
+import { normalizeMealIngredient } from './ingredientNormalization';
+export { normalizeMealIngredient } from './ingredientNormalization';
 
 export type PlannerGrocerySourceMeal = {
   mealName: string;
@@ -50,26 +52,6 @@ export type PlannerGroceryDerivationState = {
   editedById?: Record<string, { name?: string; quantitySummary?: string; category?: string }>;
 };
 
-const SAFE_DESCRIPTORS = new Set([
-  'boneless',
-  'skinless',
-  'fresh',
-  'frozen',
-  'raw',
-  'cooked',
-  'chopped',
-  'diced',
-  'sliced',
-  'minced',
-  'shredded',
-  'grated',
-  'whole',
-  'large',
-  'small',
-  'medium',
-  'extra',
-]);
-
 const GENERIC_COMPONENT_WORDS = new Set([
   'serving',
   'servings',
@@ -90,35 +72,6 @@ const titleCase = (value: string) => value
   .filter(Boolean)
   .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
   .join(' ');
-
-const singularizeToken = (token: string) => {
-  if (token.length <= 3) return token;
-  if (token.endsWith('ies')) return `${token.slice(0, -3)}y`;
-  if (token.endsWith('oes')) return token.slice(0, -2);
-  if (token.endsWith('ches') || token.endsWith('shes')) return token.slice(0, -2);
-  if (token.endsWith('s') && !token.endsWith('ss')) return token.slice(0, -1);
-  return token;
-};
-
-export const normalizeMealIngredient = (value: unknown) => {
-  const cleaned = String(value ?? '')
-    .toLowerCase()
-    .replace(/[()[\]{}]/g, ' ')
-    .replace(/[.,;:!]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-
-  if (!cleaned) return '';
-
-  const tokens = cleaned
-    .split(' ')
-    .map((token) => token.replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, ''))
-    .filter(Boolean)
-    .filter((token) => !SAFE_DESCRIPTORS.has(token))
-    .map(singularizeToken);
-
-  return tokens.join(' ').trim();
-};
 
 const isUsefulIngredient = (name: string) => {
   const normalized = normalizeMealIngredient(name);


### PR DESCRIPTION
## Two more circular import cycles fixed

The previous PR fixed one cycle but two more remained, each capable of triggering "Cannot access 'vs' before initialization".

### Cycle A — `relationshipGraph` ↔ `plannerGroceryUtils`
```
relationshipGraph → plannerGroceryUtils → relationshipGraph
```
`plannerGroceryUtils` imported `buildMealRelationshipGraph` from `relationshipGraph`, while `relationshipGraph` imported `normalizeMealIngredient` back from `plannerGroceryUtils`.

**Fix:** moved `normalizeMealIngredient` and its private helpers (`SAFE_DESCRIPTORS`, `singularizeToken`) into a new `ingredientNormalization.ts` that has zero upward dependencies. Both files now import from there.

### Cycle B — `autoPlannerTradeoffAnalysis` → `plannerObjectiveEngine`
```
plannerObjectiveEngine → plannerObjectiveScoring
  → autoPlannerTradeoffAnalysis → plannerObjectiveEngine
```
`autoPlannerTradeoffAnalysis` imported `evaluatePlannerObjectives` from `plannerObjectiveEngine` just to blend two scores together in `calculateCompositeOptimizationScore`. Since `plannerObjectiveScoring` (which `plannerObjectiveEngine` depends on) imports from `autoPlannerTradeoffAnalysis`, this closed the cycle.

**Fix:** removed the `evaluatePlannerObjectives` import from `autoPlannerTradeoffAnalysis`. `calculateCompositeOptimizationScore` now returns the legacy composite score directly. Also switched its metrics imports to `autoPlannerMetrics` to avoid the re-export chain.

### Timeline re-enabled
`ENABLE_JOURNEY_TIMELINE = true` — the journey timeline is fully live.

## Test plan
- [ ] Load the meal planner — no white-screen crash
- [ ] Activate a nutrition campaign — Weekly Journey Timeline renders
- [ ] `npm run build:client` passes ✅

https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e)_