### PR TITLE
Implement campaign identity & sharing foundation for Nutrition Planner

### DIFF
--- a/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
+++ b/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
@@ -21,6 +21,12 @@ import { deriveCampaignJourneyType, deriveJourneyCategoryNarrative } from '@/com
 import { deriveCoachCampaignInsights, deriveCampaignInterventionReasoning } from '@/components/meal-planner/campaigns/ecosystem/coachCampaignIntegration';
 import { deriveCampaignEvents } from '@/components/meal-planner/campaigns/ecosystem/campaignEvents';
 
+import { deriveCampaignIdentity } from '@/components/meal-planner/campaigns/identity/campaignIdentity';
+import { deriveCampaignRemix, deriveCampaignRemixNarrative } from '@/components/meal-planner/campaigns/identity/campaignRemix';
+import { deriveCampaignCollections } from '@/components/meal-planner/campaigns/identity/campaignCollections';
+import { deriveCampaignLineage, deriveCampaignEvolutionNarrative } from '@/components/meal-planner/campaigns/identity/campaignLineage';
+import { getSavedCampaigns, removeSavedCampaign, saveCampaignIdentity } from '@/components/meal-planner/campaigns/identity/savedCampaignStore';
+
 const WeeklyNutritionJourneyTimeline = React.lazy(() => import('@/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline'));
 const ENABLE_JOURNEY_TIMELINE = true;
 
@@ -66,6 +72,24 @@ const NutritionCampaignPanel: React.FC<Props> = ({
   adaptiveRecommendationsByCampaignId,
 }) => {
   const [pendingCampaignId, setPendingCampaignId] = React.useState<string | null>(null);
+  const [savedCampaignIds, setSavedCampaignIds] = React.useState<Set<string>>(() => new Set(getSavedCampaigns().map((item) => item.campaignId)));
+
+  const toggleSavedCampaign = React.useCallback((campaignId: string) => {
+    const campaign = NUTRITION_CAMPAIGN_CATALOG.find((item) => item.id === campaignId);
+    if (!campaign) return;
+    const creator = deriveCreatorCampaignRecommendations([campaign], adaptiveRecommendationsByCampaignId)[campaign.id]?.creatorName;
+    setSavedCampaignIds((prev) => {
+      if (prev.has(campaignId)) {
+        removeSavedCampaign(campaignId);
+        const next = new Set(prev);
+        next.delete(campaignId);
+        return next;
+      }
+      const identity = deriveCampaignIdentity(campaign, progress, creator);
+      saveCampaignIdentity(identity);
+      return new Set(prev).add(campaignId);
+    });
+  }, [adaptiveRecommendationsByCampaignId, progress]);
 
   const activeCampaign = NUTRITION_CAMPAIGN_CATALOG.find((item) => item.id === activeCampaignId) || null;
   const pendingCampaign = NUTRITION_CAMPAIGN_CATALOG.find((item) => item.id === pendingCampaignId) || null;
@@ -106,6 +130,7 @@ const NutritionCampaignPanel: React.FC<Props> = ({
     [rankedCampaigns, adaptiveRecommendationsByCampaignId, progress],
   );
   const campaignEvents = React.useMemo(() => deriveCampaignEvents(progress), [progress]);
+  const collections = React.useMemo(() => deriveCampaignCollections(rankedCampaigns), [rankedCampaigns]);
 
   return (
     <div className="space-y-4">
@@ -284,6 +309,24 @@ const NutritionCampaignPanel: React.FC<Props> = ({
                 })()}
               </div>
 
+
+              {(() => {
+                const creatorName = creatorTemplatesByCampaignId[campaign.id]?.creatorName;
+                const identity = deriveCampaignIdentity(campaign, progress, creatorName);
+                const remix = deriveCampaignRemix(campaign, { householdContinuity: campaign.theme === 'leftovers' });
+                const lineage = deriveCampaignLineage(campaign, remix, creatorName);
+                const collection = collections.find((item) => item.campaignIds.includes(campaign.id));
+                return (
+                  <div className={`mt-2 rounded-md border p-2 text-[11px] ${identity.visualIdentity.bgClassName} ${identity.visualIdentity.borderClassName} ${identity.visualIdentity.textClassName}`}>
+                    <p className="font-medium">{identity.journeySignature}</p>
+                    <p>{identity.creatorAttribution}</p>
+                    <p>{deriveCampaignRemixNarrative(remix)}</p>
+                    <p>{deriveCampaignEvolutionNarrative(lineage)}</p>
+                    {collection && <p>Collection: {collection.label}</p>}
+                  </div>
+                );
+              })()}
+
               <CampaignRecommendationBadges
                 recommendation={adaptiveRecommendationsByCampaignId?.[campaign.id]}
                 compactReasons
@@ -297,6 +340,14 @@ const NutritionCampaignPanel: React.FC<Props> = ({
                 onClick={() => setPendingCampaignId(campaign.id)}
               >
                 {activeCampaignId === campaign.id ? 'Active' : 'Start Campaign'}
+              </Button>
+              <Button
+                className="mt-2"
+                size="sm"
+                variant="outline"
+                onClick={() => toggleSavedCampaign(campaign.id)}
+              >
+                {savedCampaignIds.has(campaign.id) ? 'Saved' : 'Save Campaign'}
               </Button>
             </div>
           ))}

--- a/client/src/components/meal-planner/campaigns/identity/campaignCollections.ts
+++ b/client/src/components/meal-planner/campaigns/identity/campaignCollections.ts
@@ -1,0 +1,37 @@
+import type { NutritionCampaignDefinition } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+
+const COLLECTION_STORAGE_KEY = 'mealPlanner.campaignCollections.v1';
+
+export type NutritionCampaignCollection = {
+  id: string;
+  label: string;
+  campaignIds: string[];
+};
+
+export const deriveCampaignCollections = (campaigns: NutritionCampaignDefinition[]): NutritionCampaignCollection[] => {
+  const byTheme = (id: string, label: string, predicate: (campaign: NutritionCampaignDefinition) => boolean): NutritionCampaignCollection => ({
+    id,
+    label,
+    campaignIds: campaigns.filter(predicate).map((campaign) => campaign.id),
+  });
+  return [
+    byTheme('recovery', 'Recovery journeys', (campaign) => campaign.theme === 'recovery'),
+    byTheme('prep', 'Prep mastery', (campaign) => campaign.theme === 'meal-prep'),
+    byTheme('sustainability', 'Sustainability favorites', (campaign) => campaign.theme === 'budget' || campaign.theme === 'pantry'),
+    byTheme('seasonal', 'Seasonal resets', (campaign) => campaign.durationDays >= 7),
+    byTheme('creator', 'Creator campaigns', () => true),
+  ].filter((collection) => collection.campaignIds.length > 0);
+};
+
+export const saveCampaignCollection = (collection: NutritionCampaignCollection): NutritionCampaignCollection[] => {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) return [];
+    const raw = window.localStorage.getItem(COLLECTION_STORAGE_KEY);
+    const parsed = raw ? (JSON.parse(raw) as NutritionCampaignCollection[]) : [];
+    const next = [collection, ...parsed.filter((item) => item.id !== collection.id)].slice(0, 20);
+    window.localStorage.setItem(COLLECTION_STORAGE_KEY, JSON.stringify(next));
+    return next;
+  } catch {
+    return [];
+  }
+};

--- a/client/src/components/meal-planner/campaigns/identity/campaignIdentity.ts
+++ b/client/src/components/meal-planner/campaigns/identity/campaignIdentity.ts
@@ -1,0 +1,45 @@
+import type { NutritionCampaignDefinition, NutritionCampaignProgress } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+import { deriveCampaignJourneyType } from '@/components/meal-planner/campaigns/ecosystem/campaignJourneyTypes';
+import { deriveCampaignThemeTokens } from '@/components/meal-planner/campaigns/identity/campaignVisualIdentity';
+
+export type NutritionCampaignIdentity = {
+  campaignId: string;
+  slug: string;
+  creatorAttribution: string;
+  shareTitle: string;
+  campaignSummary: string;
+  pacingSignature: string;
+  journeySignature: string;
+  semanticIdentityTags: string[];
+  visualIdentity: ReturnType<typeof deriveCampaignThemeTokens>;
+};
+
+const slugify = (value: string): string => value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+export const deriveCampaignSignature = (campaign: NutritionCampaignDefinition): string => {
+  const missionDensity = campaign.missions.length >= 4 ? 'prep-intensive' : 'semantic-refresh';
+  const continuity = campaign.theme === 'leftovers' || campaign.theme === 'meal-prep' ? 'continuity-driven' : 'momentum-optimizer';
+  return `${campaign.theme}-${missionDensity}-${continuity}`;
+};
+
+export const deriveCampaignVisualIdentity = (campaign: NutritionCampaignDefinition) => deriveCampaignThemeTokens(campaign);
+
+export const deriveCampaignIdentity = (
+  campaign: NutritionCampaignDefinition,
+  progress?: NutritionCampaignProgress | null,
+  creatorName?: string,
+): NutritionCampaignIdentity => {
+  const journeyType = deriveCampaignJourneyType(campaign, progress || null) || 'Guided journey';
+  const pacingSignature = progress?.phase || (campaign.durationDays <= 7 ? 'Recovery-first' : 'Continuity-driven');
+  return {
+    campaignId: campaign.id,
+    slug: slugify(campaign.title),
+    creatorAttribution: creatorName ? `Creator: ${creatorName}` : 'ChefSire Nutrition Studio',
+    shareTitle: `${campaign.title} · ${journeyType}`,
+    campaignSummary: campaign.description,
+    pacingSignature,
+    journeySignature: deriveCampaignSignature(campaign),
+    semanticIdentityTags: [campaign.theme, journeyType.toLowerCase().replace(/\s+/g, '-'), `${campaign.durationDays}-day`],
+    visualIdentity: deriveCampaignThemeTokens(campaign),
+  };
+};

--- a/client/src/components/meal-planner/campaigns/identity/campaignLineage.ts
+++ b/client/src/components/meal-planner/campaigns/identity/campaignLineage.ts
@@ -1,0 +1,23 @@
+import type { NutritionCampaignDefinition } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+import type { NutritionCampaignRemix } from '@/components/meal-planner/campaigns/identity/campaignRemix';
+
+export type NutritionCampaignLineage = {
+  derivedFrom?: string;
+  inspiredBy?: string;
+  adaptationBranch?: string;
+  creatorLineage?: string;
+};
+
+export const deriveCampaignLineage = (
+  campaign: NutritionCampaignDefinition,
+  remix?: NutritionCampaignRemix,
+  creatorName?: string,
+): NutritionCampaignLineage => ({
+  derivedFrom: remix ? `Derived from ${remix.basedOnTitle}` : undefined,
+  inspiredBy: `Inspired by ${campaign.title}`,
+  adaptationBranch: campaign.theme === 'leftovers' ? 'Household adaptation branch' : 'Adaptive campaign branch',
+  creatorLineage: creatorName ? `${creatorName} template lineage` : 'ChefSire creator lineage',
+});
+
+export const deriveCampaignEvolutionNarrative = (lineage: NutritionCampaignLineage): string =>
+  [lineage.derivedFrom, lineage.inspiredBy, lineage.adaptationBranch, lineage.creatorLineage].filter(Boolean).join(' · ');

--- a/client/src/components/meal-planner/campaigns/identity/campaignRemix.ts
+++ b/client/src/components/meal-planner/campaigns/identity/campaignRemix.ts
@@ -1,0 +1,29 @@
+import type { NutritionCampaignDefinition } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+
+export type NutritionCampaignRemix = {
+  basedOnCampaignId: string;
+  basedOnTitle: string;
+  modifications: string[];
+  remixLabel: string;
+};
+
+export const deriveCampaignRemix = (
+  campaign: NutritionCampaignDefinition,
+  options?: { recoveryFocus?: boolean; householdContinuity?: boolean; reducedPrepIntensity?: boolean },
+): NutritionCampaignRemix => {
+  const modifications: string[] = [];
+  if (options?.recoveryFocus || campaign.theme === 'recovery') modifications.push('Modified for recovery pacing');
+  if (options?.householdContinuity || campaign.theme === 'leftovers') modifications.push('Adapted for household continuity');
+  if (options?.reducedPrepIntensity) modifications.push('Reduced prep intensity');
+  if (!modifications.length) modifications.push('Semantic refresh');
+
+  return {
+    basedOnCampaignId: campaign.id,
+    basedOnTitle: campaign.title,
+    modifications,
+    remixLabel: `Based on ${campaign.title}`,
+  };
+};
+
+export const deriveCampaignRemixNarrative = (remix: NutritionCampaignRemix): string =>
+  `${remix.remixLabel} · ${remix.modifications.join(' · ')}`;

--- a/client/src/components/meal-planner/campaigns/identity/campaignSharing.ts
+++ b/client/src/components/meal-planner/campaigns/identity/campaignSharing.ts
@@ -1,0 +1,33 @@
+import type { NutritionCampaignDefinition, NutritionCampaignProgress } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+import type { NutritionCampaignIdentity } from '@/components/meal-planner/campaigns/identity/campaignIdentity';
+
+export type NutritionCampaignSharePayload = {
+  id: string;
+  title: string;
+  summary: string;
+  missions: string[];
+  pacingProfile: string;
+  adaptiveHighlights: string[];
+  achievementHighlights: string[];
+  journeySignature: string;
+};
+
+export const deriveCampaignSharePayload = (
+  campaign: NutritionCampaignDefinition,
+  identity: NutritionCampaignIdentity,
+  progress?: NutritionCampaignProgress | null,
+): NutritionCampaignSharePayload => ({
+  id: campaign.id,
+  title: identity.shareTitle,
+  summary: campaign.description,
+  missions: campaign.missions.map((mission) => mission.title),
+  pacingProfile: identity.pacingSignature,
+  adaptiveHighlights: [progress?.phaseNarrative, progress?.transitionReason].filter(Boolean) as string[],
+  achievementHighlights: progress?.complete ? [campaign.rewardCopy] : [],
+  journeySignature: identity.journeySignature,
+});
+
+export const deriveCampaignShareSummary = (payload: NutritionCampaignSharePayload): string =>
+  `${payload.title}: ${payload.summary} · Pacing ${payload.pacingProfile}`;
+
+export const deriveCampaignExportData = (payload: NutritionCampaignSharePayload): string => JSON.stringify(payload, null, 2);

--- a/client/src/components/meal-planner/campaigns/identity/campaignVisualIdentity.ts
+++ b/client/src/components/meal-planner/campaigns/identity/campaignVisualIdentity.ts
@@ -1,0 +1,46 @@
+import type { NutritionCampaignDefinition } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+
+export type NutritionCampaignMood = 'recovery' | 'momentum' | 'continuity' | 'sustainability' | 'prep-mastery';
+
+export type NutritionCampaignThemeTokens = {
+  accentColor: string;
+  gradient: string;
+  bgClassName: string;
+  textClassName: string;
+  borderClassName: string;
+};
+
+export const deriveCampaignMood = (campaign: NutritionCampaignDefinition): NutritionCampaignMood => {
+  if (campaign.theme === 'recovery') return 'recovery';
+  if (campaign.theme === 'meal-prep') return 'prep-mastery';
+  if (campaign.theme === 'leftovers') return 'continuity';
+  if (campaign.theme === 'budget' || campaign.theme === 'pantry') return 'sustainability';
+  return 'momentum';
+};
+
+export const deriveCampaignAccentColor = (campaign: NutritionCampaignDefinition): string => {
+  const mood = deriveCampaignMood(campaign);
+  return {
+    recovery: '#0ea5e9',
+    momentum: '#f97316',
+    continuity: '#6366f1',
+    sustainability: '#16a34a',
+    'prep-mastery': '#0f766e',
+  }[mood];
+};
+
+export const deriveCampaignThemeTokens = (campaign: NutritionCampaignDefinition): NutritionCampaignThemeTokens => {
+  const mood = deriveCampaignMood(campaign);
+  switch (mood) {
+    case 'recovery':
+      return { accentColor: '#0ea5e9', gradient: 'from-sky-500/20 to-cyan-500/20', bgClassName: 'bg-sky-50', textClassName: 'text-sky-900', borderClassName: 'border-sky-200' };
+    case 'continuity':
+      return { accentColor: '#6366f1', gradient: 'from-indigo-500/20 to-violet-500/20', bgClassName: 'bg-indigo-50', textClassName: 'text-indigo-900', borderClassName: 'border-indigo-200' };
+    case 'sustainability':
+      return { accentColor: '#16a34a', gradient: 'from-emerald-500/20 to-lime-500/20', bgClassName: 'bg-emerald-50', textClassName: 'text-emerald-900', borderClassName: 'border-emerald-200' };
+    case 'prep-mastery':
+      return { accentColor: '#0f766e', gradient: 'from-teal-500/20 to-cyan-500/20', bgClassName: 'bg-teal-50', textClassName: 'text-teal-900', borderClassName: 'border-teal-200' };
+    default:
+      return { accentColor: '#f97316', gradient: 'from-orange-500/20 to-amber-500/20', bgClassName: 'bg-orange-50', textClassName: 'text-orange-900', borderClassName: 'border-orange-200' };
+  }
+};

--- a/client/src/components/meal-planner/campaigns/identity/savedCampaignStore.ts
+++ b/client/src/components/meal-planner/campaigns/identity/savedCampaignStore.ts
@@ -1,0 +1,40 @@
+import type { NutritionCampaignIdentity } from '@/components/meal-planner/campaigns/identity/campaignIdentity';
+
+const STORAGE_KEY = 'mealPlanner.savedCampaigns.v1';
+const MAX_SAVED = 40;
+
+const safeRead = (): NutritionCampaignIdentity[] => {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) return [];
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+const safeWrite = (items: NutritionCampaignIdentity[]): void => {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) return;
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items.slice(0, MAX_SAVED)));
+  } catch {
+    // localStorage unavailable: no-op fallback to preserve planner behavior
+  }
+};
+
+export const getSavedCampaigns = (): NutritionCampaignIdentity[] => safeRead();
+
+export const saveCampaignIdentity = (identity: NutritionCampaignIdentity): NutritionCampaignIdentity[] => {
+  const existing = safeRead().filter((item) => item.campaignId !== identity.campaignId);
+  const next = [identity, ...existing];
+  safeWrite(next);
+  return next;
+};
+
+export const removeSavedCampaign = (campaignId: string): NutritionCampaignIdentity[] => {
+  const next = safeRead().filter((item) => item.campaignId !== campaignId);
+  safeWrite(next);
+  return next;
+};


### PR DESCRIPTION
### Motivation
- Introduce a lightweight, local-first identity and sharing layer so campaigns feel reusable, remixable, saveable and identity-bearing without adding realtime or backend social infrastructure.
- Provide foundation primitives (identity, visual identity, remix, lineage, collections, share/export payloads, and local persistence) while preserving all existing campaign, adaptive and timeline behavior.

### Description
- Added a new identity folder `client/src/components/meal-planner/campaigns/identity/` with modular, memo-friendly derivation utilities: `campaignIdentity.ts`, `campaignVisualIdentity.ts`, `campaignRemix.ts`, `campaignSharing.ts`, `campaignCollections.ts`, `campaignLineage.ts`, and `savedCampaignStore.ts` implementing `NutritionCampaignIdentity`, `NutritionCampaignRemix`, `NutritionCampaignCollection`, `NutritionCampaignLineage` and helpers like `deriveCampaignIdentity()`, `deriveCampaignSignature()`, `deriveCampaignMood()`, `deriveCampaignThemeTokens()`, `deriveCampaignRemixNarrative()`, `deriveCampaignSharePayload()` and `deriveCampaignExportData()`; localStorage keys used are `mealPlanner.savedCampaigns.v1` and `mealPlanner.campaignCollections.v1`.
- UI integration: enhanced suggested campaign cards in `client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx` to surface identity metadata, remix/lineage narratives, collection labels, visual identity accents, and a lightweight Save/Remove (bookmark) button that uses the local-first `savedCampaignStore` APIs while preserving existing adaptive recommendations, campaign arcs and journey timeline.
- Persistence & safety: all persistence is frontend/localStorage-only, capped and gracefully no-op if `localStorage` is unavailable; no backend sync, realtime, or global social feed code introduced.
- Files created/modified: created `campaignIdentity.ts`, `campaignVisualIdentity.ts`, `campaignRemix.ts`, `campaignSharing.ts`, `campaignCollections.ts`, `campaignLineage.ts`, `savedCampaignStore.ts`; modified `NutritionCampaignPanel.tsx` to wire identity and save behavior and call the new derivation helpers.

### Testing
- Ran `npm run build:client` which completed successfully (Vite production build passed).
- Ran `npm run build:server` which completed successfully (server bundle built via `esbuild`).
- Ran targeted TypeScript checks for the new modules and panel; invoking `tsc` directly against the files showed failures when run outside the project JSX/path alias configuration, but overall project `tsc -p tsconfig.json` surfaced unrelated, preexisting TypeScript issues elsewhere in the repo; no regressions introduced by these new identity modules were found in the successful client/server builds.
- Notes: behavior is local-first and additive; validation focused on build + type-check runs described above and preserved existing planner behavior and integrations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1498b7e480832583bbdf0ce74ef925)