### PR TITLE
Fix planner selectors to traverse nested weekly meal state

### DIFF
--- a/client/src/components/meal-planner/planner-core/selectors/plannerSelectors.ts
+++ b/client/src/components/meal-planner/planner-core/selectors/plannerSelectors.ts
@@ -1,7 +1,33 @@
-type PlannerMeal = { id?: string };
+import { getAllPlannerMeals } from '../traversal/plannerTraversal';
+import type { PlannerMealRef, WeeklyMeals } from '../traversal/plannerTraversal';
 
-export const selectPlannerMeals = (weeklyMeals: PlannerMeal[] | null | undefined): PlannerMeal[] =>
-  Array.isArray(weeklyMeals) ? weeklyMeals : [];
+const isPlannerMealRefArray = (value: unknown): value is PlannerMealRef[] => (
+  Array.isArray(value) && value.every((entry) => !!entry && typeof entry === 'object' && 'meal' in entry && 'day' in entry && 'mealType' in entry)
+);
 
-export const selectPlannerMealCount = (weeklyMeals: PlannerMeal[] | null | undefined): number =>
-  selectPlannerMeals(weeklyMeals).length;
+const deriveTraversalAxes = (weeklyMeals: WeeklyMeals | null | undefined): { weekDays: string[]; mealTypes: string[] } => {
+  if (!weeklyMeals || typeof weeklyMeals !== 'object' || Array.isArray(weeklyMeals)) {
+    return { weekDays: [], mealTypes: [] };
+  }
+
+  const weekDays = Object.keys(weeklyMeals).sort();
+  const mealTypeSet = new Set<string>();
+
+  weekDays.forEach((day) => {
+    const daySlots = weeklyMeals?.[day];
+    if (!daySlots || typeof daySlots !== 'object' || Array.isArray(daySlots)) return;
+    Object.keys(daySlots).forEach((mealType) => mealTypeSet.add(mealType));
+  });
+
+  return { weekDays, mealTypes: [...mealTypeSet].sort() };
+};
+
+export const selectPlannerMeals = (weeklyMeals: WeeklyMeals | PlannerMealRef[] | null | undefined): PlannerMealRef[] => {
+  if (isPlannerMealRefArray(weeklyMeals)) return weeklyMeals;
+  const { weekDays, mealTypes } = deriveTraversalAxes(weeklyMeals as WeeklyMeals | null | undefined);
+  return getAllPlannerMeals(weeklyMeals as WeeklyMeals | null | undefined, weekDays, mealTypes);
+};
+
+export const selectPlannerMealCount = (weeklyMeals: WeeklyMeals | PlannerMealRef[] | null | undefined): number => (
+  selectPlannerMeals(weeklyMeals).length
+);


### PR DESCRIPTION
### Motivation
- The previous selectors assumed `weeklyMeals` was a flat array which does not match the nested weekly planner state used across planner codepaths. 
- Selectors should rely on the planner-core traversal helpers to produce deterministic, correct traversal outputs without duplicating traversal logic.

### Description
- Replaced shallow `Array.isArray` normalization with a traversal-backed implementation that uses `getAllPlannerMeals` from `planner-core/traversal`. 
- Added `deriveTraversalAxes` to deterministically derive and sort `weekDays` and `mealTypes` from nested `WeeklyMeals` so traversal ordering is stable. 
- Added a lightweight fast-path to accept an already-flattened `PlannerMealRef[]` and otherwise call `getAllPlannerMeals` to return `PlannerMealRef[]`. 
- Kept the exported selector surface intact (`selectPlannerMeals`, `selectPlannerMealCount`) and made the count selector compose the traversal-backed selector for consistent semantics.

### Testing
- Ran `npm run build:client` which completed successfully. 
- Ran `npm run build:server` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15bf0b72c08325b94b9634f9830df7)