### PR TITLE
Fix StoreBuilder fetch URLs: /api/stores-crud → /api/stores

### DIFF
--- a/client/src/components/store/StoreBuilder.tsx
+++ b/client/src/components/store/StoreBuilder.tsx
@@ -138,7 +138,7 @@ export default function StoreBuilder({
     if (!storeId) { setLayoutReady(true); return; }
     (async () => {
       try {
-        const res = await fetch(`/api/stores-crud/${storeId}`, {
+        const res = await fetch(`/api/stores/${storeId}`, {
           credentials: "include",
         });
         if (res.ok) {
@@ -170,7 +170,7 @@ export default function StoreBuilder({
     }
     setSaving(true);
     try {
-      const res = await fetch(`/api/stores-crud/${storeId}/layout`, {
+      const res = await fetch(`/api/stores/${storeId}/layout`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         credentials: "include",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5552,9 +5552,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001775",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001775.tgz",
-      "integrity": "sha512-s3Qv7Lht9zbVKE9XoTyRG6wVDCKdtOFIjBGg3+Yhn6JaytuNKPIjBMTMIY1AnOH3seL5mvF+x33oGAyK3hVt3A==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "dev": true,
       "funding": [
         {

--- a/server/routes/stores-crud.ts
+++ b/server/routes/stores-crud.ts
@@ -146,7 +146,7 @@ router.post("/", requireAuth, async (req, res) => {
   }
 });
 
-// PATCH /api/stores-crud/:id - Update store details
+// PATCH /api/stores/:id - Update store details
 router.patch("/:id", requireAuth, async (req, res) => {
   try {
     if (!req.user) {
@@ -201,7 +201,7 @@ router.patch("/:id", requireAuth, async (req, res) => {
   }
 });
 
-// PATCH /api/stores-crud/:id/layout - Update store builder layout
+// PATCH /api/stores/:id/layout - Update store builder layout
 router.patch("/:id/layout", requireAuth, async (req, res) => {
   try {
     if (!req.user) {
@@ -239,7 +239,7 @@ router.patch("/:id/layout", requireAuth, async (req, res) => {
   }
 });
 
-// PATCH /api/stores-crud/:id/publish - Toggle published status
+// PATCH /api/stores/:id/publish - Toggle published status
 router.patch("/:id/publish", requireAuth, async (req, res) => {
   try {
     if (!req.user) {


### PR DESCRIPTION
## Summary

- `StoreBuilder.tsx` was calling `/api/stores-crud/${storeId}` and `/api/stores-crud/${storeId}/layout` — but the router is mounted at `/api/stores/`, causing 404s on both the layout load and the save action
- Fixed both fetch URLs to use `/api/stores/${storeId}` and `/api/stores/${storeId}/layout`
- Corrected three stale comment lines in `stores-crud.ts` that still said `/api/stores-crud/...`

## Test plan

- [ ] Open the Store Builder tab for an existing store — layout loads without 404
- [ ] Drag a block onto the canvas, click **Save & Publish** — no error toast
- [ ] Reload the page — the saved block is still present on the canvas

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e)_