### PR TITLE
refactor(planner): centralize traversal primitives for orchestration safety

### DIFF
--- a/client/src/components/meal-planner/auto-planner/autoPlannerScoring.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerScoring.ts
@@ -1,21 +1,23 @@
 import { type AutoPlannerScores } from './autoPlannerTypes';
+import { getMealsForSlot } from '../planner-core/traversal/plannerTraversal';
 
 const clamp = (v: number) => Math.max(0, Math.min(100, Math.round(v)));
 
 export const calculateMealVarietyScore = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
   const names = new Set<string>();
   let total = 0;
-  weekDays.forEach((d) => mealTypes.forEach((m) => {
-    const items = weeklyMeals?.[d]?.[m];
-    const arr = Array.isArray(items) ? items : items ? [items] : [];
-    arr.forEach((it: any) => { total += 1; if (it?.name) names.add(String(it.name).toLowerCase()); });
+  weekDays.forEach((day) => mealTypes.forEach((mealType) => {
+    getMealsForSlot(weeklyMeals, day, mealType).forEach((meal: any) => {
+      total += 1;
+      if (meal?.name) names.add(String(meal.name).toLowerCase());
+    });
   }));
   if (!total) return 0;
   return clamp((names.size / total) * 100);
 };
 
 export const calculatePrepLoadScore = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
-  const perDay = weekDays.map((d) => mealTypes.reduce((n, m) => n + (Array.isArray(weeklyMeals?.[d]?.[m]) ? weeklyMeals[d][m].length : weeklyMeals?.[d]?.[m] ? 1 : 0), 0));
+  const perDay = weekDays.map((day) => mealTypes.reduce((count, mealType) => count + getMealsForSlot(weeklyMeals, day, mealType).length, 0));
   const max = Math.max(0, ...perDay);
   const avg = perDay.reduce((a, b) => a + b, 0) / Math.max(1, perDay.length);
   return clamp(100 - Math.max(0, (max - avg) * 18));
@@ -24,9 +26,11 @@ export const calculatePrepLoadScore = (weeklyMeals: Record<string, any>, weekDay
 export const calculatePantryReuseScore = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
   let meals = 0;
   let pantryLinked = 0;
-  weekDays.forEach((d) => mealTypes.forEach((m) => {
-    const arr = Array.isArray(weeklyMeals?.[d]?.[m]) ? weeklyMeals[d][m] : weeklyMeals?.[d]?.[m] ? [weeklyMeals[d][m]] : [];
-    arr.forEach((it: any) => { meals += 1; if (it?.source === 'pantry' || it?.isPantryItem) pantryLinked += 1; });
+  weekDays.forEach((day) => mealTypes.forEach((mealType) => {
+    getMealsForSlot(weeklyMeals, day, mealType).forEach((meal: any) => {
+      meals += 1;
+      if (meal?.source === 'pantry' || meal?.isPantryItem) pantryLinked += 1;
+    });
   }));
   return clamp(meals ? (pantryLinked / meals) * 100 : 0);
 };
@@ -35,10 +39,12 @@ export const calculateWeeklyScores = (weeklyMeals: Record<string, any>, weekDays
   const variety = calculateMealVarietyScore(weeklyMeals, weekDays, mealTypes);
   const prep = calculatePrepLoadScore(weeklyMeals, weekDays, mealTypes);
   const pantry = calculatePantryReuseScore(weeklyMeals, weekDays, mealTypes);
-  const proteinTotal = weekDays.reduce((acc, d) => acc + mealTypes.reduce((mAcc, m) => {
-    const arr = Array.isArray(weeklyMeals?.[d]?.[m]) ? weeklyMeals[d][m] : weeklyMeals?.[d]?.[m] ? [weeklyMeals[d][m]] : [];
-    return mAcc + arr.reduce((s: number, it: any) => s + Number(it?.protein || 0), 0);
-  }, 0), 0);
+  let proteinTotal = 0;
+  weekDays.forEach((day) => mealTypes.forEach((mealType) => {
+    getMealsForSlot(weeklyMeals, day, mealType).forEach((meal: any) => {
+      proteinTotal += Number(meal?.protein || 0);
+    });
+  }));
   const proteinCoverage = clamp(((proteinTotal / Math.max(1, proteinGoal * weekDays.length)) * 100));
   const groceryEfficiency = clamp((variety * 0.4) + (prep * 0.3) + (pantry * 0.3));
   const readiness = clamp((proteinCoverage * 0.35) + (prep * 0.25) + (groceryEfficiency * 0.2) + (pantry * 0.2));

--- a/client/src/components/meal-planner/auto-planner/autoPlannerTemporalOptimization.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerTemporalOptimization.ts
@@ -1,6 +1,7 @@
 import { deriveDayRhythmProfile, calculateDailyLifestyleLoad, classifyDayEnergyLevel, type DayRhythmProfile } from './autoPlannerLifestyleAnalysis';
+import { calculateMealComplexity, getMealsForSlot } from '../planner-core/traversal/plannerTraversal';
 
-const mealComplexity = (meal: any) => Number(meal?.mealItems?.length || meal?.ingredients?.length || 1);
+const mealComplexity = (meal: any) => Math.max(1, calculateMealComplexity(meal));
 
 export const calculateMealEnergyFit = (meal: any, mealType: string, energyLevel: 'low' | 'medium' | 'high') => {
   const complexity = mealComplexity(meal);
@@ -21,10 +22,7 @@ export const calculateRecoveryMealSupport = (meal: any, mealType: string, rhythm
 export const analyzeWeeklyEnergyFlow = (weeklyMeals: Record<string, any>, weekDays: readonly string[], mealTypes: readonly string[]) => {
   const daily = weekDays.map((day, dayIndex) => {
     const rhythm = deriveDayRhythmProfile(day, dayIndex, weekDays.length);
-    const meals = mealTypes.flatMap((mealType) => {
-      const arr = Array.isArray(weeklyMeals?.[day]?.[mealType]) ? weeklyMeals[day][mealType] : weeklyMeals?.[day]?.[mealType] ? [weeklyMeals[day][mealType]] : [];
-      return arr;
-    }).filter(Boolean);
+    const meals = mealTypes.flatMap((mealType) => getMealsForSlot(weeklyMeals, day, mealType));
     const load = calculateDailyLifestyleLoad(day, meals, rhythm);
     const energyLevel = classifyDayEnergyLevel(load.lifestyleLoad);
     return { day, rhythm, load, energyLevel, meals };
@@ -32,7 +30,7 @@ export const analyzeWeeklyEnergyFlow = (weeklyMeals: Record<string, any>, weekDa
 
   const lateWeekLoad = daily.filter((d) => d.rhythm.lifecyclePhase === 'late-week').reduce((acc, d) => acc + d.load.lifestyleLoad, 0);
   const prepHeavyDinners = daily.reduce((acc, d) => {
-    const dinners = Array.isArray(weeklyMeals?.[d.day]?.dinner) ? weeklyMeals[d.day].dinner : weeklyMeals?.[d.day]?.dinner ? [weeklyMeals[d.day].dinner] : [];
+    const dinners = getMealsForSlot(weeklyMeals, d.day, 'dinner');
     const heavy = dinners.some((meal: any) => mealComplexity(meal) >= 8);
     return acc + (heavy ? 1 : 0);
   }, 0);

--- a/client/src/components/meal-planner/planner-core/traversal/plannerTraversal.ts
+++ b/client/src/components/meal-planner/planner-core/traversal/plannerTraversal.ts
@@ -1,0 +1,66 @@
+import { calculateMealComplexity as baseCalculateMealComplexity } from '../../planner-graph/plannerComplexity';
+import { getAllPlannerMeals, getMealsForDay, getMealsForSlot } from '../../planner-graph/plannerGraphUtils';
+import { iteratePlannerSlots, iterateWeeklyMeals } from '../../planner-graph/plannerIteration';
+import { extractMealIngredients, extractMealProteins } from '../../planner-graph/plannerMealExtraction';
+import { normalizePlannerMeal } from '../../planner-graph/plannerNormalization';
+import type { PlannerMeal, PlannerMealRef, PlannerSlotRef, WeeklyMeals } from '../../planner-graph/plannerTypes';
+
+export {
+  getMealsForDay,
+  getMealsForSlot,
+  getAllPlannerMeals,
+  iterateWeeklyMeals,
+  iteratePlannerSlots,
+  extractMealIngredients,
+  extractMealProteins,
+  normalizePlannerMeal,
+};
+
+export const calculateMealComplexity = (meal: any): number => baseCalculateMealComplexity(meal);
+
+export const getUniqueMeals = <T extends PlannerMeal>(
+  weeklyMeals: WeeklyMeals | null | undefined,
+  weekDays: readonly string[],
+  mealTypes: readonly string[],
+): T[] => {
+  const seen = new Set<string>();
+  const unique: T[] = [];
+
+  getAllPlannerMeals<T>(weeklyMeals, weekDays, mealTypes).forEach(({ meal, day, mealType, index }) => {
+    const key = String(
+      meal?.entryId
+      || meal?.plannerGeneratedId
+      || meal?.id
+      || meal?.name
+      || meal?.title
+      || `${day}-${mealType}-${index}`,
+    ).trim().toLowerCase();
+    if (!key || seen.has(key)) return;
+    seen.add(key);
+    unique.push(meal as T);
+  });
+
+  return unique;
+};
+
+export const getPlannerMealIds = (
+  weeklyMeals: WeeklyMeals | null | undefined,
+  weekDays: readonly string[],
+  mealTypes: readonly string[],
+): string[] => {
+  const ids = new Set<string>();
+
+  getAllPlannerMeals(weeklyMeals, weekDays, mealTypes).forEach(({ meal, day, mealType, index }: PlannerMealRef) => {
+    const id = String(
+      meal?.entryId
+      || meal?.plannerGeneratedId
+      || meal?.id
+      || `${day}-${mealType}-${index}`,
+    ).trim();
+    if (id) ids.add(id);
+  });
+
+  return [...ids];
+};
+
+export type { PlannerMeal, PlannerMealRef, PlannerSlotRef, WeeklyMeals };


### PR DESCRIPTION
### Motivation
- Reduce repeated weekly traversal/normalization logic and selector inconsistency across planner modules by centralizing traversal helpers. 
- Harden orchestration dependency surface to improve maintainability, hook-order safety, and future extensibility without changing planner behavior.

### Description
- Added a new traversal facade at `client/src/components/meal-planner/planner-core/traversal/plannerTraversal.ts` that re-exports and composes existing planner-graph primitives and exposes stable helpers (`getMealsForDay`, `getMealsForSlot`, `getAllPlannerMeals`, `iterateWeeklyMeals`, `iteratePlannerSlots`, `extractMealIngredients`, `extractMealProteins`, `normalizePlannerMeal`, `calculateMealComplexity`) plus `getUniqueMeals` and `getPlannerMealIds` for selector consistency. 
- Refactored `client/src/components/meal-planner/auto-planner/autoPlannerTemporalOptimization.ts` to consume `getMealsForSlot` and `calculateMealComplexity` instead of inline `Array.isArray(...)` normalization and ad-hoc complexity calculations. 
- Refactored `client/src/components/meal-planner/auto-planner/autoPlannerScoring.ts` to use `getMealsForSlot` across variety, prep-load, pantry-reuse, and protein coverage calculations, removing duplicated slot normalization patterns. 
- Changes are additive/refactor-only and do not alter persistence, backend, or planner intelligence layers.

### Testing
- Ran TypeScript check with `npm run check` to validate type surface after changes, which executed but reported pre-existing repo-wide TypeScript errors; the failures are unrelated to the localized refactor. 
- No runtime behavior or backend integration tests were added in this pass and no other automated test suites were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14ead396f883259241eb04ce237dbf)