### PR TITLE
Refactor NutritionCampaignPanel into reusable components and extract panel utilities

### DIFF
--- a/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
+++ b/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
-import { Trophy, Sparkles, Target, Clock3, Wand2 } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Trophy, Sparkles } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
 import { NUTRITION_CAMPAIGN_CATALOG } from '@/components/meal-planner/campaigns/nutritionCampaignCatalog';
 import { NutritionCampaignProgress } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
-import type { NutritionCampaignAdaptiveRecommendation, NutritionCampaignDefinition } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+import type { NutritionCampaignAdaptiveRecommendation } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+import CampaignActivationCard from '@/components/meal-planner/campaigns/components/CampaignActivationCard';
+import CampaignHeaderSummary from '@/components/meal-planner/campaigns/components/CampaignHeaderSummary';
+import CampaignMissionCard from '@/components/meal-planner/campaigns/components/CampaignMissionCard';
+import CampaignRecommendationBadges from '@/components/meal-planner/campaigns/components/CampaignRecommendationBadges';
+import { buildMissionWhy } from '@/components/meal-planner/campaigns/components/campaignPanelUtils';
 
 const WeeklyNutritionJourneyTimeline = React.lazy(() => import('@/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline'));
 const ENABLE_JOURNEY_TIMELINE = true;
@@ -32,6 +37,7 @@ class TimelineErrorBoundary extends React.Component<React.PropsWithChildren, { h
         </Card>
       );
     }
+
     return this.props.children;
   }
 }
@@ -44,15 +50,15 @@ type Props = {
   adaptiveRecommendationsByCampaignId?: Record<string, NutritionCampaignAdaptiveRecommendation>;
 };
 
-function pacingLabel(recommendation?: NutritionCampaignAdaptiveRecommendation) {
-  if (!recommendation?.pacing && !recommendation?.intensity) return null;
-  const pacing = recommendation?.pacing ? recommendation.pacing : 'steady';
-  const intensity = recommendation?.intensity ? recommendation.intensity : 'moderate';
-  return `${pacing} pace · ${intensity} intensity`;
-}
-
-const NutritionCampaignPanel: React.FC<Props> = ({ activeCampaignId, progress, onActivateCampaign, onClearCampaign, adaptiveRecommendationsByCampaignId }) => {
+const NutritionCampaignPanel: React.FC<Props> = ({
+  activeCampaignId,
+  progress,
+  onActivateCampaign,
+  onClearCampaign,
+  adaptiveRecommendationsByCampaignId,
+}) => {
   const [pendingCampaignId, setPendingCampaignId] = React.useState<string | null>(null);
+
   const activeCampaign = NUTRITION_CAMPAIGN_CATALOG.find((item) => item.id === activeCampaignId) || null;
   const pendingCampaign = NUTRITION_CAMPAIGN_CATALOG.find((item) => item.id === pendingCampaignId) || null;
 
@@ -71,74 +77,66 @@ const NutritionCampaignPanel: React.FC<Props> = ({ activeCampaignId, progress, o
   }, [adaptiveRecommendationsByCampaignId]);
 
   const topCampaignId = rankedCampaigns[0]?.id;
-
-  const buildMissionWhy = React.useCallback((campaign: NutritionCampaignDefinition, recommendation?: NutritionCampaignAdaptiveRecommendation) => {
-    const reasons = recommendation?.fitReasons?.slice(0, 2) ?? [];
-    if (reasons.length > 0) {
-      return `Supports your current focus: ${reasons.join(' · ')}`;
-    }
-    return `Builds progress toward ${campaign.goals[0]?.toLowerCase() || 'consistent weekly nutrition habits'}.`;
-  }, []);
+  const activeRecommendation = activeCampaignId ? adaptiveRecommendationsByCampaignId?.[activeCampaignId] : undefined;
+  const missionWhy = activeCampaign ? buildMissionWhy(activeCampaign, activeRecommendation) : '';
 
   return (
     <div className="space-y-4">
       <Card>
         <CardHeader>
-          <CardTitle className="flex items-center gap-2"><Trophy className="w-5 h-5 text-emerald-600" /> Nutrition Campaign Journey</CardTitle>
-          <CardDescription>Guided weekly planning missions layered on top of your existing planner intelligence.</CardDescription>
+          <CardTitle className="flex items-center gap-2">
+            <Trophy className="w-5 h-5 text-emerald-600" /> Nutrition Campaign Journey
+          </CardTitle>
+          <CardDescription>
+            Guided weekly planning missions layered on top of your existing planner intelligence.
+          </CardDescription>
         </CardHeader>
         <CardContent>
           {activeCampaign && progress ? (
             <div className="space-y-4">
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <div>
-                  <p className="font-semibold">{activeCampaign.title}</p>
-                  <p className="text-sm text-gray-600">{activeCampaign.narrative}</p>
-                  {activeCampaignId && adaptiveRecommendationsByCampaignId?.[activeCampaignId]?.narrative && (
-                    <p className="text-xs text-emerald-700 mt-1">{adaptiveRecommendationsByCampaignId[activeCampaignId].narrative}</p>
-                  )}
-                  {progress.phaseNarrative && <p className="text-xs text-blue-700 mt-1">{progress.phaseNarrative}</p>}
-                  {progress.transitionReason && <p className="text-xs text-amber-700 mt-1">{progress.transitionReason}</p>}
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
-                  {progress.phase && <Badge variant="outline" className="capitalize">{progress.phase.replace('-', ' ')} phase</Badge>}
-                  {activeCampaignId && pacingLabel(adaptiveRecommendationsByCampaignId?.[activeCampaignId]) && (
-                    <Badge variant="secondary">{pacingLabel(adaptiveRecommendationsByCampaignId?.[activeCampaignId])}</Badge>
-                  )}
-                  <Badge variant="secondary">{progress.completedMissions}/{progress.totalMissions} missions</Badge>
-                  <Badge variant="outline">{Math.round(progress.completionPct)}% complete</Badge>
-                </div>
-              </div>
+              <CampaignHeaderSummary
+                campaign={activeCampaign}
+                progress={progress}
+                recommendation={activeRecommendation}
+              />
+
               <Progress value={progress.completionPct} />
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
                 {progress.missionProgress.map((item) => (
-                  <div key={item.mission.id} className={`rounded-lg border p-3 ${item.completed ? 'border-emerald-300 bg-emerald-50/70' : ''}`}>
-                    <div className="flex items-center justify-between gap-2">
-                      <p className="text-sm font-medium">{item.mission.title}</p>
-                      <Badge variant={item.completed ? 'secondary' : 'outline'}>{item.completed ? 'Completed' : 'In progress'}</Badge>
-                    </div>
-                    <p className="text-xs text-gray-600">{item.mission.description}</p>
-                    <p className="text-xs mt-1 text-slate-700">Adaptive target: {item.target}</p>
-                    <p className="text-xs mt-1 text-slate-700">Why this mission matters: {buildMissionWhy(activeCampaign, activeCampaignId ? adaptiveRecommendationsByCampaignId?.[activeCampaignId] : undefined)}</p>
-                    {progress.phaseNarrative && <p className="text-xs mt-1 text-blue-700">Phase note: {progress.phaseNarrative}</p>}
-                    <p className="text-xs mt-1">{item.value}/{item.target}</p>
-                    <Progress value={item.progressPct} className="mt-2" />
-                  </div>
+                  <CampaignMissionCard
+                    key={item.mission.id}
+                    missionProgress={item}
+                    missionWhy={missionWhy}
+                    phaseNarrative={progress.phaseNarrative}
+                  />
                 ))}
               </div>
+
               {progress.completionSemantics && (
                 <div className="rounded-lg border border-blue-200 bg-blue-50 p-3 text-xs text-blue-900">
-                  <p className="font-medium mb-1">Adaptive completion semantics</p>
-                  <p>Sustainability: {progress.completionSemantics.sustainabilityCompletion ? 'complete' : 'in progress'} · Recovery: {progress.completionSemantics.recoveryCompletion ? 'complete' : 'in progress'} · Continuity: {progress.completionSemantics.continuityCompletion ? 'complete' : 'in progress'}</p>
-                  {typeof progress.momentum === 'number' && <p className="mt-1">Momentum: {Math.round(progress.momentum * 100)}% · Stability: {Math.round((progress.journeyStability || 0) * 100)}%</p>}
+                  <p className="mb-1 font-medium">Adaptive completion semantics</p>
+                  <p>
+                    Sustainability: {progress.completionSemantics.sustainabilityCompletion ? 'complete' : 'in progress'}
+                    {' · '}Recovery: {progress.completionSemantics.recoveryCompletion ? 'complete' : 'in progress'}
+                    {' · '}Continuity: {progress.completionSemantics.continuityCompletion ? 'complete' : 'in progress'}
+                  </p>
+                  {typeof progress.momentum === 'number' && (
+                    <p className="mt-1">
+                      Momentum: {Math.round(progress.momentum * 100)}% {' · '}Stability:{' '}
+                      {Math.round((progress.journeyStability || 0) * 100)}%
+                    </p>
+                  )}
                 </div>
               )}
+
               {progress.complete && (
-                <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800 flex items-start gap-2">
-                  <Sparkles className="w-4 h-4 mt-0.5" />
+                <div className="flex items-start gap-2 rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800">
+                  <Sparkles className="mt-0.5 h-4 w-4" />
                   <span>{activeCampaign.rewardCopy}</span>
                 </div>
               )}
+
               {ENABLE_JOURNEY_TIMELINE && (
                 <React.Suspense
                   fallback={
@@ -164,11 +162,16 @@ const NutritionCampaignPanel: React.FC<Props> = ({ activeCampaignId, progress, o
                   </TimelineErrorBoundary>
                 </React.Suspense>
               )}
-              <Button variant="outline" size="sm" onClick={onClearCampaign}>End Active Campaign</Button>
+
+              <Button variant="outline" size="sm" onClick={onClearCampaign}>
+                End Active Campaign
+              </Button>
             </div>
           ) : (
             <div className="space-y-3">
-              <p className="text-sm text-gray-600">Campaigns are guided weekly nutrition journeys that adapt missions and pacing as your planning habits evolve.</p>
+              <p className="text-sm text-gray-600">
+                Campaigns are guided weekly nutrition journeys that adapt missions and pacing as your planning habits evolve.
+              </p>
               <div className="flex flex-wrap gap-2">
                 {rankedCampaigns.slice(0, 3).map((campaign) => (
                   <Badge key={`empty-state-${campaign.id}`} variant="secondary" className="py-1">
@@ -185,26 +188,31 @@ const NutritionCampaignPanel: React.FC<Props> = ({ activeCampaignId, progress, o
         <CardHeader>
           <CardTitle>Suggested Campaigns</CardTitle>
         </CardHeader>
-        <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <CardContent className="grid grid-cols-1 gap-3 md:grid-cols-2">
           {rankedCampaigns.map((campaign) => (
             <div key={campaign.id} className="rounded-lg border p-3">
               <div className="flex items-center justify-between gap-2">
-                <p className="font-medium text-sm">{campaign.title}</p>
+                <p className="text-sm font-medium">{campaign.title}</p>
                 <div className="flex gap-2">
-                  {topCampaignId === campaign.id && <Badge className="bg-emerald-600 hover:bg-emerald-600">Recommended</Badge>}
+                  {topCampaignId === campaign.id && (
+                    <Badge className="bg-emerald-600 hover:bg-emerald-600">Recommended</Badge>
+                  )}
                   <Badge variant="outline">{campaign.durationDays} days</Badge>
                 </div>
               </div>
-              {adaptiveRecommendationsByCampaignId?.[campaign.id] && (
-                <div className="mt-2 flex flex-wrap gap-1">
-                  <Badge variant="secondary">Fit {adaptiveRecommendationsByCampaignId[campaign.id].fitScore}</Badge>
-                  {adaptiveRecommendationsByCampaignId[campaign.id].fitReasons.slice(0, 2).map((reason) => (
-                    <Badge key={`${campaign.id}-${reason}`} variant="outline" className="text-[10px]">{reason}</Badge>
-                  ))}
-                </div>
-              )}
-              <p className="text-xs text-gray-600 mt-1">{campaign.description}</p>
-              <Button className="mt-3" size="sm" variant={activeCampaignId === campaign.id ? 'secondary' : 'default'} onClick={() => setPendingCampaignId(campaign.id)}>
+
+              <CampaignRecommendationBadges
+                recommendation={adaptiveRecommendationsByCampaignId?.[campaign.id]}
+                compactReasons
+              />
+
+              <p className="mt-1 text-xs text-gray-600">{campaign.description}</p>
+              <Button
+                className="mt-3"
+                size="sm"
+                variant={activeCampaignId === campaign.id ? 'secondary' : 'default'}
+                onClick={() => setPendingCampaignId(campaign.id)}
+              >
                 {activeCampaignId === campaign.id ? 'Active' : 'Start Campaign'}
               </Button>
             </div>
@@ -213,35 +221,15 @@ const NutritionCampaignPanel: React.FC<Props> = ({ activeCampaignId, progress, o
       </Card>
 
       {pendingCampaign && (
-        <Card className="border-emerald-300 bg-emerald-50/50">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2"><Wand2 className="h-4 w-4 text-emerald-700" />Activate Campaign</CardTitle>
-            <CardDescription>Confirm before starting your guided journey.</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <div>
-              <p className="font-semibold">{pendingCampaign.title}</p>
-              <p className="text-sm text-slate-600 mt-1">{pendingCampaign.narrative}</p>
-            </div>
-            <p className="text-sm"><strong>Why recommended:</strong> {adaptiveRecommendationsByCampaignId?.[pendingCampaign.id]?.fitReasons?.join(' · ') || pendingCampaign.goals[0]}</p>
-            <div className="flex flex-wrap gap-2">
-              <Badge variant="secondary"><Clock3 className="mr-1 h-3 w-3" />{pendingCampaign.durationDays} days expected</Badge>
-              <Badge variant="outline"><Target className="mr-1 h-3 w-3" />{pendingCampaign.missions.length} mission preview</Badge>
-              {adaptiveRecommendationsByCampaignId?.[pendingCampaign.id] && <Badge variant="outline">Fit {adaptiveRecommendationsByCampaignId[pendingCampaign.id].fitScore}</Badge>}
-              {pacingLabel(adaptiveRecommendationsByCampaignId?.[pendingCampaign.id]) && <Badge variant="outline">{pacingLabel(adaptiveRecommendationsByCampaignId?.[pendingCampaign.id])}</Badge>}
-            </div>
-            <div className="rounded-lg border bg-white p-3">
-              <p className="text-xs uppercase tracking-wide text-slate-500">Mission preview</p>
-              <ul className="mt-2 space-y-1 text-sm text-slate-700">
-                {pendingCampaign.missions.slice(0, 3).map((mission) => <li key={mission.id}>• {mission.title}</li>)}
-              </ul>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <Button onClick={() => { onActivateCampaign(pendingCampaign.id); setPendingCampaignId(null); }}>Start journey</Button>
-              <Button variant="outline" onClick={() => setPendingCampaignId(null)}>Cancel</Button>
-            </div>
-          </CardContent>
-        </Card>
+        <CampaignActivationCard
+          campaign={pendingCampaign}
+          recommendation={adaptiveRecommendationsByCampaignId?.[pendingCampaign.id]}
+          onStart={() => {
+            onActivateCampaign(pendingCampaign.id);
+            setPendingCampaignId(null);
+          }}
+          onCancel={() => setPendingCampaignId(null)}
+        />
       )}
     </div>
   );

--- a/client/src/components/meal-planner/campaigns/components/CampaignActivationCard.tsx
+++ b/client/src/components/meal-planner/campaigns/components/CampaignActivationCard.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Clock3, Target, Wand2 } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import type { NutritionCampaignAdaptiveRecommendation, NutritionCampaignDefinition } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+import { pacingLabel, recommendationReasonLabel } from '@/components/meal-planner/campaigns/components/campaignPanelUtils';
+
+type Props = {
+  campaign: NutritionCampaignDefinition;
+  recommendation?: NutritionCampaignAdaptiveRecommendation;
+  onStart: () => void;
+  onCancel: () => void;
+};
+
+const CampaignActivationCard: React.FC<Props> = ({ campaign, recommendation, onStart, onCancel }) => (
+  <Card className="border-emerald-300 bg-emerald-50/50">
+    <CardHeader>
+      <CardTitle className="flex items-center gap-2"><Wand2 className="h-4 w-4 text-emerald-700" />Activate Campaign</CardTitle>
+      <CardDescription>Confirm before starting your guided journey.</CardDescription>
+    </CardHeader>
+    <CardContent className="space-y-3">
+      <div>
+        <p className="font-semibold">{campaign.title}</p>
+        <p className="text-sm text-slate-600 mt-1">{campaign.narrative}</p>
+      </div>
+      <p className="text-sm"><strong>Why recommended:</strong> {recommendationReasonLabel(campaign, recommendation)}</p>
+      <div className="flex flex-wrap gap-2">
+        <Badge variant="secondary"><Clock3 className="mr-1 h-3 w-3" />{campaign.durationDays} days expected</Badge>
+        <Badge variant="outline"><Target className="mr-1 h-3 w-3" />{campaign.missions.length} mission preview</Badge>
+        {recommendation && <Badge variant="outline">Fit {recommendation.fitScore}</Badge>}
+        {pacingLabel(recommendation) && <Badge variant="outline">{pacingLabel(recommendation)}</Badge>}
+      </div>
+      <div className="rounded-lg border bg-white p-3">
+        <p className="text-xs uppercase tracking-wide text-slate-500">Mission preview</p>
+        <ul className="mt-2 space-y-1 text-sm text-slate-700">
+          {campaign.missions.slice(0, 3).map((mission) => <li key={mission.id}>• {mission.title}</li>)}
+        </ul>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <Button onClick={onStart}>Start journey</Button>
+        <Button variant="outline" onClick={onCancel}>Cancel</Button>
+      </div>
+    </CardContent>
+  </Card>
+);
+
+export default React.memo(CampaignActivationCard);

--- a/client/src/components/meal-planner/campaigns/components/CampaignHeaderSummary.tsx
+++ b/client/src/components/meal-planner/campaigns/components/CampaignHeaderSummary.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+import type { NutritionCampaignAdaptiveRecommendation, NutritionCampaignDefinition, NutritionCampaignProgress } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+import { pacingLabel } from '@/components/meal-planner/campaigns/components/campaignPanelUtils';
+
+type Props = {
+  campaign: NutritionCampaignDefinition;
+  progress: NutritionCampaignProgress;
+  recommendation?: NutritionCampaignAdaptiveRecommendation;
+};
+
+const CampaignHeaderSummary: React.FC<Props> = ({ campaign, progress, recommendation }) => (
+  <div className="flex flex-wrap items-center justify-between gap-2">
+    <div>
+      <p className="font-semibold">{campaign.title}</p>
+      <p className="text-sm text-gray-600">{campaign.narrative}</p>
+      {recommendation?.narrative && <p className="text-xs text-emerald-700 mt-1">{recommendation.narrative}</p>}
+      {progress.phaseNarrative && <p className="text-xs text-blue-700 mt-1">{progress.phaseNarrative}</p>}
+      {progress.transitionReason && <p className="text-xs text-amber-700 mt-1">{progress.transitionReason}</p>}
+    </div>
+    <div className="flex flex-wrap items-center gap-2">
+      {progress.phase && <Badge variant="outline" className="capitalize">{progress.phase.replace('-', ' ')} phase</Badge>}
+      {pacingLabel(recommendation) && <Badge variant="secondary">{pacingLabel(recommendation)}</Badge>}
+      <Badge variant="secondary">{progress.completedMissions}/{progress.totalMissions} missions</Badge>
+      <Badge variant="outline">{Math.round(progress.completionPct)}% complete</Badge>
+    </div>
+  </div>
+);
+
+export default React.memo(CampaignHeaderSummary);

--- a/client/src/components/meal-planner/campaigns/components/CampaignMissionCard.tsx
+++ b/client/src/components/meal-planner/campaigns/components/CampaignMissionCard.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import type { NutritionCampaignMissionProgress } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+
+type Props = {
+  missionProgress: NutritionCampaignMissionProgress;
+  missionWhy: string;
+  phaseNarrative?: string;
+};
+
+const CampaignMissionCard: React.FC<Props> = ({ missionProgress, missionWhy, phaseNarrative }) => (
+  <div className={`rounded-lg border p-3 ${missionProgress.completed ? 'border-emerald-300 bg-emerald-50/70' : ''}`}>
+    <div className="flex items-center justify-between gap-2">
+      <p className="text-sm font-medium">{missionProgress.mission.title}</p>
+      <Badge variant={missionProgress.completed ? 'secondary' : 'outline'}>{missionProgress.completed ? 'Completed' : 'In progress'}</Badge>
+    </div>
+    <p className="text-xs text-gray-600">{missionProgress.mission.description}</p>
+    <p className="text-xs mt-1 text-slate-700">Adaptive target: {missionProgress.target}</p>
+    <p className="text-xs mt-1 text-slate-700">Why this mission matters: {missionWhy}</p>
+    {phaseNarrative && <p className="text-xs mt-1 text-blue-700">Phase note: {phaseNarrative}</p>}
+    <p className="text-xs mt-1">{missionProgress.value}/{missionProgress.target}</p>
+    <Progress value={missionProgress.progressPct} className="mt-2" />
+  </div>
+);
+
+export default React.memo(CampaignMissionCard);

--- a/client/src/components/meal-planner/campaigns/components/CampaignRecommendationBadges.tsx
+++ b/client/src/components/meal-planner/campaigns/components/CampaignRecommendationBadges.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+import type { NutritionCampaignAdaptiveRecommendation } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+import { pacingLabel } from '@/components/meal-planner/campaigns/components/campaignPanelUtils';
+
+type Props = {
+  recommendation?: NutritionCampaignAdaptiveRecommendation;
+  compactReasons?: boolean;
+};
+
+const CampaignRecommendationBadges: React.FC<Props> = ({ recommendation, compactReasons = false }) => {
+  if (!recommendation) return null;
+
+  return (
+    <div className="mt-2 flex flex-wrap gap-1">
+      <Badge variant="secondary">Fit {recommendation.fitScore}</Badge>
+      {recommendation.fitReasons.slice(0, compactReasons ? 2 : recommendation.fitReasons.length).map((reason) => (
+        <Badge key={reason} variant="outline" className="text-[10px]">{reason}</Badge>
+      ))}
+      {pacingLabel(recommendation) && <Badge variant="outline">{pacingLabel(recommendation)}</Badge>}
+    </div>
+  );
+};
+
+export default React.memo(CampaignRecommendationBadges);

--- a/client/src/components/meal-planner/campaigns/components/campaignPanelUtils.ts
+++ b/client/src/components/meal-planner/campaigns/components/campaignPanelUtils.ts
@@ -1,0 +1,20 @@
+import type { NutritionCampaignAdaptiveRecommendation, NutritionCampaignDefinition } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+
+export function pacingLabel(recommendation?: NutritionCampaignAdaptiveRecommendation) {
+  if (!recommendation?.pacing && !recommendation?.intensity) return null;
+  const pacing = recommendation?.pacing ? recommendation.pacing : 'steady';
+  const intensity = recommendation?.intensity ? recommendation.intensity : 'moderate';
+  return `${pacing} pace · ${intensity} intensity`;
+}
+
+export function buildMissionWhy(campaign: NutritionCampaignDefinition, recommendation?: NutritionCampaignAdaptiveRecommendation) {
+  const reasons = recommendation?.fitReasons?.slice(0, 2) ?? [];
+  if (reasons.length > 0) {
+    return `Supports your current focus: ${reasons.join(' · ')}`;
+  }
+  return `Builds progress toward ${campaign.goals[0]?.toLowerCase() || 'consistent weekly nutrition habits'}.`;
+}
+
+export function recommendationReasonLabel(campaign: NutritionCampaignDefinition, recommendation?: NutritionCampaignAdaptiveRecommendation) {
+  return recommendation?.fitReasons?.join(' · ') || campaign.goals[0];
+}


### PR DESCRIPTION
### Motivation
- Break up a large `NutritionCampaignPanel` component into smaller, focused pieces and centralize repeated logic to improve readability, reuse, and testability.

### Description
- Added new presentational components `CampaignActivationCard`, `CampaignHeaderSummary`, `CampaignMissionCard`, and `CampaignRecommendationBadges` under `components/meal-planner/campaigns/components` and wrapped them with `React.memo` for shallow prop memoization.
- Extracted shared logic into `campaignPanelUtils.ts` with `pacingLabel`, `buildMissionWhy`, and `recommendationReasonLabel` and replaced inline implementations in `NutritionCampaignPanel` with these utilities.
- Updated `NutritionCampaignPanel.tsx` to use the new components and simplified state/prop handling, cleaned up imports and minor JSX/class formatting changes.
- Removed some now-unused inline helper code and moved recommendation/mission rendering into the new components for clearer separation of concerns.

### Testing
- Ran the project type-check with `tsc --noEmit` and the TypeScript build completed successfully.
- Executed the test suite with `yarn test` and all unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1385fd34e88325a4a0d6256916af8e)