### PR TITLE
Add deterministic life-state intelligence layer for nutrition campaigns

### DIFF
--- a/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
+++ b/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
@@ -39,6 +39,13 @@ import { deriveBehavioralEvolutionTimeline } from '@/components/meal-planner/cam
 import { deriveBehavioralRecommendationConfidence, deriveBehavioralCompatibilityScore, deriveGlobalRecommendationBias } from '@/components/meal-planner/campaigns/behavioral-intelligence/behavioralRecommendationIntelligence';
 import { deriveAdaptiveStrategyWeights, deriveBehavioralStrategyBias } from '@/components/meal-planner/campaigns/behavioral-intelligence/adaptiveStrategyWeights';
 import { getBehavioralIntelligenceProfile, saveBehavioralIntelligenceProfile } from '@/components/meal-planner/campaigns/behavioral-intelligence/behavioralIntelligenceStore';
+import { createDefaultLifeStateProfile, updateLifeStateProfile } from '@/components/meal-planner/campaigns/life-state-intelligence/lifeStateProfile';
+import { getLifeStateProfile, saveLifeStateProfile } from '@/components/meal-planner/campaigns/life-state-intelligence/lifeStateStore';
+import { deriveContextualAdaptationBias, deriveContextualInterventionStrategies } from '@/components/meal-planner/campaigns/life-state-intelligence/contextualAdaptation';
+import { deriveContextualStabilityProfile, deriveRecoveryStabilizationWindows } from '@/components/meal-planner/campaigns/life-state-intelligence/contextualStability';
+import { deriveLifeStateEvolutionTimeline } from '@/components/meal-planner/campaigns/life-state-intelligence/contextualTimeline';
+import { deriveContextualStrategyWeights, deriveProtectiveAdaptationBias } from '@/components/meal-planner/campaigns/life-state-intelligence/contextualStrategyWeights';
+import { deriveContextualCompatibilityScore, deriveContextualRecommendationConfidence, deriveProtectiveRecommendationBias } from '@/components/meal-planner/campaigns/life-state-intelligence/contextualRecommendationIntelligence';
 
 const WeeklyNutritionJourneyTimeline = React.lazy(() => import('@/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline'));
 const ENABLE_JOURNEY_TIMELINE = true;
@@ -94,6 +101,7 @@ const NutritionCampaignPanel: React.FC<Props> = ({
     }, {});
   });
   const [behavioralProfile, setBehavioralProfile] = React.useState(() => getBehavioralIntelligenceProfile());
+  const [lifeStateProfile, setLifeStateProfile] = React.useState(() => getLifeStateProfile() ?? createDefaultLifeStateProfile());
 
   const toggleSavedCampaign = React.useCallback((campaignId: string) => {
     const campaign = NUTRITION_CAMPAIGN_CATALOG.find((item) => item.id === campaignId);
@@ -155,9 +163,11 @@ const NutritionCampaignPanel: React.FC<Props> = ({
 
   React.useEffect(() => {
     if (!activeCampaignId) return;
+    let nextValue: Record<string, ReturnType<typeof deriveCampaignEvolutionMemory>> | null = null;
     setEvolutionMemoryByCampaignId((prev) => {
       const nextMemory = updateCampaignEvolutionMemory(prev[activeCampaignId] ?? null, activeCampaignId, progress);
       const next = { ...prev, [activeCampaignId]: nextMemory };
+      nextValue = next;
       const allMemories = saveCampaignEvolutionMemory(Object.values(next));
       setBehavioralProfile((previous) => {
         const updated = updateBehavioralIntelligenceProfile(previous, allMemories);
@@ -165,6 +175,12 @@ const NutritionCampaignPanel: React.FC<Props> = ({
       });
       return next;
     });
+    if (nextValue) {
+      const allMemories = Object.values(nextValue) as ReturnType<typeof deriveCampaignEvolutionMemory>[];
+      const behavioralForLifeState = updateBehavioralIntelligenceProfile(behavioralProfile, allMemories);
+      const nextLifeState = updateLifeStateProfile(lifeStateProfile, behavioralForLifeState, allMemories);
+      setLifeStateProfile(saveLifeStateProfile(nextLifeState));
+    }
   }, [activeCampaignId, progress]);
 
   const activeEvolutionMemory = activeCampaignId ? evolutionMemoryByCampaignId[activeCampaignId] : null;
@@ -194,6 +210,22 @@ const NutritionCampaignPanel: React.FC<Props> = ({
   const behavioralMilestones = React.useMemo(() => deriveBehavioralEvolutionTimeline(resolvedBehavioralProfile), [resolvedBehavioralProfile]);
   const strategyWeights = React.useMemo(() => deriveAdaptiveStrategyWeights(resolvedBehavioralProfile), [resolvedBehavioralProfile]);
   const strategyBias = React.useMemo(() => deriveBehavioralStrategyBias(strategyWeights), [strategyWeights]);
+  const contextualAdaptationBias = React.useMemo(() => deriveContextualAdaptationBias(lifeStateProfile), [lifeStateProfile]);
+  const contextualInterventions = React.useMemo(() => deriveContextualInterventionStrategies(lifeStateProfile), [lifeStateProfile]);
+  const contextualStability = React.useMemo(() => deriveContextualStabilityProfile(lifeStateProfile, Object.values(evolutionMemoryByCampaignId)), [lifeStateProfile, evolutionMemoryByCampaignId]);
+  const recoveryWindows = React.useMemo(() => deriveRecoveryStabilizationWindows(lifeStateProfile), [lifeStateProfile]);
+  const contextualTimeline = React.useMemo(() => deriveLifeStateEvolutionTimeline(lifeStateProfile), [lifeStateProfile]);
+  const contextualWeights = React.useMemo(() => deriveContextualStrategyWeights(lifeStateProfile), [lifeStateProfile]);
+  const protectiveNotes = React.useMemo(() => deriveProtectiveAdaptationBias(contextualWeights), [contextualWeights]);
+  const contextualCompatibility = React.useMemo(
+    () => deriveContextualCompatibilityScore(resolvedBehavioralProfile, lifeStateProfile, activeRecommendation),
+    [resolvedBehavioralProfile, lifeStateProfile, activeRecommendation],
+  );
+  const contextualRecommendationConfidence = React.useMemo(
+    () => deriveContextualRecommendationConfidence(lifeStateProfile, contextualCompatibility),
+    [lifeStateProfile, contextualCompatibility],
+  );
+  const protectiveRecommendationBias = React.useMemo(() => deriveProtectiveRecommendationBias(lifeStateProfile), [lifeStateProfile]);
 
   return (
     <div className="space-y-4">
@@ -348,6 +380,19 @@ const NutritionCampaignPanel: React.FC<Props> = ({
                 <p className="mt-1">Strategy weights · continuity {Math.round(strategyWeights.continuityAnchor * 100)}%, recovery {Math.round(strategyWeights.recoveryPacing * 100)}%, prep reduction {Math.round(strategyWeights.prepReduction * 100)}%</p>
                 {strategyBias[0] && <p className="mt-1">Adaptive weighting: {strategyBias[0]}</p>}
                 {behavioralMilestones[0] && <p className="mt-1">Behavioral evolution: {behavioralMilestones.slice(0, 2).map((m) => m.detail).join(' · ')}</p>}
+              </div>
+              <div className="rounded-lg border border-rose-200 bg-rose-50 p-3 text-xs text-rose-900">
+                <p className="font-medium">Life-state intelligence · {Math.round(lifeStateProfile.contextualConfidence * 100)}% contextual confidence</p>
+                <p className="mt-1">Volatility {Math.round(lifeStateProfile.scheduleVolatilityScore * 100)}% · Time scarcity {Math.round(lifeStateProfile.timeScarcityScore * 100)}% · Burnout pressure {Math.round(lifeStateProfile.burnoutPressureScore * 100)}%</p>
+                <p className="mt-1">Recovery pressure {Math.round(lifeStateProfile.recoveryPressureScore * 100)}% · Stabilization need {Math.round(lifeStateProfile.stabilizationNeedScore * 100)}% · Energy consistency {Math.round(lifeStateProfile.energyConsistencyScore * 100)}%</p>
+                <p className="mt-1">Contextual compatibility {Math.round(contextualCompatibility * 100)}% · Recommendation confidence {Math.round(contextualRecommendationConfidence * 100)}%</p>
+                {contextualAdaptationBias[0] && <p className="mt-1">Adaptive guidance: {contextualAdaptationBias.slice(0, 2).join(' · ')}</p>}
+                {contextualInterventions[0] && <p className="mt-1">Protective interventions: {contextualInterventions.slice(0, 2).join(' · ')}</p>}
+                <p className="mt-1">Stability trend {Math.round(contextualStability.stabilizationTrend * 100)}% · Burnout cycle risk {Math.round(contextualStability.burnoutCycleRisk * 100)}%</p>
+                {recoveryWindows[0] && <p className="mt-1">Recovery window: {recoveryWindows[0]}</p>}
+                {protectiveNotes[0] && <p className="mt-1">Protective weighting: {protectiveNotes.slice(0, 2).join(' · ')}</p>}
+                {protectiveRecommendationBias[0] && <p className="mt-1">Recommendation bias: {protectiveRecommendationBias[0]}</p>}
+                {contextualTimeline[0] && <p className="mt-1">Contextual evolution: {contextualTimeline.slice(0, 2).map((m) => m.detail).join(' · ')}</p>}
               </div>
 
               {ENABLE_JOURNEY_TIMELINE && (

--- a/client/src/components/meal-planner/campaigns/life-state-intelligence/contextualAdaptation.ts
+++ b/client/src/components/meal-planner/campaigns/life-state-intelligence/contextualAdaptation.ts
@@ -1,0 +1,28 @@
+import type { NutritionLifeStateProfile } from '@/components/meal-planner/campaigns/life-state-intelligence/lifeStateProfile';
+
+export const deriveContextualAdaptationBias = (profile: NutritionLifeStateProfile): string[] => {
+  const output: string[] = [];
+  if (profile.scheduleVolatilityScore >= 0.55) output.push('Reduce prep intensity while schedule volatility is elevated.');
+  if (profile.householdDisruptionScore >= 0.5) output.push('Increase continuity anchors to protect household meal flow.');
+  if (profile.burnoutPressureScore >= 0.5) output.push('Prioritize recovery pacing and lower novelty load this week.');
+  if (profile.shoppingInstabilityScore >= 0.45) output.push('Simplify grocery cadence with short, repeatable lists.');
+  if (profile.stabilizationNeedScore >= 0.55) output.push('Favor familiar semantic patterns until continuity rebounds.');
+  return output;
+};
+
+export const deriveContextualInterventionStrategies = (profile: NutritionLifeStateProfile): string[] => {
+  const strategies: string[] = [];
+  if (profile.timeScarcityScore >= 0.5) strategies.push('Time-compressed prep blocks + backup no-cook meals');
+  if (profile.recoveryPressureScore >= 0.5) strategies.push('Recovery guardrails after disruption days');
+  if (profile.socialDisruptionScore >= 0.45) strategies.push('Flexible social meal slots with continuity anchors');
+  if (profile.energyConsistencyScore <= 0.45) strategies.push('Low-friction meal repeats on low-energy windows');
+  return strategies;
+};
+
+export const deriveLifeStateRecommendationAdjustments = (profile: NutritionLifeStateProfile) => ({
+  prepIntensityAdjustment: -(profile.timeScarcityScore * 0.5 + profile.scheduleVolatilityScore * 0.4),
+  continuityAnchorBoost: profile.householdDisruptionScore * 0.5 + profile.stabilizationNeedScore * 0.35,
+  recoveryPacingBoost: profile.recoveryPressureScore * 0.6 + profile.burnoutPressureScore * 0.25,
+  semanticFamiliarityBoost: profile.stabilizationNeedScore * 0.45 + profile.burnoutPressureScore * 0.25,
+  grocerySimplificationBoost: profile.shoppingInstabilityScore * 0.7,
+});

--- a/client/src/components/meal-planner/campaigns/life-state-intelligence/contextualRecommendationIntelligence.ts
+++ b/client/src/components/meal-planner/campaigns/life-state-intelligence/contextualRecommendationIntelligence.ts
@@ -1,0 +1,30 @@
+import type { NutritionBehavioralIntelligenceProfile } from '@/components/meal-planner/campaigns/behavioral-intelligence/behavioralIntelligenceProfile';
+import type { NutritionCampaignAdaptiveRecommendation } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+import type { NutritionLifeStateProfile } from '@/components/meal-planner/campaigns/life-state-intelligence/lifeStateProfile';
+
+const clamp01 = (value: number): number => Math.max(0, Math.min(1, value));
+
+export const deriveContextualCompatibilityScore = (
+  behavioral: NutritionBehavioralIntelligenceProfile,
+  profile: NutritionLifeStateProfile,
+  recommendation?: NutritionCampaignAdaptiveRecommendation,
+): number => {
+  const fitScore = recommendation?.fitScore ?? 0.5;
+  const protectivePenalty = profile.scheduleVolatilityScore * 0.15 + profile.burnoutPressureScore * 0.2 + profile.timeScarcityScore * 0.15;
+  const resilienceBoost = behavioral.recoveryStabilizationScore * 0.2 + behavioral.continuityPreferenceScore * 0.15;
+  return clamp01(fitScore * 0.7 + resilienceBoost - protectivePenalty);
+};
+
+export const deriveContextualRecommendationConfidence = (
+  profile: NutritionLifeStateProfile,
+  compatibilityScore: number,
+): number => clamp01(compatibilityScore * 0.6 + profile.contextualConfidence * 0.4);
+
+export const deriveProtectiveRecommendationBias = (profile: NutritionLifeStateProfile): string[] => {
+  const bias: string[] = [];
+  if (profile.burnoutPressureScore >= 0.5) bias.push('Bias toward low-load recovery-friendly recommendations.');
+  if (profile.scheduleVolatilityScore >= 0.5) bias.push('Favor flexible cadence over strict prep milestones.');
+  if (profile.shoppingInstabilityScore >= 0.5) bias.push('Prefer campaigns with simplified grocery demands.');
+  if (profile.stabilizationNeedScore >= 0.6) bias.push('Prioritize continuity-preserving missions before novelty objectives.');
+  return bias;
+};

--- a/client/src/components/meal-planner/campaigns/life-state-intelligence/contextualStability.ts
+++ b/client/src/components/meal-planner/campaigns/life-state-intelligence/contextualStability.ts
@@ -1,0 +1,35 @@
+import type { NutritionCampaignEvolutionMemory } from '@/components/meal-planner/campaigns/evolution/campaignEvolutionMemory';
+import type { NutritionLifeStateProfile } from '@/components/meal-planner/campaigns/life-state-intelligence/lifeStateProfile';
+
+const clamp01 = (value: number): number => Math.max(0, Math.min(1, value));
+
+export const deriveRecoveryStabilizationWindows = (profile: NutritionLifeStateProfile): string[] => {
+  const windows: string[] = [];
+  if (profile.recoveryPressureScore >= 0.55) windows.push('Prioritize 2-3 day stabilization windows after disruption spikes.');
+  if (profile.energyConsistencyScore <= 0.45) windows.push('Use low-energy recovery windows with repeated safe meals.');
+  if (profile.scheduleVolatilityScore <= 0.4) windows.push('Leverage stable days for prep rebound windows.');
+  return windows;
+};
+
+export const deriveVolatilityRecoveryPatterns = (memories: NutritionCampaignEvolutionMemory[]) => {
+  const disruption = memories.filter((item) => item.prepStabilitySignals.includes('prep-overload-watch')).length;
+  const recoveries = memories.filter((item) => item.recoveryInterventions.length > 0).length;
+  const reboundRatio = memories.length ? recoveries / memories.length : 0;
+  return {
+    disruptionEpisodes: disruption,
+    recoveryEpisodes: recoveries,
+    reboundRatio: clamp01(reboundRatio),
+    burnoutCycleRisk: clamp01(disruption / Math.max(1, memories.length) * 0.6 + (1 - reboundRatio) * 0.4),
+  };
+};
+
+export const deriveContextualStabilityProfile = (profile: NutritionLifeStateProfile, memories: NutritionCampaignEvolutionMemory[]) => {
+  const volatilityPatterns = deriveVolatilityRecoveryPatterns(memories);
+  const stabilizationTrend = clamp01(1 - profile.scheduleVolatilityScore * 0.5 - profile.stabilizationNeedScore * 0.3 + profile.energyConsistencyScore * 0.2);
+  return {
+    stabilizationTrend,
+    recoveryReboundStrength: volatilityPatterns.reboundRatio,
+    burnoutCycleRisk: volatilityPatterns.burnoutCycleRisk,
+    prepRecoveryWindowOpen: profile.timeScarcityScore < 0.55 && profile.burnoutPressureScore < 0.6,
+  };
+};

--- a/client/src/components/meal-planner/campaigns/life-state-intelligence/contextualStrategyWeights.ts
+++ b/client/src/components/meal-planner/campaigns/life-state-intelligence/contextualStrategyWeights.ts
@@ -1,0 +1,21 @@
+import type { NutritionLifeStateProfile } from '@/components/meal-planner/campaigns/life-state-intelligence/lifeStateProfile';
+
+const clamp01 = (value: number): number => Math.max(0, Math.min(1, value));
+
+export const deriveContextualStrategyWeights = (profile: NutritionLifeStateProfile) => ({
+  recoveryPacing: clamp01(0.3 + profile.recoveryPressureScore * 0.55 + profile.burnoutPressureScore * 0.15),
+  continuityAnchors: clamp01(0.25 + profile.stabilizationNeedScore * 0.45 + profile.householdDisruptionScore * 0.2),
+  noveltyReduction: clamp01(0.2 + profile.burnoutPressureScore * 0.45 + profile.scheduleVolatilityScore * 0.2),
+  prepSimplification: clamp01(0.2 + profile.timeScarcityScore * 0.5 + profile.shoppingInstabilityScore * 0.2),
+  grocerySimplification: clamp01(0.2 + profile.shoppingInstabilityScore * 0.55 + profile.scheduleVolatilityScore * 0.15),
+});
+
+export const deriveProtectiveAdaptationBias = (weights: ReturnType<typeof deriveContextualStrategyWeights>): string[] => {
+  const notes: string[] = [];
+  if (weights.recoveryPacing >= 0.6) notes.push('Recovery pacing has emergency priority.');
+  if (weights.continuityAnchors >= 0.6) notes.push('Continuity anchors are in protective mode.');
+  if (weights.noveltyReduction >= 0.55) notes.push('Novelty cadence is temporarily reduced to limit fatigue.');
+  if (weights.prepSimplification >= 0.55) notes.push('Prep simplification is upweighted to protect consistency.');
+  if (weights.grocerySimplification >= 0.55) notes.push('Grocery simplification activated under instability.');
+  return notes;
+};

--- a/client/src/components/meal-planner/campaigns/life-state-intelligence/contextualTimeline.ts
+++ b/client/src/components/meal-planner/campaigns/life-state-intelligence/contextualTimeline.ts
@@ -1,0 +1,21 @@
+import type { NutritionLifeStateProfile } from '@/components/meal-planner/campaigns/life-state-intelligence/lifeStateProfile';
+
+export type ContextualMilestone = { id: string; detail: string; severity: 'info' | 'watch' | 'protective' };
+
+export const deriveContextualMilestones = (profile: NutritionLifeStateProfile): ContextualMilestone[] => {
+  const milestones: ContextualMilestone[] = [];
+  if (profile.scheduleVolatilityScore <= 0.4) milestones.push({ id: 'schedule-stabilized', detail: 'Schedule volatility stabilized.', severity: 'info' });
+  if (profile.burnoutPressureScore <= 0.4) milestones.push({ id: 'burnout-reduced', detail: 'Burnout pressure reduced.', severity: 'info' });
+  if (profile.recoveryPressureScore <= 0.45) milestones.push({ id: 'recovery-softened', detail: 'Recovery pressure softened.', severity: 'info' });
+  if (profile.stabilizationNeedScore >= 0.6) milestones.push({ id: 'protective-mode', detail: 'Continuity protection mode activated during instability.', severity: 'protective' });
+  if (profile.timeScarcityScore >= 0.6) milestones.push({ id: 'time-scarcity-watch', detail: 'Time scarcity elevated; simplify prep cadence.', severity: 'watch' });
+  return milestones;
+};
+
+export const deriveLifeStateEvolutionTimeline = (profile: NutritionLifeStateProfile): ContextualMilestone[] => {
+  const milestones = deriveContextualMilestones(profile);
+  if (!milestones.length) {
+    return [{ id: 'context-calibrating', detail: 'Life-state intelligence is calibrating from recent campaign behavior.', severity: 'info' }];
+  }
+  return milestones;
+};

--- a/client/src/components/meal-planner/campaigns/life-state-intelligence/lifeStateProfile.ts
+++ b/client/src/components/meal-planner/campaigns/life-state-intelligence/lifeStateProfile.ts
@@ -1,0 +1,91 @@
+import type { NutritionBehavioralIntelligenceProfile } from '@/components/meal-planner/campaigns/behavioral-intelligence/behavioralIntelligenceProfile';
+import type { NutritionCampaignEvolutionMemory } from '@/components/meal-planner/campaigns/evolution/campaignEvolutionMemory';
+import { deriveContextualStressSignals, deriveEnvironmentalVolatilitySignals, deriveLifeStateSignals } from '@/components/meal-planner/campaigns/life-state-intelligence/lifeStateSignals';
+
+export type NutritionLifeStateProfile = {
+  scheduleVolatilityScore: number;
+  timeScarcityScore: number;
+  burnoutPressureScore: number;
+  householdDisruptionScore: number;
+  shoppingInstabilityScore: number;
+  recoveryPressureScore: number;
+  seasonalStressScore: number;
+  energyConsistencyScore: number;
+  socialDisruptionScore: number;
+  stabilizationNeedScore: number;
+  contextualConfidence: number;
+  evolutionVersion: number;
+  lastUpdatedAt: string;
+};
+
+const clamp01 = (value: number): number => Math.max(0, Math.min(1, value));
+export const createDefaultLifeStateProfile = (): NutritionLifeStateProfile => ({
+  scheduleVolatilityScore: 0.35,
+  timeScarcityScore: 0.35,
+  burnoutPressureScore: 0.3,
+  householdDisruptionScore: 0.3,
+  shoppingInstabilityScore: 0.3,
+  recoveryPressureScore: 0.3,
+  seasonalStressScore: 0.25,
+  energyConsistencyScore: 0.55,
+  socialDisruptionScore: 0.25,
+  stabilizationNeedScore: 0.3,
+  contextualConfidence: 0.2,
+  evolutionVersion: 1,
+  lastUpdatedAt: new Date().toISOString(),
+});
+
+export const deriveLifeStateProfile = (
+  behavioral: NutritionBehavioralIntelligenceProfile,
+  memories: NutritionCampaignEvolutionMemory[],
+): NutritionLifeStateProfile => {
+  const lifeSignals = deriveLifeStateSignals(behavioral, memories);
+  const stress = deriveContextualStressSignals(lifeSignals);
+  const volatility = deriveEnvironmentalVolatilitySignals(lifeSignals);
+  const seasonalBurden = clamp01(lifeSignals.cadenceInstability * 0.4 + lifeSignals.lateWeekFatiguePattern * 0.6);
+  const energyConsistency = clamp01(behavioral.momentumRecoveryScore * 0.6 + behavioral.sustainabilityResilienceScore * 0.4);
+  const stabilizationNeed = clamp01((stress.recoveryPressure + volatility.scheduleVolatility + stress.burnoutPressure) / 3);
+
+  return {
+    scheduleVolatilityScore: volatility.scheduleVolatility,
+    timeScarcityScore: stress.timeScarcityPressure,
+    burnoutPressureScore: stress.burnoutPressure,
+    householdDisruptionScore: volatility.householdDisruption,
+    shoppingInstabilityScore: volatility.shoppingInstability,
+    recoveryPressureScore: stress.recoveryPressure,
+    seasonalStressScore: seasonalBurden,
+    energyConsistencyScore: energyConsistency,
+    socialDisruptionScore: volatility.socialDisruption,
+    stabilizationNeedScore: stabilizationNeed,
+    contextualConfidence: clamp01(behavioral.behavioralConfidence * 0.7 + Math.min(memories.length, 12) / 12 * 0.3),
+    evolutionVersion: 1,
+    lastUpdatedAt: new Date().toISOString(),
+  };
+};
+
+export const updateLifeStateProfile = (
+  previous: NutritionLifeStateProfile | null,
+  behavioral: NutritionBehavioralIntelligenceProfile,
+  memories: NutritionCampaignEvolutionMemory[],
+): NutritionLifeStateProfile => {
+  const derived = deriveLifeStateProfile(behavioral, memories);
+  if (!previous) return derived;
+
+  const smooth = (a: number, b: number): number => clamp01(a * 0.45 + b * 0.55);
+  return {
+    ...derived,
+    scheduleVolatilityScore: smooth(previous.scheduleVolatilityScore, derived.scheduleVolatilityScore),
+    timeScarcityScore: smooth(previous.timeScarcityScore, derived.timeScarcityScore),
+    burnoutPressureScore: smooth(previous.burnoutPressureScore, derived.burnoutPressureScore),
+    householdDisruptionScore: smooth(previous.householdDisruptionScore, derived.householdDisruptionScore),
+    shoppingInstabilityScore: smooth(previous.shoppingInstabilityScore, derived.shoppingInstabilityScore),
+    recoveryPressureScore: smooth(previous.recoveryPressureScore, derived.recoveryPressureScore),
+    seasonalStressScore: smooth(previous.seasonalStressScore, derived.seasonalStressScore),
+    energyConsistencyScore: smooth(previous.energyConsistencyScore, derived.energyConsistencyScore),
+    socialDisruptionScore: smooth(previous.socialDisruptionScore, derived.socialDisruptionScore),
+    stabilizationNeedScore: smooth(previous.stabilizationNeedScore, derived.stabilizationNeedScore),
+    contextualConfidence: smooth(previous.contextualConfidence, derived.contextualConfidence),
+    evolutionVersion: previous.evolutionVersion + 1,
+    lastUpdatedAt: new Date().toISOString(),
+  };
+};

--- a/client/src/components/meal-planner/campaigns/life-state-intelligence/lifeStateSignals.ts
+++ b/client/src/components/meal-planner/campaigns/life-state-intelligence/lifeStateSignals.ts
@@ -1,0 +1,51 @@
+import type { NutritionBehavioralIntelligenceProfile } from '@/components/meal-planner/campaigns/behavioral-intelligence/behavioralIntelligenceProfile';
+import type { NutritionCampaignEvolutionMemory } from '@/components/meal-planner/campaigns/evolution/campaignEvolutionMemory';
+
+export type NutritionLifeStateSignals = {
+  repeatedPrepFailures: number;
+  continuityCollapse: number;
+  cadenceInstability: number;
+  reducedAdherenceVelocity: number;
+  repeatedRecoveryInterventions: number;
+  lateWeekFatiguePattern: number;
+  lowPrepResilience: number;
+};
+
+const clamp01 = (value: number): number => Math.max(0, Math.min(1, value));
+
+export const deriveLifeStateSignals = (
+  behavioral: NutritionBehavioralIntelligenceProfile,
+  memories: NutritionCampaignEvolutionMemory[],
+): NutritionLifeStateSignals => {
+  const prepWatchRate = memories.length
+    ? memories.filter((item) => item.prepStabilitySignals.includes('prep-overload-watch')).length / memories.length
+    : 0;
+  const failedPrepStrategies = memories.flatMap((item) => item.failedStrategies).filter((item) => item.includes('prep')).length;
+  const recoveryDensity = memories.length ? memories.flatMap((item) => item.recoveryInterventions).length / memories.length : 0;
+  const avgMomentum = memories.length
+    ? memories.reduce((sum, item) => sum + (item.momentumHistory[item.momentumHistory.length - 1] ?? 0.5), 0) / memories.length
+    : behavioral.momentumRecoveryScore;
+
+  return {
+    repeatedPrepFailures: clamp01(prepWatchRate * 0.65 + Math.min(failedPrepStrategies, 10) / 10 * 0.35),
+    continuityCollapse: clamp01(1 - behavioral.continuityPreferenceScore),
+    cadenceInstability: clamp01(1 - behavioral.cadenceStabilityScore),
+    reducedAdherenceVelocity: clamp01(1 - behavioral.sustainabilityResilienceScore * 0.6 - avgMomentum * 0.4),
+    repeatedRecoveryInterventions: clamp01(recoveryDensity / 3),
+    lateWeekFatiguePattern: clamp01((1 - behavioral.momentumRecoveryScore) * 0.6 + (1 - behavioral.prepToleranceScore) * 0.4),
+    lowPrepResilience: clamp01((1 - behavioral.prepToleranceScore) * 0.7 + prepWatchRate * 0.3),
+  };
+};
+
+export const deriveContextualStressSignals = (signals: NutritionLifeStateSignals) => ({
+  burnoutPressure: clamp01(signals.lateWeekFatiguePattern * 0.5 + signals.repeatedRecoveryInterventions * 0.3 + signals.reducedAdherenceVelocity * 0.2),
+  recoveryPressure: clamp01(signals.repeatedRecoveryInterventions * 0.6 + signals.continuityCollapse * 0.4),
+  timeScarcityPressure: clamp01(signals.repeatedPrepFailures * 0.5 + signals.lowPrepResilience * 0.5),
+});
+
+export const deriveEnvironmentalVolatilitySignals = (signals: NutritionLifeStateSignals) => ({
+  scheduleVolatility: clamp01(signals.cadenceInstability * 0.6 + signals.continuityCollapse * 0.4),
+  householdDisruption: clamp01(signals.continuityCollapse * 0.45 + signals.repeatedPrepFailures * 0.35 + signals.repeatedRecoveryInterventions * 0.2),
+  shoppingInstability: clamp01(signals.repeatedPrepFailures * 0.55 + signals.reducedAdherenceVelocity * 0.45),
+  socialDisruption: clamp01(signals.cadenceInstability * 0.5 + signals.reducedAdherenceVelocity * 0.5),
+});

--- a/client/src/components/meal-planner/campaigns/life-state-intelligence/lifeStateStore.ts
+++ b/client/src/components/meal-planner/campaigns/life-state-intelligence/lifeStateStore.ts
@@ -1,0 +1,44 @@
+import type { NutritionLifeStateProfile } from '@/components/meal-planner/campaigns/life-state-intelligence/lifeStateProfile';
+import { createDefaultLifeStateProfile } from '@/components/meal-planner/campaigns/life-state-intelligence/lifeStateProfile';
+
+const STORAGE_KEY = 'mealPlanner.lifeStateIntelligence.v1';
+const MAX_SERIALIZED_LENGTH = 20_000;
+
+const hasWindow = (): boolean => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+const normalizeProfile = (input: unknown): NutritionLifeStateProfile | null => {
+  if (!input || typeof input !== 'object') return null;
+  const candidate = input as Partial<NutritionLifeStateProfile>;
+  if (typeof candidate.scheduleVolatilityScore !== 'number' || typeof candidate.contextualConfidence !== 'number') return null;
+  return {
+    ...createDefaultLifeStateProfile(),
+    ...candidate,
+    evolutionVersion: typeof candidate.evolutionVersion === 'number' ? candidate.evolutionVersion : 1,
+    lastUpdatedAt: typeof candidate.lastUpdatedAt === 'string' ? candidate.lastUpdatedAt : new Date().toISOString(),
+  };
+};
+
+export const getLifeStateProfile = (): NutritionLifeStateProfile | null => {
+  if (!hasWindow()) return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    if (raw.length > MAX_SERIALIZED_LENGTH) return null;
+    return normalizeProfile(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+};
+
+export const saveLifeStateProfile = (profile: NutritionLifeStateProfile): NutritionLifeStateProfile => {
+  if (!hasWindow()) return profile;
+  try {
+    const serialized = JSON.stringify(profile);
+    if (serialized.length <= MAX_SERIALIZED_LENGTH) {
+      window.localStorage.setItem(STORAGE_KEY, serialized);
+    }
+  } catch {
+    // preserve graceful fallback
+  }
+  return profile;
+};


### PR DESCRIPTION
### Motivation
- Provide a lightweight, deterministic layer so campaign recommendations can adapt to why behavior changes (environmental/life-state pressures) in addition to how users behave. 
- Keep the change additive and explainable, preserving existing campaign evolution, behavioral intelligence, ecosystem integrations, and localStorage fallback semantics. 

### Description
- Added a new life-state intelligence module set under `client/src/components/meal-planner/campaigns/life-state-intelligence/` providing profile derivation, signal extraction, adaptation biasing, stability/recovery modeling, timeline milestones, strategy weighting, recommendation intelligence, and bounded localStorage persistence (created files: `lifeStateProfile.ts`, `lifeStateSignals.ts`, `contextualAdaptation.ts`, `contextualStability.ts`, `contextualTimeline.ts`, `contextualStrategyWeights.ts`, `contextualRecommendationIntelligence.ts`, `lifeStateStore.ts`).
- Integrated the layer into the campaign UI by adding state, derivation/update cycles, memoized computed outputs and a new “Life-state intelligence” summary card in `NutritionCampaignPanel.tsx` while leaving existing behavioral intelligence and campaign evolution flows intact (modified file: `client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx`).
- Implemented deterministic, inspectable behaviors: `NutritionLifeStateProfile` with `deriveLifeStateProfile()` and `updateLifeStateProfile()` (bounded smoothing/evolutionVersion), life-state signals via `deriveLifeStateSignals()` plus `deriveContextualStressSignals()` and `deriveEnvironmentalVolatilitySignals()`, and adaptation helpers like `deriveContextualAdaptationBias()`, `deriveContextualInterventionStrategies()`, `deriveLifeStateRecommendationAdjustments()`. 
- Implemented stability and timeline tooling: `deriveContextualStabilityProfile()`, `deriveRecoveryStabilizationWindows()`, `deriveVolatilityRecoveryPatterns()`, `deriveLifeStateEvolutionTimeline()`, plus strategy weighting and protective bias (`deriveContextualStrategyWeights()`, `deriveProtectiveAdaptationBias()`), and contextual recommendation scoring (`deriveContextualCompatibilityScore()`, `deriveContextualRecommendationConfidence()`, `deriveProtectiveRecommendationBias()`).
- Persistence is local-only, corruption-safe, capped, and uses key `mealPlanner.lifeStateIntelligence.v1` with graceful fallback via `getLifeStateProfile()` and `saveLifeStateProfile()` in `lifeStateStore.ts`.

### Testing
- Built the client bundle with `npm run build:client` successfully (production build completed). 
- Built the server bundle with `npm run build:server` successfully (esbuild output generated). 
- Ran targeted TypeScript invocation for the new life-state modules (via `npx tsc --noEmit` on the file set) and observed path-alias / invocation nuances; module-level code type-checking for the new files is expected to be sound in project-mode. 
- Ran full repo `npm run check` which failed due to pre-existing, repo-wide TypeScript errors unrelated to these additions (detailed failures recorded during the run and not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a582a77c83259b40c239a3509191)