### PR TITLE
Add deterministic Temporal Rhythm Intelligence layer to Nutrition planner

### DIFF
--- a/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
+++ b/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
@@ -46,6 +46,14 @@ import { deriveContextualStabilityProfile, deriveRecoveryStabilizationWindows } 
 import { deriveLifeStateEvolutionTimeline } from '@/components/meal-planner/campaigns/life-state-intelligence/contextualTimeline';
 import { deriveContextualStrategyWeights, deriveProtectiveAdaptationBias } from '@/components/meal-planner/campaigns/life-state-intelligence/contextualStrategyWeights';
 import { deriveContextualCompatibilityScore, deriveContextualRecommendationConfidence, deriveProtectiveRecommendationBias } from '@/components/meal-planner/campaigns/life-state-intelligence/contextualRecommendationIntelligence';
+import { createDefaultTemporalRhythmProfile, updateTemporalRhythmProfile } from '@/components/meal-planner/campaigns/temporal-rhythm/temporalRhythmProfile';
+import { getTemporalRhythmProfile, saveTemporalRhythmProfile } from '@/components/meal-planner/campaigns/temporal-rhythm/temporalRhythmStore';
+import { deriveTemporalAdaptationBias, deriveRhythmOrchestrationStrategies, deriveCadencePhaseRecommendations } from '@/components/meal-planner/campaigns/temporal-rhythm/temporalAdaptation';
+import { deriveTemporalPhase, deriveTemporalPhaseTransitions, deriveRhythmCycleNarratives } from '@/components/meal-planner/campaigns/temporal-rhythm/temporalPhaseModeling';
+import { deriveTemporalStabilityProfile } from '@/components/meal-planner/campaigns/temporal-rhythm/temporalStability';
+import { deriveTemporalCompatibilityScore, deriveTemporalRecommendationConfidence, deriveTemporalProtectionBias } from '@/components/meal-planner/campaigns/temporal-rhythm/temporalRecommendationIntelligence';
+import { deriveTemporalStrategyWeights, deriveRhythmProtectionBias } from '@/components/meal-planner/campaigns/temporal-rhythm/temporalStrategyWeights';
+import { deriveTemporalEvolutionTimeline } from '@/components/meal-planner/campaigns/temporal-rhythm/temporalTimeline';
 
 const WeeklyNutritionJourneyTimeline = React.lazy(() => import('@/components/meal-planner/journey-timeline/WeeklyNutritionJourneyTimeline'));
 const ENABLE_JOURNEY_TIMELINE = true;
@@ -102,6 +110,7 @@ const NutritionCampaignPanel: React.FC<Props> = ({
   });
   const [behavioralProfile, setBehavioralProfile] = React.useState(() => getBehavioralIntelligenceProfile());
   const [lifeStateProfile, setLifeStateProfile] = React.useState(() => getLifeStateProfile() ?? createDefaultLifeStateProfile());
+  const [temporalRhythmProfile, setTemporalRhythmProfile] = React.useState(() => getTemporalRhythmProfile() ?? createDefaultTemporalRhythmProfile());
 
   const toggleSavedCampaign = React.useCallback((campaignId: string) => {
     const campaign = NUTRITION_CAMPAIGN_CATALOG.find((item) => item.id === campaignId);
@@ -180,8 +189,10 @@ const NutritionCampaignPanel: React.FC<Props> = ({
       const behavioralForLifeState = updateBehavioralIntelligenceProfile(behavioralProfile, allMemories);
       const nextLifeState = updateLifeStateProfile(lifeStateProfile, behavioralForLifeState, allMemories);
       setLifeStateProfile(saveLifeStateProfile(nextLifeState));
+      const nextTemporal = updateTemporalRhythmProfile(temporalRhythmProfile, behavioralForLifeState, nextLifeState, allMemories);
+      setTemporalRhythmProfile(saveTemporalRhythmProfile(nextTemporal));
     }
-  }, [activeCampaignId, progress]);
+  }, [activeCampaignId, progress, behavioralProfile, lifeStateProfile, temporalRhythmProfile]);
 
   const activeEvolutionMemory = activeCampaignId ? evolutionMemoryByCampaignId[activeCampaignId] : null;
   const activeLearningProfile = activeEvolutionMemory ? deriveCampaignLearningProfile(activeEvolutionMemory) : null;
@@ -226,6 +237,25 @@ const NutritionCampaignPanel: React.FC<Props> = ({
     [lifeStateProfile, contextualCompatibility],
   );
   const protectiveRecommendationBias = React.useMemo(() => deriveProtectiveRecommendationBias(lifeStateProfile), [lifeStateProfile]);
+  const temporalPhase = React.useMemo(() => deriveTemporalPhase(temporalRhythmProfile), [temporalRhythmProfile]);
+  const temporalTransitions = React.useMemo(() => deriveTemporalPhaseTransitions(temporalRhythmProfile), [temporalRhythmProfile]);
+  const rhythmNarratives = React.useMemo(() => deriveRhythmCycleNarratives(temporalRhythmProfile), [temporalRhythmProfile]);
+  const temporalAdaptationBias = React.useMemo(() => deriveTemporalAdaptationBias(temporalRhythmProfile), [temporalRhythmProfile]);
+  const rhythmStrategies = React.useMemo(() => deriveRhythmOrchestrationStrategies(temporalRhythmProfile), [temporalRhythmProfile]);
+  const cadenceRecommendations = React.useMemo(() => deriveCadencePhaseRecommendations(temporalRhythmProfile), [temporalRhythmProfile]);
+  const temporalStability = React.useMemo(() => deriveTemporalStabilityProfile(temporalRhythmProfile), [temporalRhythmProfile]);
+  const temporalCompatibility = React.useMemo(
+    () => deriveTemporalCompatibilityScore(resolvedBehavioralProfile, lifeStateProfile, temporalRhythmProfile, activeRecommendation),
+    [resolvedBehavioralProfile, lifeStateProfile, temporalRhythmProfile, activeRecommendation],
+  );
+  const temporalRecommendationConfidence = React.useMemo(
+    () => deriveTemporalRecommendationConfidence(temporalRhythmProfile, temporalCompatibility),
+    [temporalRhythmProfile, temporalCompatibility],
+  );
+  const temporalProtectionBias = React.useMemo(() => deriveTemporalProtectionBias(temporalRhythmProfile), [temporalRhythmProfile]);
+  const temporalWeights = React.useMemo(() => deriveTemporalStrategyWeights(temporalRhythmProfile), [temporalRhythmProfile]);
+  const rhythmProtectionBias = React.useMemo(() => deriveRhythmProtectionBias(temporalWeights), [temporalWeights]);
+  const temporalEvolutionTimeline = React.useMemo(() => deriveTemporalEvolutionTimeline(temporalRhythmProfile), [temporalRhythmProfile]);
 
   return (
     <div className="space-y-4">
@@ -393,6 +423,24 @@ const NutritionCampaignPanel: React.FC<Props> = ({
                 {protectiveNotes[0] && <p className="mt-1">Protective weighting: {protectiveNotes.slice(0, 2).join(' · ')}</p>}
                 {protectiveRecommendationBias[0] && <p className="mt-1">Recommendation bias: {protectiveRecommendationBias[0]}</p>}
                 {contextualTimeline[0] && <p className="mt-1">Contextual evolution: {contextualTimeline.slice(0, 2).map((m) => m.detail).join(' · ')}</p>}
+              </div>
+              <div className="rounded-lg border border-violet-200 bg-violet-50 p-3 text-xs text-violet-900">
+                <p className="font-medium">Temporal rhythm intelligence</p>
+                <p className="mt-1">
+                  Phase {temporalPhase} · Rhythm stability {Math.round(temporalRhythmProfile.rhythmStabilityScore * 100)}% · Recovery window {Math.round(temporalRhythmProfile.recoveryWindowScore * 100)}%
+                </p>
+                <p className="mt-1">
+                  Cadence resilience {Math.round(temporalStability.cadenceResilience * 100)}% · Temporal confidence {Math.round(temporalRecommendationConfidence * 100)}%
+                </p>
+                <p className="mt-1">Timing weights · recovery {Math.round(temporalWeights.recoveryPacingWeight * 100)}% · novelty {Math.round(temporalWeights.noveltyReintroductionWeight * 100)}% · continuity {Math.round(temporalWeights.continuityAnchorWeight * 100)}%</p>
+                <ul className="mt-1 list-disc pl-4">
+                  {[...rhythmNarratives, ...temporalTransitions, ...cadenceRecommendations].slice(0, 4).map((item) => <li key={item}>{item}</li>)}
+                </ul>
+                {temporalAdaptationBias[0] && <p className="mt-1">Rhythm adaptation: {temporalAdaptationBias.slice(0, 2).join(' · ')}</p>}
+                {rhythmStrategies[0] && <p className="mt-1">Orchestration: {rhythmStrategies.slice(0, 2).join(' · ')}</p>}
+                {temporalProtectionBias[0] && <p className="mt-1">Protection timing: {temporalProtectionBias[0]}</p>}
+                {rhythmProtectionBias[0] && <p className="mt-1">Protection weighting: {rhythmProtectionBias[0]}</p>}
+                {temporalEvolutionTimeline[0] && <p className="mt-1">Temporal evolution: {temporalEvolutionTimeline.slice(0, 2).join(' · ')}</p>}
               </div>
 
               {ENABLE_JOURNEY_TIMELINE && (

--- a/client/src/components/meal-planner/campaigns/temporal-rhythm/temporalAdaptation.ts
+++ b/client/src/components/meal-planner/campaigns/temporal-rhythm/temporalAdaptation.ts
@@ -1,0 +1,24 @@
+import type { NutritionTemporalRhythmProfile } from '@/components/meal-planner/campaigns/temporal-rhythm/temporalRhythmProfile';
+
+export const deriveTemporalAdaptationBias = (profile: NutritionTemporalRhythmProfile): string[] => {
+  const notes: string[] = [];
+  if (profile.rhythmStabilityScore > 0.65) notes.push('Deploy novelty in current stable momentum window.');
+  if (profile.recoveryWindowScore < 0.45) notes.push('Reduce challenge and prioritize recovery pacing.');
+  if (profile.cadenceTransitionScore < 0.5) notes.push('Shift to lighter cadence transition guidance this week.');
+  if (profile.continuityProtectionScore < 0.5) notes.push('Pre-activate continuity anchors before likely instability.');
+  if (profile.prepRecoveryWindowScore > 0.55) notes.push('Schedule prep rebound immediately after recovery phase.');
+  return notes;
+};
+
+export const deriveRhythmOrchestrationStrategies = (profile: NutritionTemporalRhythmProfile): string[] => [
+  profile.noveltyWindowScore > 0.6 ? 'Novelty reintroduction window is open.' : 'Novelty should remain capped until rhythm stabilizes.',
+  profile.recoveryWindowScore > 0.55 ? 'Recovery sequencing is ready for moderate challenge.' : 'Recovery sequencing should be protected from new load.',
+  profile.prepRecoveryWindowScore > 0.55 ? 'Prep recovery windows can carry continuity.' : 'Keep prep expectations lightweight and bounded.',
+  profile.continuityProtectionScore > 0.55 ? 'Continuity protection can be proactive this cycle.' : 'Add conservative continuity anchors now.',
+];
+
+export const deriveCadencePhaseRecommendations = (profile: NutritionTemporalRhythmProfile): string[] => {
+  if (profile.cadenceTransitionScore >= 0.7) return ['Advance cadence with a momentum-focused transition.'];
+  if (profile.cadenceTransitionScore >= 0.5) return ['Use a blended cadence: moderate challenge, protected recovery.'];
+  return ['Use stabilization cadence with explicit recovery checkpoints.'];
+};

--- a/client/src/components/meal-planner/campaigns/temporal-rhythm/temporalPhaseModeling.ts
+++ b/client/src/components/meal-planner/campaigns/temporal-rhythm/temporalPhaseModeling.ts
@@ -1,0 +1,27 @@
+import type { NutritionTemporalRhythmProfile } from '@/components/meal-planner/campaigns/temporal-rhythm/temporalRhythmProfile';
+
+export type TemporalPhase = 'recovery' | 'stabilization' | 'momentum' | 'transformation' | 'protection' | 'novelty-reintroduction';
+
+export const deriveTemporalPhase = (profile: NutritionTemporalRhythmProfile): TemporalPhase => {
+  if (profile.recoveryWindowScore < 0.45) return 'recovery';
+  if (profile.continuityProtectionScore < 0.45) return 'protection';
+  if (profile.rhythmStabilityScore < 0.5) return 'stabilization';
+  if (profile.transformationMomentumScore > 0.7) return 'transformation';
+  if (profile.noveltyWindowScore > 0.65) return 'novelty-reintroduction';
+  return 'momentum';
+};
+
+export const deriveTemporalPhaseTransitions = (profile: NutritionTemporalRhythmProfile): string[] => [
+  profile.recoveryWindowScore > 0.55 ? 'Recovery → Stabilization ready.' : 'Recovery hold remains active.',
+  profile.rhythmStabilityScore > 0.58 ? 'Stabilization → Momentum ready.' : 'Stabilization extension recommended.',
+  profile.noveltyWindowScore > 0.65 ? 'Momentum → Novelty reintroduction unlocked.' : 'Novelty gate remains protected.',
+];
+
+export const deriveRhythmCycleNarratives = (profile: NutritionTemporalRhythmProfile): string[] => {
+  const phase = deriveTemporalPhase(profile);
+  return [
+    `Current temporal phase: ${phase}.`,
+    `Cadence transition score: ${Math.round(profile.cadenceTransitionScore * 100)}%.`,
+    `Recovery window readiness: ${Math.round(profile.recoveryWindowScore * 100)}%.`,
+  ];
+};

--- a/client/src/components/meal-planner/campaigns/temporal-rhythm/temporalRecommendationIntelligence.ts
+++ b/client/src/components/meal-planner/campaigns/temporal-rhythm/temporalRecommendationIntelligence.ts
@@ -1,0 +1,24 @@
+import type { NutritionCampaignAdaptiveRecommendation } from '@/components/meal-planner/campaigns/nutritionCampaignTypes';
+import type { NutritionBehavioralIntelligenceProfile } from '@/components/meal-planner/campaigns/behavioral-intelligence/behavioralIntelligenceProfile';
+import type { NutritionLifeStateProfile } from '@/components/meal-planner/campaigns/life-state-intelligence/lifeStateProfile';
+import type { NutritionTemporalRhythmProfile } from '@/components/meal-planner/campaigns/temporal-rhythm/temporalRhythmProfile';
+
+const clamp01 = (value: number): number => Math.max(0, Math.min(1, value));
+
+export const deriveTemporalCompatibilityScore = (
+  behavioral: NutritionBehavioralIntelligenceProfile,
+  life: NutritionLifeStateProfile,
+  temporal: NutritionTemporalRhythmProfile,
+  recommendation?: NutritionCampaignAdaptiveRecommendation,
+): number => clamp01(
+  behavioral.momentumRecoveryScore * 0.2 + (1 - life.scheduleVolatilityScore) * 0.2 + temporal.rhythmStabilityScore * 0.3 + temporal.recoveryWindowScore * 0.2 + ((recommendation?.fitScore ?? 0.5) * 0.1),
+);
+
+export const deriveTemporalRecommendationConfidence = (temporal: NutritionTemporalRhythmProfile, compatibility: number): number => clamp01(
+  temporal.temporalConfidence * 0.55 + compatibility * 0.45,
+);
+
+export const deriveTemporalProtectionBias = (temporal: NutritionTemporalRhythmProfile): string[] => [
+  temporal.continuityProtectionScore < 0.5 ? 'Prioritize continuity protection windows before escalation.' : 'Continuity protection can stay light-touch this cycle.',
+  temporal.recoveryWindowScore < 0.5 ? 'Hold challenge until recovery timing improves.' : 'Recovery timing supports selective challenge windows.',
+];

--- a/client/src/components/meal-planner/campaigns/temporal-rhythm/temporalRhythmProfile.ts
+++ b/client/src/components/meal-planner/campaigns/temporal-rhythm/temporalRhythmProfile.ts
@@ -1,0 +1,81 @@
+import type { NutritionBehavioralIntelligenceProfile } from '@/components/meal-planner/campaigns/behavioral-intelligence/behavioralIntelligenceProfile';
+import type { NutritionCampaignEvolutionMemory } from '@/components/meal-planner/campaigns/evolution/campaignEvolutionMemory';
+import type { NutritionLifeStateProfile } from '@/components/meal-planner/campaigns/life-state-intelligence/lifeStateProfile';
+import { deriveCadenceTransitionSignals, deriveRecoveryTimingSignals, deriveTemporalRhythmSignals } from '@/components/meal-planner/campaigns/temporal-rhythm/temporalSignals';
+
+export type NutritionTemporalRhythmProfile = {
+  noveltyWindowScore: number;
+  stabilizationWindowScore: number;
+  recoveryWindowScore: number;
+  transformationMomentumScore: number;
+  cadenceTransitionScore: number;
+  prepRecoveryWindowScore: number;
+  continuityProtectionScore: number;
+  temporalFlexibilityScore: number;
+  rhythmStabilityScore: number;
+  seasonalRhythmScore: number;
+  temporalConfidence: number;
+  evolutionVersion: number;
+  lastUpdatedAt: string;
+};
+
+const clamp01 = (value: number): number => Math.max(0, Math.min(1, value));
+
+export const createDefaultTemporalRhythmProfile = (): NutritionTemporalRhythmProfile => ({
+  noveltyWindowScore: 0.4, stabilizationWindowScore: 0.5, recoveryWindowScore: 0.45, transformationMomentumScore: 0.4,
+  cadenceTransitionScore: 0.45, prepRecoveryWindowScore: 0.45, continuityProtectionScore: 0.5, temporalFlexibilityScore: 0.45,
+  rhythmStabilityScore: 0.45, seasonalRhythmScore: 0.4, temporalConfidence: 0.2, evolutionVersion: 1, lastUpdatedAt: new Date().toISOString(),
+});
+
+export const deriveTemporalRhythmProfile = (
+  behavioral: NutritionBehavioralIntelligenceProfile,
+  lifeState: NutritionLifeStateProfile,
+  memories: NutritionCampaignEvolutionMemory[],
+): NutritionTemporalRhythmProfile => {
+  const rhythm = deriveTemporalRhythmSignals(behavioral, lifeState, memories);
+  const cadence = deriveCadenceTransitionSignals(behavioral, lifeState, memories);
+  const recovery = deriveRecoveryTimingSignals(behavioral, lifeState, memories);
+  const stability = clamp01((rhythm.stabilizationDurationQuality + cadence.cadenceTransitionStability + recovery.recoveryCycleEfficiency) / 3);
+  return {
+    noveltyWindowScore: clamp01(rhythm.momentumRecoveryTiming * 0.55 + (1 - lifeState.stabilizationNeedScore) * 0.45),
+    stabilizationWindowScore: clamp01(rhythm.stabilizationDurationQuality * 0.65 + lifeState.stabilizationNeedScore * 0.35),
+    recoveryWindowScore: clamp01(recovery.lateWeekFatigueRecovery * 0.4 + recovery.successfulRecoverySequencing * 0.6),
+    transformationMomentumScore: clamp01(behavioral.momentumRecoveryScore * 0.65 + cadence.cadenceTransitionStability * 0.35),
+    cadenceTransitionScore: cadence.cadenceTransitionStability,
+    prepRecoveryWindowScore: clamp01(recovery.prepReboundTiming * 0.7 + recovery.continuityReboundWindow * 0.3),
+    continuityProtectionScore: clamp01(recovery.continuityReboundWindow * 0.6 + (1 - lifeState.scheduleVolatilityScore) * 0.4),
+    temporalFlexibilityScore: clamp01(behavioral.cadenceStabilityScore * 0.6 + cadence.transitionReadiness * 0.4),
+    rhythmStabilityScore: stability,
+    seasonalRhythmScore: clamp01((1 - lifeState.seasonalStressScore) * 0.6 + stability * 0.4),
+    temporalConfidence: clamp01((behavioral.behavioralConfidence + lifeState.contextualConfidence + Math.min(memories.length, 16) / 16) / 3),
+    evolutionVersion: 1,
+    lastUpdatedAt: new Date().toISOString(),
+  };
+};
+
+export const updateTemporalRhythmProfile = (
+  previous: NutritionTemporalRhythmProfile | null,
+  behavioral: NutritionBehavioralIntelligenceProfile,
+  lifeState: NutritionLifeStateProfile,
+  memories: NutritionCampaignEvolutionMemory[],
+): NutritionTemporalRhythmProfile => {
+  const derived = deriveTemporalRhythmProfile(behavioral, lifeState, memories);
+  if (!previous) return derived;
+  const smooth = (a: number, b: number): number => clamp01(a * 0.4 + b * 0.6);
+  return {
+    ...derived,
+    noveltyWindowScore: smooth(previous.noveltyWindowScore, derived.noveltyWindowScore),
+    stabilizationWindowScore: smooth(previous.stabilizationWindowScore, derived.stabilizationWindowScore),
+    recoveryWindowScore: smooth(previous.recoveryWindowScore, derived.recoveryWindowScore),
+    transformationMomentumScore: smooth(previous.transformationMomentumScore, derived.transformationMomentumScore),
+    cadenceTransitionScore: smooth(previous.cadenceTransitionScore, derived.cadenceTransitionScore),
+    prepRecoveryWindowScore: smooth(previous.prepRecoveryWindowScore, derived.prepRecoveryWindowScore),
+    continuityProtectionScore: smooth(previous.continuityProtectionScore, derived.continuityProtectionScore),
+    temporalFlexibilityScore: smooth(previous.temporalFlexibilityScore, derived.temporalFlexibilityScore),
+    rhythmStabilityScore: smooth(previous.rhythmStabilityScore, derived.rhythmStabilityScore),
+    seasonalRhythmScore: smooth(previous.seasonalRhythmScore, derived.seasonalRhythmScore),
+    temporalConfidence: smooth(previous.temporalConfidence, derived.temporalConfidence),
+    evolutionVersion: previous.evolutionVersion + 1,
+    lastUpdatedAt: new Date().toISOString(),
+  };
+};

--- a/client/src/components/meal-planner/campaigns/temporal-rhythm/temporalRhythmStore.ts
+++ b/client/src/components/meal-planner/campaigns/temporal-rhythm/temporalRhythmStore.ts
@@ -1,0 +1,43 @@
+import type { NutritionTemporalRhythmProfile } from '@/components/meal-planner/campaigns/temporal-rhythm/temporalRhythmProfile';
+import { createDefaultTemporalRhythmProfile } from '@/components/meal-planner/campaigns/temporal-rhythm/temporalRhythmProfile';
+
+const STORAGE_KEY = 'mealPlanner.temporalRhythmIntelligence.v1';
+const MAX_SERIALIZED_LENGTH = 24_000;
+
+const hasWindow = (): boolean => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+const normalizeProfile = (input: unknown): NutritionTemporalRhythmProfile | null => {
+  if (!input || typeof input !== 'object') return null;
+  const candidate = input as Partial<NutritionTemporalRhythmProfile>;
+  if (typeof candidate.rhythmStabilityScore !== 'number' || typeof candidate.temporalConfidence !== 'number') return null;
+  return {
+    ...createDefaultTemporalRhythmProfile(),
+    ...candidate,
+    evolutionVersion: typeof candidate.evolutionVersion === 'number' ? candidate.evolutionVersion : 1,
+    lastUpdatedAt: typeof candidate.lastUpdatedAt === 'string' ? candidate.lastUpdatedAt : new Date().toISOString(),
+  };
+};
+
+export const getTemporalRhythmProfile = (): NutritionTemporalRhythmProfile | null => {
+  if (!hasWindow()) return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw || raw.length > MAX_SERIALIZED_LENGTH) return null;
+    return normalizeProfile(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+};
+
+export const saveTemporalRhythmProfile = (profile: NutritionTemporalRhythmProfile): NutritionTemporalRhythmProfile => {
+  if (!hasWindow()) return profile;
+  try {
+    const serialized = JSON.stringify(profile);
+    if (serialized.length <= MAX_SERIALIZED_LENGTH) {
+      window.localStorage.setItem(STORAGE_KEY, serialized);
+    }
+  } catch {
+    // graceful fallback
+  }
+  return profile;
+};

--- a/client/src/components/meal-planner/campaigns/temporal-rhythm/temporalSignals.ts
+++ b/client/src/components/meal-planner/campaigns/temporal-rhythm/temporalSignals.ts
@@ -1,0 +1,31 @@
+import type { NutritionBehavioralIntelligenceProfile } from '@/components/meal-planner/campaigns/behavioral-intelligence/behavioralIntelligenceProfile';
+import type { NutritionCampaignEvolutionMemory } from '@/components/meal-planner/campaigns/evolution/campaignEvolutionMemory';
+import type { NutritionLifeStateProfile } from '@/components/meal-planner/campaigns/life-state-intelligence/lifeStateProfile';
+
+const clamp01 = (value: number): number => Math.max(0, Math.min(1, value));
+const activityRatio = (memories: NutritionCampaignEvolutionMemory[]): number => clamp01(Math.min(memories.length, 12) / 12);
+
+export const deriveRecoveryTimingSignals = (behavioral: NutritionBehavioralIntelligenceProfile, life: NutritionLifeStateProfile, memories: NutritionCampaignEvolutionMemory[]) => ({
+  lateWeekFatigueRecovery: clamp01(life.recoveryPressureScore * 0.5 + behavioral.recoveryStabilizationScore * 0.5),
+  continuityReboundWindow: clamp01((1 - life.scheduleVolatilityScore) * 0.45 + behavioral.sustainabilityResilienceScore * 0.55),
+  successfulRecoverySequencing: clamp01(behavioral.momentumRecoveryScore * 0.7 + activityRatio(memories) * 0.3),
+  prepReboundTiming: clamp01((1 - life.timeScarcityScore) * 0.5 + behavioral.prepToleranceScore * 0.5),
+  recoveryCycleEfficiency: clamp01((1 - life.burnoutPressureScore) * 0.4 + behavioral.recoveryStabilizationScore * 0.6),
+});
+
+export const deriveCadenceTransitionSignals = (behavioral: NutritionBehavioralIntelligenceProfile, life: NutritionLifeStateProfile, memories: NutritionCampaignEvolutionMemory[]) => ({
+  cadenceTransitionStability: clamp01((1 - life.scheduleVolatilityScore) * 0.5 + behavioral.cadenceStabilityScore * 0.5),
+  noveltyCollapseTiming: clamp01(life.stabilizationNeedScore * 0.5 + (1 - behavioral.noveltyToleranceScore) * 0.5),
+  transitionReadiness: clamp01((behavioral.behavioralConfidence + life.contextualConfidence + activityRatio(memories)) / 3),
+});
+
+export const deriveTemporalRhythmSignals = (behavioral: NutritionBehavioralIntelligenceProfile, life: NutritionLifeStateProfile, memories: NutritionCampaignEvolutionMemory[]) => {
+  const recovery = deriveRecoveryTimingSignals(behavioral, life, memories);
+  const cadence = deriveCadenceTransitionSignals(behavioral, life, memories);
+  return {
+    ...recovery,
+    ...cadence,
+    momentumRecoveryTiming: clamp01(behavioral.momentumRecoveryScore * 0.6 + recovery.recoveryCycleEfficiency * 0.4),
+    stabilizationDurationQuality: clamp01((1 - life.stabilizationNeedScore) * 0.3 + cadence.cadenceTransitionStability * 0.35 + recovery.continuityReboundWindow * 0.35),
+  };
+};

--- a/client/src/components/meal-planner/campaigns/temporal-rhythm/temporalStability.ts
+++ b/client/src/components/meal-planner/campaigns/temporal-rhythm/temporalStability.ts
@@ -1,0 +1,20 @@
+import type { NutritionTemporalRhythmProfile } from '@/components/meal-planner/campaigns/temporal-rhythm/temporalRhythmProfile';
+
+const clamp01 = (value: number): number => Math.max(0, Math.min(1, value));
+
+export const deriveRhythmResilience = (profile: NutritionTemporalRhythmProfile): number => clamp01(
+  profile.rhythmStabilityScore * 0.5 + profile.temporalFlexibilityScore * 0.3 + profile.continuityProtectionScore * 0.2,
+);
+
+export const deriveRecoveryCycleStability = (profile: NutritionTemporalRhythmProfile): number => clamp01(
+  profile.recoveryWindowScore * 0.5 + profile.prepRecoveryWindowScore * 0.5,
+);
+
+export const deriveTemporalStabilityProfile = (profile: NutritionTemporalRhythmProfile) => ({
+  cadenceResilience: deriveRhythmResilience(profile),
+  reboundTimingQuality: clamp01(profile.prepRecoveryWindowScore * 0.6 + profile.recoveryWindowScore * 0.4),
+  recoveryDurationEffectiveness: clamp01(profile.recoveryWindowScore * 0.7 + profile.stabilizationWindowScore * 0.3),
+  continuityPreservationTiming: clamp01(profile.continuityProtectionScore * 0.7 + profile.rhythmStabilityScore * 0.3),
+  noveltyRecoveryStabilization: clamp01((1 - Math.abs(profile.noveltyWindowScore - profile.stabilizationWindowScore)) * 0.8 + profile.temporalFlexibilityScore * 0.2),
+  recoveryCycleStability: deriveRecoveryCycleStability(profile),
+});

--- a/client/src/components/meal-planner/campaigns/temporal-rhythm/temporalStrategyWeights.ts
+++ b/client/src/components/meal-planner/campaigns/temporal-rhythm/temporalStrategyWeights.ts
@@ -1,0 +1,17 @@
+import type { NutritionTemporalRhythmProfile } from '@/components/meal-planner/campaigns/temporal-rhythm/temporalRhythmProfile';
+
+const clamp01 = (value: number): number => Math.max(0, Math.min(1, value));
+
+export const deriveTemporalStrategyWeights = (profile: NutritionTemporalRhythmProfile) => ({
+  recoveryPacingWeight: clamp01((1 - profile.recoveryWindowScore) * 0.55 + profile.stabilizationWindowScore * 0.45),
+  noveltyReintroductionWeight: clamp01(profile.noveltyWindowScore * profile.rhythmStabilityScore),
+  continuityAnchorWeight: clamp01((1 - profile.continuityProtectionScore) * 0.5 + (1 - profile.cadenceTransitionScore) * 0.5),
+  prepRecoveryProtectionWeight: clamp01(profile.prepRecoveryWindowScore * 0.7 + (1 - profile.temporalFlexibilityScore) * 0.3),
+});
+
+export const deriveRhythmProtectionBias = (weights: ReturnType<typeof deriveTemporalStrategyWeights>): string[] => [
+  weights.recoveryPacingWeight > 0.55 ? 'Recovery pacing receives temporary timing priority.' : 'Recovery pacing can remain baseline.',
+  weights.noveltyReintroductionWeight < 0.45 ? 'Delay novelty reintroduction until stability rises.' : 'Novelty reintroduction is rhythm-approved.',
+  weights.continuityAnchorWeight > 0.55 ? 'Activate continuity anchors preemptively.' : 'Continuity anchors can stay reactive.',
+  weights.prepRecoveryProtectionWeight > 0.55 ? 'Protect prep rebound windows in scheduling.' : 'Prep windows can stay flexible.',
+];

--- a/client/src/components/meal-planner/campaigns/temporal-rhythm/temporalTimeline.ts
+++ b/client/src/components/meal-planner/campaigns/temporal-rhythm/temporalTimeline.ts
@@ -1,0 +1,17 @@
+import type { NutritionTemporalRhythmProfile } from '@/components/meal-planner/campaigns/temporal-rhythm/temporalRhythmProfile';
+
+export const deriveTemporalMilestones = (profile: NutritionTemporalRhythmProfile): string[] => {
+  const milestones: string[] = [];
+  if (profile.recoveryWindowScore > 0.6) milestones.push('Recovery windows stabilized.');
+  if (profile.noveltyWindowScore > 0.6) milestones.push('Novelty timing improved.');
+  if (profile.continuityProtectionScore > 0.6) milestones.push('Continuity protection became proactive.');
+  if (profile.cadenceTransitionScore > 0.6) milestones.push('Cadence transitions became smoother.');
+  if (profile.transformationMomentumScore > 0.6) milestones.push('Momentum rebound accelerated.');
+  return milestones;
+};
+
+export const deriveTemporalEvolutionTimeline = (profile: NutritionTemporalRhythmProfile): string[] => [
+  `Rhythm stability ${Math.round(profile.rhythmStabilityScore * 100)}%.`,
+  `Temporal flexibility ${Math.round(profile.temporalFlexibilityScore * 100)}%.`,
+  ...deriveTemporalMilestones(profile),
+];


### PR DESCRIPTION
### Motivation
- Enable the planner to reason about WHEN strategies should activate (timing windows, phase transitions and protection windows) in addition to WHAT the current state is, while keeping all logic additive, deterministic, explainable and local-first.

### Description
- Added a new temporal-rhythm module set under `client/src/components/meal-planner/campaigns/temporal-rhythm/` implementing profile derivation/update, deterministic signal derivation, adaptation bias/orchestration, phase modeling, stability profiling, recommendation intelligence, strategy weighting, evolution timeline and bounded localStorage persistence (files added: `temporalRhythmProfile.ts`, `temporalSignals.ts`, `temporalAdaptation.ts`, `temporalPhaseModeling.ts`, `temporalStability.ts`, `temporalRecommendationIntelligence.ts`, `temporalStrategyWeights.ts`, `temporalTimeline.ts`, `temporalRhythmStore.ts`).
- Integrated the temporal profile into the campaign pipeline in `NutritionCampaignPanel.tsx` by deriving/updating the temporal profile alongside behavioral and life-state profiles and persisting it to `mealPlanner.temporalRhythmIntelligence.v1`, preserving all existing planner flows and localStorage fallback behavior. 
- All scoring is deterministic and transparent: small, human-readable numeric scores and string guidance are produced (novelty/stabilization/recovery windows, cadence transition, momentum, continuity protection, confidence, evolution version) and surfaced in a new UI card in the campaign panel for explainable orchestration guidance.

### Testing
- Ran `npm run build:client` and the client build completed successfully. 
- Ran `npm run build:server` and the server build completed successfully. 
- Ran TypeScript checks with `npx tsc --noEmit -p tsconfig.json`; the new temporal-rhythm modules and their integrations produce no type errors in the targeted meal-planner campaign areas, however the full repo type-check run surfaced pre-existing, unrelated TypeScript errors elsewhere in the codebase (e.g. routing and other components) that are outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14d388b7c88325a88e3aeba59bf780)