### PR TITLE
Add global behavioral intelligence layer for nutrition campaigns

### DIFF
--- a/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
+++ b/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
@@ -33,6 +33,13 @@ import { deriveCampaignLearningProfile, deriveAdaptiveLearningInsights } from '@
 import { deriveEvolutionTimeline } from '@/components/meal-planner/campaigns/evolution/campaignEvolutionTimeline';
 import { deriveCampaignRecommendationFeedback } from '@/components/meal-planner/campaigns/evolution/campaignRecommendationFeedback';
 
+import { deriveBehavioralPreferenceNarratives, deriveBehavioralSensitivitySignals, deriveBehavioralStrengths } from '@/components/meal-planner/campaigns/behavioral-intelligence/behavioralPreferences';
+import { deriveBehavioralIntelligenceProfile, updateBehavioralIntelligenceProfile } from '@/components/meal-planner/campaigns/behavioral-intelligence/behavioralIntelligenceProfile';
+import { deriveBehavioralEvolutionTimeline } from '@/components/meal-planner/campaigns/behavioral-intelligence/behavioralEvolutionTimeline';
+import { deriveBehavioralRecommendationConfidence, deriveBehavioralCompatibilityScore, deriveGlobalRecommendationBias } from '@/components/meal-planner/campaigns/behavioral-intelligence/behavioralRecommendationIntelligence';
+import { deriveAdaptiveStrategyWeights, deriveBehavioralStrategyBias } from '@/components/meal-planner/campaigns/behavioral-intelligence/adaptiveStrategyWeights';
+import { getBehavioralIntelligenceProfile, saveBehavioralIntelligenceProfile } from '@/components/meal-planner/campaigns/behavioral-intelligence/behavioralIntelligenceStore';
+
 const WeeklyNutritionJourneyTimeline = React.lazy(() => import('@/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline'));
 const ENABLE_JOURNEY_TIMELINE = true;
 
@@ -86,6 +93,7 @@ const NutritionCampaignPanel: React.FC<Props> = ({
       return acc;
     }, {});
   });
+  const [behavioralProfile, setBehavioralProfile] = React.useState(() => getBehavioralIntelligenceProfile());
 
   const toggleSavedCampaign = React.useCallback((campaignId: string) => {
     const campaign = NUTRITION_CAMPAIGN_CATALOG.find((item) => item.id === campaignId);
@@ -150,7 +158,11 @@ const NutritionCampaignPanel: React.FC<Props> = ({
     setEvolutionMemoryByCampaignId((prev) => {
       const nextMemory = updateCampaignEvolutionMemory(prev[activeCampaignId] ?? null, activeCampaignId, progress);
       const next = { ...prev, [activeCampaignId]: nextMemory };
-      saveCampaignEvolutionMemory(Object.values(next));
+      const allMemories = saveCampaignEvolutionMemory(Object.values(next));
+      setBehavioralProfile((previous) => {
+        const updated = updateBehavioralIntelligenceProfile(previous, allMemories);
+        return saveBehavioralIntelligenceProfile(updated);
+      });
       return next;
     });
   }, [activeCampaignId, progress]);
@@ -162,6 +174,26 @@ const NutritionCampaignPanel: React.FC<Props> = ({
   const activeRecommendationFeedback = activeEvolutionMemory
     ? deriveCampaignRecommendationFeedback(activeEvolutionMemory, activeRecommendation)
     : null;
+
+  const resolvedBehavioralProfile = React.useMemo(
+    () => behavioralProfile ?? deriveBehavioralIntelligenceProfile(Object.values(evolutionMemoryByCampaignId)),
+    [behavioralProfile, evolutionMemoryByCampaignId],
+  );
+  const behavioralNarratives = React.useMemo(() => deriveBehavioralPreferenceNarratives(resolvedBehavioralProfile), [resolvedBehavioralProfile]);
+  const behavioralStrengths = React.useMemo(() => deriveBehavioralStrengths(resolvedBehavioralProfile), [resolvedBehavioralProfile]);
+  const behavioralSensitivity = React.useMemo(() => deriveBehavioralSensitivitySignals(resolvedBehavioralProfile), [resolvedBehavioralProfile]);
+  const recommendationCompatibility = React.useMemo(
+    () => deriveBehavioralCompatibilityScore(resolvedBehavioralProfile, activeRecommendation),
+    [resolvedBehavioralProfile, activeRecommendation],
+  );
+  const behavioralRecommendationConfidence = React.useMemo(
+    () => deriveBehavioralRecommendationConfidence(resolvedBehavioralProfile, recommendationCompatibility),
+    [resolvedBehavioralProfile, recommendationCompatibility],
+  );
+  const globalRecommendationBias = React.useMemo(() => deriveGlobalRecommendationBias(resolvedBehavioralProfile), [resolvedBehavioralProfile]);
+  const behavioralMilestones = React.useMemo(() => deriveBehavioralEvolutionTimeline(resolvedBehavioralProfile), [resolvedBehavioralProfile]);
+  const strategyWeights = React.useMemo(() => deriveAdaptiveStrategyWeights(resolvedBehavioralProfile), [resolvedBehavioralProfile]);
+  const strategyBias = React.useMemo(() => deriveBehavioralStrategyBias(strategyWeights), [strategyWeights]);
 
   return (
     <div className="space-y-4">
@@ -297,6 +329,26 @@ const NutritionCampaignPanel: React.FC<Props> = ({
                   {activeRecommendationFeedback.cautionSignals[0] && <p className="mt-1">Watch: {activeRecommendationFeedback.cautionSignals[0]}</p>}
                 </div>
               )}
+
+
+              <div className="rounded-lg border border-indigo-200 bg-indigo-50 p-3 text-xs text-indigo-900">
+                <p className="font-medium">Behavioral intelligence · {Math.round(resolvedBehavioralProfile.behavioralConfidence * 100)}% confidence</p>
+                <p className="mt-1">Continuity: {Math.round(resolvedBehavioralProfile.continuityPreferenceScore * 100)}% · Recovery: {Math.round(resolvedBehavioralProfile.recoveryStabilizationScore * 100)}% · Prep tolerance: {Math.round(resolvedBehavioralProfile.prepToleranceScore * 100)}%</p>
+                <p className="mt-1">Cadence compatibility: {Math.round(recommendationCompatibility * 100)}% · Recommendation confidence: {Math.round(behavioralRecommendationConfidence * 100)}%</p>
+                <div className="mt-2 flex flex-wrap gap-1">
+                  {behavioralNarratives.slice(0, 3).map((item) => <Badge key={item} variant="secondary" className="bg-indigo-100 text-indigo-900 hover:bg-indigo-100">{item}</Badge>)}
+                </div>
+                <p className="mt-2 font-medium">Global recommendation bias</p>
+                <ul className="list-disc pl-4">
+                  {globalRecommendationBias.slice(0, 2).map((item) => <li key={item}>{item}</li>)}
+                </ul>
+                {(behavioralStrengths[0] || behavioralSensitivity[0]) && (
+                  <p className="mt-1">Strength: {behavioralStrengths[0] ?? 'Calibrating'} · Sensitivity: {behavioralSensitivity[0] ?? 'No major sensitivity detected'}</p>
+                )}
+                <p className="mt-1">Strategy weights · continuity {Math.round(strategyWeights.continuityAnchor * 100)}%, recovery {Math.round(strategyWeights.recoveryPacing * 100)}%, prep reduction {Math.round(strategyWeights.prepReduction * 100)}%</p>
+                {strategyBias[0] && <p className="mt-1">Adaptive weighting: {strategyBias[0]}</p>}
+                {behavioralMilestones[0] && <p className="mt-1">Behavioral evolution: {behavioralMilestones.slice(0, 2).map((m) => m.detail).join(' · ')}</p>}
+              </div>
 
               {ENABLE_JOURNEY_TIMELINE && (
                 <React.Suspense

--- a/client/src/components/meal-planner/campaigns/behavioral-intelligence/adaptiveStrategyWeights.ts
+++ b/client/src/components/meal-planner/campaigns/behavioral-intelligence/adaptiveStrategyWeights.ts
@@ -1,0 +1,22 @@
+import type { NutritionBehavioralIntelligenceProfile } from '@/components/meal-planner/campaigns/behavioral-intelligence/behavioralIntelligenceProfile';
+
+export type AdaptiveStrategyWeights = Record<'continuityAnchor' | 'recoveryPacing' | 'prepReduction' | 'noveltyCadence', number>;
+
+const clamp01 = (value: number): number => Math.max(0, Math.min(1, value));
+
+export const deriveAdaptiveStrategyWeights = (profile: NutritionBehavioralIntelligenceProfile): AdaptiveStrategyWeights => ({
+  continuityAnchor: clamp01(0.4 + profile.continuityPreferenceScore * 0.6),
+  recoveryPacing: clamp01(0.35 + profile.recoveryStabilizationScore * 0.65),
+  prepReduction: clamp01(0.3 + (1 - profile.prepToleranceScore) * 0.7),
+  noveltyCadence: clamp01(0.2 + profile.noveltyToleranceScore * 0.8),
+});
+
+export const deriveBehavioralStrategyBias = (weights: AdaptiveStrategyWeights): string[] => {
+  const bias: string[] = [];
+  if (weights.continuityAnchor >= 0.75) bias.push('Continuity anchors gain weight');
+  if (weights.recoveryPacing >= 0.7) bias.push('Recovery pacing gains confidence');
+  if (weights.prepReduction >= 0.65) bias.push('Prep reduction becomes default recommendation');
+  if (weights.noveltyCadence <= 0.45) bias.push('Novelty-heavy cadence gets penalized');
+  if (!bias.length) bias.push('Balanced adaptive strategy weighting');
+  return bias;
+};

--- a/client/src/components/meal-planner/campaigns/behavioral-intelligence/behavioralEvolutionTimeline.ts
+++ b/client/src/components/meal-planner/campaigns/behavioral-intelligence/behavioralEvolutionTimeline.ts
@@ -1,0 +1,19 @@
+import type { NutritionBehavioralIntelligenceProfile } from '@/components/meal-planner/campaigns/behavioral-intelligence/behavioralIntelligenceProfile';
+
+export type BehavioralMilestone = {
+  id: string;
+  detail: string;
+  signal: 'continuity' | 'recovery' | 'novelty' | 'prep' | 'momentum';
+};
+
+export const deriveBehavioralMilestones = (profile: NutritionBehavioralIntelligenceProfile): BehavioralMilestone[] => {
+  const milestones: BehavioralMilestone[] = [];
+  if (profile.continuityPreferenceScore >= 0.7) milestones.push({ id: 'continuity-stabilized', detail: 'Continuity preference stabilized', signal: 'continuity' });
+  if (profile.recoveryStabilizationScore >= 0.65) milestones.push({ id: 'recovery-improved', detail: 'Recovery responsiveness improved', signal: 'recovery' });
+  if (profile.noveltyToleranceScore < 0.5) milestones.push({ id: 'novelty-decreased', detail: 'Novelty tolerance decreased', signal: 'novelty' });
+  if (profile.prepToleranceScore >= 0.6) milestones.push({ id: 'prep-resilience', detail: 'Prep resilience improved', signal: 'prep' });
+  if (profile.momentumRecoveryScore >= 0.6) milestones.push({ id: 'momentum-consistency', detail: 'Momentum recovery became more consistent', signal: 'momentum' });
+  return milestones;
+};
+
+export const deriveBehavioralEvolutionTimeline = (profile: NutritionBehavioralIntelligenceProfile): BehavioralMilestone[] => deriveBehavioralMilestones(profile);

--- a/client/src/components/meal-planner/campaigns/behavioral-intelligence/behavioralIntelligenceProfile.ts
+++ b/client/src/components/meal-planner/campaigns/behavioral-intelligence/behavioralIntelligenceProfile.ts
@@ -1,0 +1,66 @@
+import type { NutritionCampaignEvolutionMemory } from '@/components/meal-planner/campaigns/evolution/campaignEvolutionMemory';
+import {
+  deriveBehavioralConsistency,
+  deriveCrossCampaignBehavioralPatterns,
+  deriveSharedAdaptivePatterns,
+} from '@/components/meal-planner/campaigns/behavioral-intelligence/crossCampaignAggregation';
+
+export type NutritionBehavioralIntelligenceProfile = {
+  continuityPreferenceScore: number;
+  noveltyToleranceScore: number;
+  prepToleranceScore: number;
+  recoveryStabilizationScore: number;
+  cadenceStabilityScore: number;
+  sustainabilityResilienceScore: number;
+  momentumRecoveryScore: number;
+  semanticRefreshResponsiveness: number;
+  successfulStrategyPatterns: string[];
+  failedStrategyPatterns: string[];
+  remixPreferencePatterns: string[];
+  behavioralConfidence: number;
+  evolutionVersion: number;
+  lastUpdatedAt: string;
+};
+
+const clamp01 = (value: number): number => Math.max(0, Math.min(1, value));
+
+export const deriveBehavioralIntelligenceProfile = (memories: NutritionCampaignEvolutionMemory[]): NutritionBehavioralIntelligenceProfile => {
+  const aggregated = deriveCrossCampaignBehavioralPatterns(memories);
+  const consistency = deriveBehavioralConsistency(aggregated);
+  const sharedPatterns = deriveSharedAdaptivePatterns(aggregated);
+
+  return {
+    continuityPreferenceScore: clamp01(aggregated.continuityStabilizationTrend * 0.65 + aggregated.averageAdherenceTrend * 0.35),
+    noveltyToleranceScore: clamp01(1 - aggregated.prepOverloadRecurrence * 0.35 + aggregated.cadenceConsistency * 0.25),
+    prepToleranceScore: clamp01(1 - aggregated.prepOverloadRecurrence),
+    recoveryStabilizationScore: aggregated.recoveryEffectiveness,
+    cadenceStabilityScore: aggregated.cadenceConsistency,
+    sustainabilityResilienceScore: clamp01((aggregated.averageAdherenceTrend + aggregated.averageMomentum) / 2),
+    momentumRecoveryScore: clamp01(aggregated.averageMomentum * 0.7 + aggregated.recoveryEffectiveness * 0.3),
+    semanticRefreshResponsiveness: clamp01(aggregated.remixSuccessRate * 0.5 + aggregated.cadenceConsistency * 0.5),
+    successfulStrategyPatterns: aggregated.repeatedSuccessPatterns,
+    failedStrategyPatterns: aggregated.repeatedFailurePatterns,
+    remixPreferencePatterns: sharedPatterns.filter((pattern) => pattern.startsWith('success:')).slice(0, 5),
+    behavioralConfidence: clamp01(consistency * 0.7 + Math.min(aggregated.totalCampaigns, 10) / 10 * 0.3),
+    evolutionVersion: 1,
+    lastUpdatedAt: new Date().toISOString(),
+  };
+};
+
+export const updateBehavioralIntelligenceProfile = (
+  previous: NutritionBehavioralIntelligenceProfile | null,
+  memories: NutritionCampaignEvolutionMemory[],
+): NutritionBehavioralIntelligenceProfile => {
+  const derived = deriveBehavioralIntelligenceProfile(memories);
+  if (!previous) return derived;
+
+  return {
+    ...derived,
+    successfulStrategyPatterns: Array.from(new Set([...previous.successfulStrategyPatterns, ...derived.successfulStrategyPatterns])).slice(-8),
+    failedStrategyPatterns: Array.from(new Set([...previous.failedStrategyPatterns, ...derived.failedStrategyPatterns])).slice(-8),
+    remixPreferencePatterns: Array.from(new Set([...previous.remixPreferencePatterns, ...derived.remixPreferencePatterns])).slice(-8),
+    behavioralConfidence: clamp01((previous.behavioralConfidence + derived.behavioralConfidence) / 2),
+    evolutionVersion: previous.evolutionVersion + 1,
+    lastUpdatedAt: new Date().toISOString(),
+  };
+};

--- a/client/src/components/meal-planner/campaigns/behavioral-intelligence/behavioralIntelligenceStore.ts
+++ b/client/src/components/meal-planner/campaigns/behavioral-intelligence/behavioralIntelligenceStore.ts
@@ -1,0 +1,39 @@
+import type { NutritionBehavioralIntelligenceProfile } from '@/components/meal-planner/campaigns/behavioral-intelligence/behavioralIntelligenceProfile';
+
+const STORAGE_KEY = 'mealPlanner.behavioralIntelligence.v1';
+const MAX_PATTERN_COUNT = 12;
+
+const isBrowser = (): boolean => typeof window !== 'undefined' && Boolean(window.localStorage);
+
+const capProfile = (profile: NutritionBehavioralIntelligenceProfile): NutritionBehavioralIntelligenceProfile => ({
+  ...profile,
+  successfulStrategyPatterns: profile.successfulStrategyPatterns.slice(-MAX_PATTERN_COUNT),
+  failedStrategyPatterns: profile.failedStrategyPatterns.slice(-MAX_PATTERN_COUNT),
+  remixPreferencePatterns: profile.remixPreferencePatterns.slice(-MAX_PATTERN_COUNT),
+});
+
+export const getBehavioralIntelligenceProfile = (): NutritionBehavioralIntelligenceProfile | null => {
+  if (!isBrowser()) return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as NutritionBehavioralIntelligenceProfile;
+    if (!parsed || typeof parsed !== 'object') return null;
+    if (typeof parsed.lastUpdatedAt !== 'string' || typeof parsed.evolutionVersion !== 'number') return null;
+    return capProfile(parsed);
+  } catch {
+    return null;
+  }
+};
+
+export const saveBehavioralIntelligenceProfile = (profile: NutritionBehavioralIntelligenceProfile): NutritionBehavioralIntelligenceProfile => {
+  const bounded = capProfile(profile);
+  if (!isBrowser()) return bounded;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, '{}');
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(bounded));
+  } catch {
+    // graceful fallback
+  }
+  return bounded;
+};

--- a/client/src/components/meal-planner/campaigns/behavioral-intelligence/behavioralPreferences.ts
+++ b/client/src/components/meal-planner/campaigns/behavioral-intelligence/behavioralPreferences.ts
@@ -1,0 +1,26 @@
+import type { NutritionBehavioralIntelligenceProfile } from '@/components/meal-planner/campaigns/behavioral-intelligence/behavioralIntelligenceProfile';
+
+export const deriveBehavioralStrengths = (profile: NutritionBehavioralIntelligenceProfile): string[] => {
+  const strengths: string[] = [];
+  if (profile.continuityPreferenceScore >= 0.7) strengths.push('Strong continuity preference');
+  if (profile.recoveryStabilizationScore >= 0.65) strengths.push('High recovery responsiveness');
+  if (profile.cadenceStabilityScore >= 0.65) strengths.push('Cadence stability is reliable');
+  if (profile.sustainabilityResilienceScore >= 0.65) strengths.push('Sustainability resilience is improving');
+  return strengths;
+};
+
+export const deriveBehavioralSensitivitySignals = (profile: NutritionBehavioralIntelligenceProfile): string[] => {
+  const signals: string[] = [];
+  if (profile.noveltyToleranceScore < 0.45) signals.push('Low novelty tolerance');
+  if (profile.prepToleranceScore < 0.5) signals.push('Prep-sensitive scheduling');
+  if (profile.momentumRecoveryScore < 0.5) signals.push('Momentum recovery needs tighter support');
+  if (profile.failedStrategyPatterns[0]) signals.push(`Watch recurring friction: ${profile.failedStrategyPatterns[0]}`);
+  return signals;
+};
+
+export const deriveBehavioralPreferenceNarratives = (profile: NutritionBehavioralIntelligenceProfile): string[] => {
+  const narratives = [...deriveBehavioralStrengths(profile), ...deriveBehavioralSensitivitySignals(profile)];
+  if (profile.semanticRefreshResponsiveness >= 0.65) narratives.push('Responds well to semantic refresh');
+  if (!narratives.length) narratives.push('Behavioral profile is still calibrating across campaigns');
+  return narratives;
+};

--- a/client/src/components/meal-planner/campaigns/behavioral-intelligence/behavioralRecommendationIntelligence.ts
+++ b/client/src/components/meal-planner/campaigns/behavioral-intelligence/behavioralRecommendationIntelligence.ts
@@ -1,0 +1,37 @@
+import type { NutritionCampaignAdaptiveRecommendation } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+import type { NutritionBehavioralIntelligenceProfile } from '@/components/meal-planner/campaigns/behavioral-intelligence/behavioralIntelligenceProfile';
+
+const clamp01 = (value: number): number => Math.max(0, Math.min(1, value));
+
+export const deriveBehavioralCompatibilityScore = (
+  profile: NutritionBehavioralIntelligenceProfile,
+  recommendation?: NutritionCampaignAdaptiveRecommendation,
+): number => {
+  if (!recommendation) return profile.behavioralConfidence;
+  const pacingFit = recommendation.pacing === 'slow'
+    ? profile.prepToleranceScore < 0.55 ? 1 : 0.7
+    : recommendation.pacing === 'steady'
+      ? 0.85
+      : profile.noveltyToleranceScore > 0.6 ? 0.8 : 0.45;
+  const intensityFit = recommendation.intensity === 'low'
+    ? profile.recoveryStabilizationScore
+    : recommendation.intensity === 'moderate'
+      ? (profile.cadenceStabilityScore + profile.noveltyToleranceScore) / 2
+      : profile.noveltyToleranceScore;
+  return clamp01((recommendation.fitScore * 0.5) + (pacingFit * 0.25) + (intensityFit * 0.25));
+};
+
+export const deriveGlobalRecommendationBias = (profile: NutritionBehavioralIntelligenceProfile): string[] => {
+  const bias: string[] = [];
+  if (profile.continuityPreferenceScore >= 0.65) bias.push('Prefer continuity anchors across campaigns');
+  if (profile.prepToleranceScore < 0.5) bias.push('Default to prep-light sequencing');
+  if (profile.recoveryStabilizationScore >= 0.6) bias.push('Prioritize recovery pacing before acceleration');
+  if (profile.noveltyToleranceScore < 0.45) bias.push('Penalize novelty-heavy cadence');
+  if (!bias.length) bias.push('Maintain balanced adaptive sequencing');
+  return bias;
+};
+
+export const deriveBehavioralRecommendationConfidence = (
+  profile: NutritionBehavioralIntelligenceProfile,
+  compatibilityScore: number,
+): number => clamp01((profile.behavioralConfidence * 0.6) + (compatibilityScore * 0.4));

--- a/client/src/components/meal-planner/campaigns/behavioral-intelligence/crossCampaignAggregation.ts
+++ b/client/src/components/meal-planner/campaigns/behavioral-intelligence/crossCampaignAggregation.ts
@@ -1,0 +1,82 @@
+import type { NutritionCampaignEvolutionMemory } from '@/components/meal-planner/campaigns/evolution/campaignEvolutionMemory';
+
+export type CrossCampaignBehavioralPatterns = {
+  totalCampaigns: number;
+  repeatedSuccessPatterns: string[];
+  repeatedFailurePatterns: string[];
+  cadenceConsistency: number;
+  prepOverloadRecurrence: number;
+  recoveryEffectiveness: number;
+  continuityStabilizationTrend: number;
+  averageAdherenceTrend: number;
+  averageMomentum: number;
+  remixSuccessRate: number;
+};
+
+const clamp01 = (value: number): number => Math.max(0, Math.min(1, value));
+
+const topPatterns = (all: string[], minCount = 2, max = 6): string[] => {
+  const counts = all.reduce<Record<string, number>>((acc, pattern) => {
+    acc[pattern] = (acc[pattern] ?? 0) + 1;
+    return acc;
+  }, {});
+  return Object.entries(counts)
+    .filter(([, count]) => count >= minCount)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, max)
+    .map(([pattern]) => pattern);
+};
+
+export const deriveCrossCampaignBehavioralPatterns = (memories: NutritionCampaignEvolutionMemory[]): CrossCampaignBehavioralPatterns => {
+  if (!memories.length) {
+    return {
+      totalCampaigns: 0,
+      repeatedSuccessPatterns: [],
+      repeatedFailurePatterns: [],
+      cadenceConsistency: 0.5,
+      prepOverloadRecurrence: 0.5,
+      recoveryEffectiveness: 0.5,
+      continuityStabilizationTrend: 0.5,
+      averageAdherenceTrend: 0.5,
+      averageMomentum: 0.5,
+      remixSuccessRate: 0.5,
+    };
+  }
+
+  const cadenceSignalRatio = memories
+    .map((memory) => memory.semanticCadencePatterns.length / Math.max(1, memory.semanticCadencePatterns.length + memory.failedStrategies.length))
+    .reduce((sum, value) => sum + value, 0) / memories.length;
+
+  const prepOverloadCount = memories.flatMap((memory) => memory.prepStabilitySignals).filter((signal) => signal.includes('overload')).length;
+  const prepSignalCount = memories.flatMap((memory) => memory.prepStabilitySignals).length;
+
+  const recoverySignals = memories.flatMap((memory) => memory.recoveryInterventions);
+  const continuitySignals = memories.flatMap((memory) => memory.continuityAnchors);
+
+  const remixOutcomes = memories.flatMap((memory) => memory.remixOutcomes);
+  const remixPositive = remixOutcomes.filter((outcome) => /lift|stable|improved|success|effective/i.test(outcome)).length;
+
+  return {
+    totalCampaigns: memories.length,
+    repeatedSuccessPatterns: topPatterns(memories.flatMap((memory) => memory.successfulStrategies)),
+    repeatedFailurePatterns: topPatterns(memories.flatMap((memory) => memory.failedStrategies)),
+    cadenceConsistency: clamp01(cadenceSignalRatio),
+    prepOverloadRecurrence: prepSignalCount > 0 ? clamp01(prepOverloadCount / prepSignalCount) : 0.5,
+    recoveryEffectiveness: clamp01(recoverySignals.length / Math.max(1, recoverySignals.length + memories.flatMap((memory) => memory.failedStrategies).length)),
+    continuityStabilizationTrend: clamp01(continuitySignals.length / Math.max(1, memories.length * 2)),
+    averageAdherenceTrend: clamp01(memories.reduce((sum, memory) => sum + memory.adherenceTrend, 0) / memories.length),
+    averageMomentum: clamp01(memories.reduce((sum, memory) => sum + (memory.momentumHistory.at(-1) ?? 0.5), 0) / memories.length),
+    remixSuccessRate: remixOutcomes.length ? clamp01(remixPositive / remixOutcomes.length) : 0.5,
+  };
+};
+
+export const deriveSharedAdaptivePatterns = (patterns: CrossCampaignBehavioralPatterns): string[] => [
+  ...patterns.repeatedSuccessPatterns.map((pattern) => `success:${pattern}`),
+  ...patterns.repeatedFailurePatterns.map((pattern) => `risk:${pattern}`),
+].slice(0, 8);
+
+export const deriveBehavioralConsistency = (patterns: CrossCampaignBehavioralPatterns): number => {
+  const positive = (patterns.cadenceConsistency + patterns.recoveryEffectiveness + patterns.continuityStabilizationTrend + patterns.averageAdherenceTrend) / 4;
+  const penalty = patterns.prepOverloadRecurrence * 0.35;
+  return clamp01(positive - penalty + 0.2);
+};


### PR DESCRIPTION
### Motivation
- Enable cross-campaign, additive behavioral learning so the planner can surface explainable, deterministic global user preferences and adapt recommendations across all campaigns while preserving existing campaign-scoped intelligence and evolution memory.

### Description
- Add a global profile model with derivation and update logic by introducing `NutritionBehavioralIntelligenceProfile`, `deriveBehavioralIntelligenceProfile()` and `updateBehavioralIntelligenceProfile()` and persisted via a bounded localStorage adapter (`mealPlanner.behavioralIntelligence.v1`).
- Implement cross-campaign aggregation and consistency analysis via `deriveCrossCampaignBehavioralPatterns()`, `deriveSharedAdaptivePatterns()`, and `deriveBehavioralConsistency()` to extract repeated success/failure patterns, cadence stability, prep overload recurrence, recovery effectiveness, continuity trends, adherence/momentum, and remix trends.
- Provide human-readable preference derivation, recommendation intelligence, adaptive strategy weighting, and evolution timeline utilities via `deriveBehavioralPreferenceNarratives()`, `deriveBehavioralCompatibilityScore()`, `deriveBehavioralRecommendationConfidence()`, `deriveAdaptiveStrategyWeights()` and `deriveBehavioralEvolutionTimeline()` to shape deterministic recommendation biases and weights.
- Wire the layer additively into the UI by loading/saving the global profile, updating it when campaign evolution memory changes, and rendering a new ``Behavioral intelligence`` summary block in `NutritionCampaignPanel` that shows confidence, continuity/recovery/prep/cadence indicators, narratives, strategy weights, and milestones.

### Testing
- Ran `npm run build:client` and the client build completed successfully (Vite production build passed). 
- Ran `npm run build:server` and the server build completed successfully (esbuild bundling passed). 
- Ran targeted TypeScript checks with `npx tsc --noEmit` for the new modules and related campaign modules and observed `TS2307` path-alias resolution errors when invoking `tsc` ad-hoc with a direct file list; this is due to bypassing the project tsconfig path resolution and not a behavioral-intelligence regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a33cced883259ae1f06c59bd1e59)