### PR TITLE
Harden meal planner circular dependencies

### DIFF
--- a/client/src/components/meal-planner/auto-planner/autoPlannerLifestyleAnalysis.ts
+++ b/client/src/components/meal-planner/auto-planner/autoPlannerLifestyleAnalysis.ts
@@ -1,4 +1,4 @@
-import { calculateDailyPrepStress } from './autoPlannerOptimizationEngine';
+import { calculateDailyPrepStress } from './autoPlannerMetrics';
 
 export type DayRhythmProfile = {
   day: string;

--- a/client/src/components/meal-planner/meal-relationships/ingredientRelationships.ts
+++ b/client/src/components/meal-planner/meal-relationships/ingredientRelationships.ts
@@ -1,4 +1,4 @@
-import { normalizeMealIngredient } from '../plannerGroceryUtils';
+import { normalizeMealIngredient } from '../ingredientNormalization';
 import type { RelationshipNode, RelationshipEdge, IngredientCluster } from './relationshipTypes';
 
 const INGREDIENT_FAMILIES: Record<string, string[]> = {

--- a/client/src/components/meal-planner/personality-modeling/personalityTypes.ts
+++ b/client/src/components/meal-planner/personality-modeling/personalityTypes.ts
@@ -1,4 +1,4 @@
-import type { LongitudinalPlanningSnapshot } from '../planner-adaptation/adaptationTypes';
+import type { LongitudinalPlanningSnapshot } from '../planner-adaptation/longitudinalPlanningTypes';
 
 export type MealTypeAdherencePattern = Record<string, number>;
 

--- a/client/src/components/meal-planner/planner-adaptation/adaptationTypes.ts
+++ b/client/src/components/meal-planner/planner-adaptation/adaptationTypes.ts
@@ -1,23 +1,7 @@
 import type { AdaptiveNutritionIdentity } from '../personality-modeling/personalityTypes';
+import type { LongitudinalPlanningSnapshot } from './longitudinalPlanningTypes';
 
-export type LongitudinalPlanningSnapshot = {
-  id: string;
-  createdAt: string;
-  weekKey: string;
-  completedMeals: number;
-  skippedMeals: number;
-  repeatedMeals: number;
-  prepCompletionRate: number;
-  groceryCompletionRate: number;
-  hydrationAdherence: number;
-  readinessAverage: number;
-  fatigueAverage: number;
-  successfulRelationshipChains: number;
-  abandonedRelationshipChains: number;
-  complexityLoad: number;
-  continuityScore: number;
-  lateWeekDropoff: number;
-};
+export type { LongitudinalPlanningSnapshot } from './longitudinalPlanningTypes';
 
 export type PlannerHistoryProfile = {
   windowSize: number;

--- a/client/src/components/meal-planner/planner-adaptation/longitudinalPlanningTypes.ts
+++ b/client/src/components/meal-planner/planner-adaptation/longitudinalPlanningTypes.ts
@@ -1,0 +1,18 @@
+export type LongitudinalPlanningSnapshot = {
+  id: string;
+  createdAt: string;
+  weekKey: string;
+  completedMeals: number;
+  skippedMeals: number;
+  repeatedMeals: number;
+  prepCompletionRate: number;
+  groceryCompletionRate: number;
+  hydrationAdherence: number;
+  readinessAverage: number;
+  fatigueAverage: number;
+  successfulRelationshipChains: number;
+  abandonedRelationshipChains: number;
+  complexityLoad: number;
+  continuityScore: number;
+  lateWeekDropoff: number;
+};

--- a/docs/planner-circular-dependency-report.md
+++ b/docs/planner-circular-dependency-report.md
@@ -1,0 +1,33 @@
+# Meal Planner Circular Dependency Hardening Report
+
+Generated during the circular dependency hardening pass for `client/src/components/meal-planner`.
+
+## Verification Command
+
+```bash
+npx madge --extensions ts,tsx --circular client/src/components/meal-planner
+```
+
+## Initial Cycles Found
+
+1. `planner-adaptation/adaptationTypes.ts` → `personality-modeling/personalityTypes.ts` → `planner-adaptation/adaptationTypes.ts`
+2. `meal-relationships/relationshipGraph.ts` → `meal-relationships/ingredientRelationships.ts` → `plannerGroceryUtils.ts` → `meal-relationships/relationshipGraph.ts`
+3. `auto-planner/autoPlannerOptimizationEngine.ts` → `planner-objectives/plannerObjectiveEngine.ts` → `planner-objectives/plannerObjectiveScoring.ts` → `auto-planner/autoPlannerRhythmEngine.ts` → `auto-planner/autoPlannerLifestyleAnalysis.ts` → `auto-planner/autoPlannerOptimizationEngine.ts`
+
+## Cycles Resolved
+
+1. Extracted `LongitudinalPlanningSnapshot` into `planner-adaptation/longitudinalPlanningTypes.ts` so personality model types no longer import back through adaptation aggregate types.
+2. Pointed ingredient relationship analysis directly at the foundational ingredient normalization utility instead of importing through grocery aggregation utilities.
+3. Pointed lifestyle analysis directly at foundational auto-planner metrics instead of importing through the optimization engine facade.
+
+## Remaining Cycles
+
+None detected by Madge in `client/src/components/meal-planner` after this pass.
+
+## Final Result
+
+Madge result after the refactor:
+
+```text
+✔ No circular dependency found!
+```


### PR DESCRIPTION
### Motivation

- Remove circular import chains in the Meal Planner domain to prevent runtime evaluation-order failures (e.g. "Cannot access 'x' before initialization") and to future-proof the planner architecture while preserving all behavior.
- Keep changes additive and minimal: prefer extracting shared types/utilities and redirecting imports rather than introducing major rewrites or behavioral changes.

### Description

- Extracted `LongitudinalPlanningSnapshot` into a new foundational type module `client/src/components/meal-planner/planner-adaptation/longitudinalPlanningTypes.ts` and re-exported it from `adaptationTypes.ts` to break the adaptation ↔ personality type cycle.
- Rewrote imports so `client/src/components/meal-planner/personality-modeling/personalityTypes.ts` consumes the new `longitudinalPlanningTypes.ts` and `client/src/components/meal-planner/planner-adaptation/adaptationTypes.ts` re-exports it for backwards compatibility.
- Redirected ingredient normalization usage so `client/src/components/meal-planner/meal-relationships/ingredientRelationships.ts` imports `normalizeMealIngredient` from `ingredientNormalization` instead of via grocery aggregation utilities, and pointed `autoPlannerLifestyleAnalysis.ts` at `autoPlannerMetrics` instead of the optimization facade to remove the auto-planner cycle.
- Added `docs/planner-circular-dependency-report.md` documenting the initial cycles, the fixes applied, and the final verification result.

### Testing

- Ran `npx madge --extensions ts,tsx --circular client/src/components/meal-planner` which reported no circular dependencies after the changes (passed).
- Built the client with `npm run build:client` which completed successfully though Vite emitted unrelated chunking warnings (passed).
- Built the server with `npm run build:server` which completed successfully (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18f24116ac83258b40087209de35f0)