### PR TITLE
feat(store): Unified Store Customizer with live side-by-side preview

### DIFF
--- a/client/src/components/store/UnifiedStoreCustomizer.tsx
+++ b/client/src/components/store/UnifiedStoreCustomizer.tsx
@@ -1,0 +1,664 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Upload,
+  X,
+  Instagram,
+  Facebook,
+  Twitter,
+  Mail,
+  Phone,
+  MapPin,
+  Save,
+  RotateCcw,
+} from "lucide-react";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { Check } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { normalizeStoreLayout } from "@shared/store/storeLayout";
+import type { StoreLayoutCustomizationConfig } from "@shared/store/storeLayout";
+import { THEMES } from "@/components/store/ThemeSelector";
+import StorefrontPreview from "@/components/store/preview/StorefrontPreview";
+import type { StoreProduct } from "@/pages/store/StoreViewerContent";
+
+interface UnifiedStoreCustomizerProps {
+  store: any;
+  products: StoreProduct[];
+  onSaved: (updatedStore: any) => void;
+}
+
+function ColorPicker({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div>
+      <Label className="text-xs">{label}</Label>
+      <div className="flex gap-2 items-center mt-1">
+        <Input type="color" value={value} onChange={(e) => onChange(e.target.value)} className="w-12 h-9 p-0.5 cursor-pointer" />
+        <Input type="text" value={value} onChange={(e) => onChange(e.target.value)} className="flex-1 text-xs font-mono" />
+      </div>
+    </div>
+  );
+}
+
+export default function UnifiedStoreCustomizer({
+  store,
+  products,
+  onSaved,
+}: UnifiedStoreCustomizerProps) {
+  const { toast } = useToast();
+  const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+
+  const savedCustomization = useMemo(
+    () => normalizeStoreLayout(store?.layout).customization,
+    [store?.layout],
+  );
+
+  const [draftName, setDraftName] = useState(store?.name || "");
+  const [draftBio, setDraftBio] = useState(store?.bio || "");
+  const [draftTheme, setDraftTheme] = useState(store?.theme || "modern");
+  const [draftCustomization, setDraftCustomization] = useState<StoreLayoutCustomizationConfig>({
+    logo: savedCustomization?.logo || "",
+    bannerImage: savedCustomization?.bannerImage || "",
+    bannerTitle: savedCustomization?.bannerTitle || "",
+    bannerSubtitle: savedCustomization?.bannerSubtitle || "",
+    showBanner: savedCustomization?.showBanner !== false,
+    aboutEnabled: savedCustomization?.aboutEnabled || false,
+    aboutTitle: savedCustomization?.aboutTitle || "About Us",
+    aboutContent: savedCustomization?.aboutContent || "",
+    announcementBar: savedCustomization?.announcementBar || "",
+    announcementEnabled: savedCustomization?.announcementEnabled || false,
+    socialLinks: savedCustomization?.socialLinks || {
+      instagram: "",
+      facebook: "",
+      twitter: "",
+      email: "",
+      phone: "",
+    },
+    contactInfo: savedCustomization?.contactInfo || { address: "", hours: "" },
+    layout: savedCustomization?.layout || {
+      gridColumns: 3,
+      productCardStyle: "elevated",
+      spacing: "normal",
+    },
+    colors: savedCustomization?.colors || {
+      primary: "#FF6B35",
+      secondary: "#2C3E50",
+      accent: "#F7F7F7",
+    },
+  });
+
+  const isDirty = useMemo(() => {
+    if (draftName !== (store?.name || "")) return true;
+    if (draftBio !== (store?.bio || "")) return true;
+    if (draftTheme !== (store?.theme || "modern")) return true;
+    return JSON.stringify(draftCustomization) !== JSON.stringify(savedCustomization);
+  }, [draftName, draftBio, draftTheme, draftCustomization, store, savedCustomization]);
+
+  // Warn on navigation away with unsaved changes
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (isDirty) {
+        e.preventDefault();
+        e.returnValue = "";
+      }
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [isDirty]);
+
+  const patchCustomization = (patch: Partial<StoreLayoutCustomizationConfig>) =>
+    setDraftCustomization((prev) => ({ ...prev, ...patch }));
+
+  const handleDiscard = () => {
+    if (!isDirty) return;
+    if (!window.confirm("Discard all unsaved changes?")) return;
+    setDraftName(store?.name || "");
+    setDraftBio(store?.bio || "");
+    setDraftTheme(store?.theme || "modern");
+    setDraftCustomization({
+      logo: savedCustomization?.logo || "",
+      bannerImage: savedCustomization?.bannerImage || "",
+      bannerTitle: savedCustomization?.bannerTitle || "",
+      bannerSubtitle: savedCustomization?.bannerSubtitle || "",
+      showBanner: savedCustomization?.showBanner !== false,
+      aboutEnabled: savedCustomization?.aboutEnabled || false,
+      aboutTitle: savedCustomization?.aboutTitle || "About Us",
+      aboutContent: savedCustomization?.aboutContent || "",
+      announcementBar: savedCustomization?.announcementBar || "",
+      announcementEnabled: savedCustomization?.announcementEnabled || false,
+      socialLinks: savedCustomization?.socialLinks || {
+        instagram: "",
+        facebook: "",
+        twitter: "",
+        email: "",
+        phone: "",
+      },
+      contactInfo: savedCustomization?.contactInfo || { address: "", hours: "" },
+      layout: savedCustomization?.layout || {
+        gridColumns: 3,
+        productCardStyle: "elevated",
+        spacing: "normal",
+      },
+      colors: savedCustomization?.colors || {
+        primary: "#FF6B35",
+        secondary: "#2C3E50",
+        accent: "#F7F7F7",
+      },
+    });
+  };
+
+  const handleSave = async () => {
+    if (!store?.id) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/stores/${store.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          name: draftName.trim() || store.name,
+          bio: draftBio.trim() || null,
+          theme: draftTheme,
+          customization: draftCustomization,
+        }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        toast({ description: "Store saved!" });
+        onSaved(data.store);
+      } else {
+        const err = await res.json();
+        toast({ title: "Save failed", description: err.error || "Please try again.", variant: "destructive" });
+      }
+    } catch {
+      toast({ title: "Save failed", description: "An error occurred.", variant: "destructive" });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleImageUpload = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+    field: "logo" | "bannerImage",
+  ) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    const formData = new FormData();
+    formData.append("file", file);
+    try {
+      const res = await fetch("/api/upload", {
+        method: "POST",
+        body: formData,
+        credentials: "include",
+      });
+      if (res.ok) {
+        const data = await res.json();
+        patchCustomization({ [field]: data.url });
+        toast({ description: "Image uploaded!" });
+      } else {
+        toast({ title: "Upload failed", description: "Failed to upload image.", variant: "destructive" });
+      }
+    } catch {
+      toast({ title: "Upload failed", description: "An error occurred.", variant: "destructive" });
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const c = draftCustomization;
+
+  return (
+    <div className="flex h-[calc(100vh-200px)] min-h-[600px]">
+      {/* ── Left control panel ── */}
+      <div className="w-[420px] flex-shrink-0 flex flex-col border-r bg-white overflow-hidden">
+        {/* Scrollable sections */}
+        <div className="flex-1 overflow-y-auto px-4 py-3">
+          <Accordion type="multiple" defaultValue={["theme", "branding"]} className="space-y-1">
+
+            {/* 1. Theme */}
+            <AccordionItem value="theme" className="border rounded-lg px-3">
+              <AccordionTrigger className="text-sm font-semibold py-3">Theme</AccordionTrigger>
+              <AccordionContent className="pb-4">
+                <div className="grid grid-cols-2 gap-3">
+                  {THEMES.map((theme) => {
+                    const selected = draftTheme === theme.id;
+                    return (
+                      <button
+                        key={theme.id}
+                        onClick={() => setDraftTheme(theme.id)}
+                        className={`relative rounded-lg border-2 overflow-hidden transition-all text-left ${
+                          selected ? "border-orange-500 shadow-md" : "border-gray-200 hover:border-gray-300"
+                        }`}
+                      >
+                        <div
+                          className="h-14"
+                          style={{
+                            background: `linear-gradient(135deg, ${theme.colors.primary} 0%, ${theme.colors.secondary} 100%)`,
+                          }}
+                        >
+                          {selected && (
+                            <div className="absolute top-1.5 right-1.5 bg-green-500 rounded-full p-0.5">
+                              <Check size={10} className="text-white" />
+                            </div>
+                          )}
+                        </div>
+                        <div className="px-2 py-1.5">
+                          <p className="text-xs font-semibold leading-tight">{theme.name}</p>
+                          <div className="flex gap-1 mt-1">
+                            {[theme.colors.primary, theme.colors.secondary, theme.colors.accent].map(
+                              (col) => (
+                                <div
+                                  key={col}
+                                  className="w-3 h-3 rounded-full border border-gray-200"
+                                  style={{ backgroundColor: col }}
+                                />
+                              ),
+                            )}
+                          </div>
+                        </div>
+                        {selected && (
+                          <Badge className="absolute bottom-1.5 right-1.5 text-[9px] px-1.5 py-0 bg-orange-500">
+                            Selected
+                          </Badge>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+
+            {/* 2. Branding */}
+            <AccordionItem value="branding" className="border rounded-lg px-3">
+              <AccordionTrigger className="text-sm font-semibold py-3">Branding</AccordionTrigger>
+              <AccordionContent className="pb-4 space-y-4">
+                <div>
+                  <Label className="text-xs">Store Name</Label>
+                  <Input
+                    value={draftName}
+                    onChange={(e) => setDraftName(e.target.value)}
+                    className="mt-1 text-sm"
+                    placeholder="Your store name"
+                  />
+                </div>
+                <div>
+                  <Label className="text-xs">Bio / Description</Label>
+                  <Textarea
+                    value={draftBio}
+                    onChange={(e) => setDraftBio(e.target.value)}
+                    rows={3}
+                    className="mt-1 text-sm resize-none"
+                    placeholder="Tell shoppers what your store is about…"
+                  />
+                </div>
+                <div>
+                  <Label className="text-xs">Logo</Label>
+                  {c.logo ? (
+                    <div className="relative inline-block mt-1">
+                      <img src={c.logo} alt="Logo" className="h-20 w-20 object-contain border rounded-lg" />
+                      <button
+                        onClick={() => patchCustomization({ logo: "" })}
+                        className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full p-0.5 hover:bg-red-600"
+                      >
+                        <X size={12} />
+                      </button>
+                    </div>
+                  ) : (
+                    <label className="mt-1 flex flex-col items-center justify-center w-full h-20 border-2 border-dashed border-gray-300 rounded-lg cursor-pointer hover:bg-gray-50">
+                      <Upload className="w-5 h-5 text-gray-400 mb-1" />
+                      <span className="text-xs text-gray-500">Upload logo</span>
+                      <input
+                        type="file"
+                        className="hidden"
+                        accept="image/*"
+                        onChange={(e) => handleImageUpload(e, "logo")}
+                        disabled={uploading}
+                      />
+                    </label>
+                  )}
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+
+            {/* 3. Colors */}
+            <AccordionItem value="colors" className="border rounded-lg px-3">
+              <AccordionTrigger className="text-sm font-semibold py-3">Colors</AccordionTrigger>
+              <AccordionContent className="pb-4 space-y-3">
+                <p className="text-xs text-gray-500">Override the theme preset with your brand colors.</p>
+                <ColorPicker
+                  label="Primary"
+                  value={c.colors?.primary || "#FF6B35"}
+                  onChange={(v) => patchCustomization({ colors: { ...c.colors, primary: v } })}
+                />
+                <ColorPicker
+                  label="Secondary"
+                  value={c.colors?.secondary || "#2C3E50"}
+                  onChange={(v) => patchCustomization({ colors: { ...c.colors, secondary: v } })}
+                />
+                <ColorPicker
+                  label="Accent / Background"
+                  value={c.colors?.accent || "#F7F7F7"}
+                  onChange={(v) => patchCustomization({ colors: { ...c.colors, accent: v } })}
+                />
+              </AccordionContent>
+            </AccordionItem>
+
+            {/* 4. Hero / Banner */}
+            <AccordionItem value="banner" className="border rounded-lg px-3">
+              <AccordionTrigger className="text-sm font-semibold py-3">
+                <span className="flex items-center gap-2">
+                  Hero / Banner
+                  <Switch
+                    checked={c.showBanner !== false}
+                    onCheckedChange={(v) => patchCustomization({ showBanner: v })}
+                    onClick={(e) => e.stopPropagation()}
+                    className="scale-75"
+                  />
+                </span>
+              </AccordionTrigger>
+              {c.showBanner !== false && (
+                <AccordionContent className="pb-4 space-y-3">
+                  {c.bannerImage ? (
+                    <div className="relative">
+                      <img src={c.bannerImage} alt="Banner" className="w-full h-28 object-cover rounded-lg" />
+                      <button
+                        onClick={() => patchCustomization({ bannerImage: "" })}
+                        className="absolute top-1.5 right-1.5 bg-red-500 text-white rounded-full p-0.5 hover:bg-red-600"
+                      >
+                        <X size={12} />
+                      </button>
+                    </div>
+                  ) : (
+                    <label className="flex flex-col items-center justify-center w-full h-28 border-2 border-dashed border-gray-300 rounded-lg cursor-pointer hover:bg-gray-50">
+                      <Upload className="w-5 h-5 text-gray-400 mb-1" />
+                      <span className="text-xs text-gray-500">Upload banner (1200×400px)</span>
+                      <input
+                        type="file"
+                        className="hidden"
+                        accept="image/*"
+                        onChange={(e) => handleImageUpload(e, "bannerImage")}
+                        disabled={uploading}
+                      />
+                    </label>
+                  )}
+                  <div>
+                    <Label className="text-xs">Banner Title</Label>
+                    <Input
+                      value={c.bannerTitle || ""}
+                      onChange={(e) => patchCustomization({ bannerTitle: e.target.value })}
+                      placeholder="Welcome to our store!"
+                      className="mt-1 text-sm"
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-xs">Banner Subtitle</Label>
+                    <Input
+                      value={c.bannerSubtitle || ""}
+                      onChange={(e) => patchCustomization({ bannerSubtitle: e.target.value })}
+                      placeholder="Discover amazing products"
+                      className="mt-1 text-sm"
+                    />
+                  </div>
+                </AccordionContent>
+              )}
+            </AccordionItem>
+
+            {/* 5. About */}
+            <AccordionItem value="about" className="border rounded-lg px-3">
+              <AccordionTrigger className="text-sm font-semibold py-3">
+                <span className="flex items-center gap-2">
+                  About
+                  <Switch
+                    checked={c.aboutEnabled || false}
+                    onCheckedChange={(v) => patchCustomization({ aboutEnabled: v })}
+                    onClick={(e) => e.stopPropagation()}
+                    className="scale-75"
+                  />
+                </span>
+              </AccordionTrigger>
+              {c.aboutEnabled && (
+                <AccordionContent className="pb-4 space-y-3">
+                  <div>
+                    <Label className="text-xs">Section Title</Label>
+                    <Input
+                      value={c.aboutTitle || "About Us"}
+                      onChange={(e) => patchCustomization({ aboutTitle: e.target.value })}
+                      className="mt-1 text-sm"
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-xs">Content</Label>
+                    <Textarea
+                      value={c.aboutContent || ""}
+                      onChange={(e) => patchCustomization({ aboutContent: e.target.value })}
+                      rows={4}
+                      className="mt-1 text-sm resize-none"
+                      placeholder="Tell your story…"
+                    />
+                  </div>
+                </AccordionContent>
+              )}
+            </AccordionItem>
+
+            {/* 6. Announcement Bar */}
+            <AccordionItem value="announcement" className="border rounded-lg px-3">
+              <AccordionTrigger className="text-sm font-semibold py-3">
+                <span className="flex items-center gap-2">
+                  Announcement Bar
+                  <Switch
+                    checked={c.announcementEnabled || false}
+                    onCheckedChange={(v) => patchCustomization({ announcementEnabled: v })}
+                    onClick={(e) => e.stopPropagation()}
+                    className="scale-75"
+                  />
+                </span>
+              </AccordionTrigger>
+              {c.announcementEnabled && (
+                <AccordionContent className="pb-4">
+                  <Input
+                    value={c.announcementBar || ""}
+                    onChange={(e) => patchCustomization({ announcementBar: e.target.value })}
+                    placeholder="e.g., Free shipping on orders over $50!"
+                    className="text-sm"
+                  />
+                </AccordionContent>
+              )}
+            </AccordionItem>
+
+            {/* 7. Layout */}
+            <AccordionItem value="layout" className="border rounded-lg px-3">
+              <AccordionTrigger className="text-sm font-semibold py-3">Layout</AccordionTrigger>
+              <AccordionContent className="pb-4 space-y-4">
+                <div>
+                  <Label className="text-xs">Grid Columns</Label>
+                  <div className="grid grid-cols-4 gap-1.5 mt-1.5">
+                    {[2, 3, 4, 5].map((cols) => (
+                      <button
+                        key={cols}
+                        onClick={() =>
+                          patchCustomization({ layout: { ...c.layout, gridColumns: cols } })
+                        }
+                        className={`py-2 border-2 rounded-lg text-center text-xs font-semibold transition-colors ${
+                          c.layout?.gridColumns === cols
+                            ? "border-orange-500 bg-orange-50 text-orange-700"
+                            : "border-gray-200 hover:border-gray-300"
+                        }`}
+                      >
+                        {cols}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <div>
+                  <Label className="text-xs">Card Style</Label>
+                  <div className="grid grid-cols-2 gap-2 mt-1.5">
+                    {[
+                      { value: "elevated", label: "Elevated", desc: "With shadow" },
+                      { value: "flat", label: "Flat", desc: "Simple border" },
+                    ].map((opt) => (
+                      <button
+                        key={opt.value}
+                        onClick={() =>
+                          patchCustomization({
+                            layout: { ...c.layout, productCardStyle: opt.value as any },
+                          })
+                        }
+                        className={`p-3 border-2 rounded-lg transition-colors text-left ${
+                          c.layout?.productCardStyle === opt.value
+                            ? "border-orange-500 bg-orange-50"
+                            : "border-gray-200 hover:border-gray-300"
+                        }`}
+                      >
+                        <p className="text-xs font-semibold">{opt.label}</p>
+                        <p className="text-[10px] text-gray-500">{opt.desc}</p>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <div>
+                  <Label className="text-xs">Spacing</Label>
+                  <div className="grid grid-cols-3 gap-1.5 mt-1.5">
+                    {["compact", "normal", "relaxed"].map((sp) => (
+                      <button
+                        key={sp}
+                        onClick={() =>
+                          patchCustomization({ layout: { ...c.layout, spacing: sp as any } })
+                        }
+                        className={`py-2 border-2 rounded-lg text-center text-xs font-medium capitalize transition-colors ${
+                          c.layout?.spacing === sp
+                            ? "border-orange-500 bg-orange-50 text-orange-700"
+                            : "border-gray-200 hover:border-gray-300"
+                        }`}
+                      >
+                        {sp}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+
+            {/* 8. Contact & Social */}
+            <AccordionItem value="contact" className="border rounded-lg px-3">
+              <AccordionTrigger className="text-sm font-semibold py-3">Contact & Social</AccordionTrigger>
+              <AccordionContent className="pb-4 space-y-3">
+                {[
+                  { key: "phone", icon: <Phone size={13} />, label: "Phone", placeholder: "(555) 123-4567", type: "tel" },
+                  { key: "email", icon: <Mail size={13} />, label: "Email", placeholder: "contact@yourstore.com", type: "email" },
+                  { key: "instagram", icon: <Instagram size={13} />, label: "Instagram", placeholder: "https://instagram.com/yourstore" },
+                  { key: "facebook", icon: <Facebook size={13} />, label: "Facebook", placeholder: "https://facebook.com/yourstore" },
+                  { key: "twitter", icon: <Twitter size={13} />, label: "Twitter", placeholder: "https://twitter.com/yourstore" },
+                ].map(({ key, icon, label, placeholder, type }) => (
+                  <div key={key}>
+                    <Label className="flex items-center gap-1.5 text-xs">
+                      {icon} {label}
+                    </Label>
+                    <Input
+                      type={type || "text"}
+                      value={(c.socialLinks as any)?.[key] || ""}
+                      onChange={(e) =>
+                        patchCustomization({
+                          socialLinks: { ...c.socialLinks, [key]: e.target.value },
+                        })
+                      }
+                      placeholder={placeholder}
+                      className="mt-1 text-xs"
+                    />
+                  </div>
+                ))}
+                <div>
+                  <Label className="flex items-center gap-1.5 text-xs">
+                    <MapPin size={13} /> Address
+                  </Label>
+                  <Textarea
+                    value={c.contactInfo?.address || ""}
+                    onChange={(e) =>
+                      patchCustomization({
+                        contactInfo: { ...c.contactInfo, address: e.target.value },
+                      })
+                    }
+                    rows={2}
+                    className="mt-1 text-xs resize-none"
+                    placeholder="123 Main St, City, State"
+                  />
+                </div>
+                <div>
+                  <Label className="text-xs">Store Hours</Label>
+                  <Textarea
+                    value={c.contactInfo?.hours || ""}
+                    onChange={(e) =>
+                      patchCustomization({
+                        contactInfo: { ...c.contactInfo, hours: e.target.value },
+                      })
+                    }
+                    rows={2}
+                    className="mt-1 text-xs resize-none"
+                    placeholder={"Mon–Fri: 9am–6pm\nSat–Sun: 10am–4pm"}
+                  />
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        </div>
+
+        {/* Sticky footer */}
+        <div className="flex-shrink-0 border-t bg-white px-4 py-3 flex items-center gap-2">
+          {isDirty && (
+            <span className="text-xs text-amber-600 font-medium flex-1">Unsaved changes</span>
+          )}
+          {!isDirty && <span className="flex-1 text-xs text-gray-400">All changes saved</span>}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleDiscard}
+            disabled={!isDirty || saving}
+          >
+            <RotateCcw className="w-3.5 h-3.5 mr-1.5" />
+            Discard
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSave}
+            disabled={!isDirty || saving}
+            className="bg-orange-500 hover:bg-orange-600 text-white"
+          >
+            <Save className="w-3.5 h-3.5 mr-1.5" />
+            {saving ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </div>
+
+      {/* ── Right preview pane ── */}
+      <div className="flex-1 min-w-0 overflow-hidden">
+        <StorefrontPreview
+          store={store}
+          draftName={draftName}
+          draftBio={draftBio}
+          draftTheme={draftTheme}
+          draftCustomization={draftCustomization}
+          products={products}
+        />
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/store/UnifiedStoreCustomizer.tsx
+++ b/client/src/components/store/UnifiedStoreCustomizer.tsx
@@ -99,11 +99,7 @@ export default function UnifiedStoreCustomizer({
       productCardStyle: "elevated",
       spacing: "normal",
     },
-    colors: savedCustomization?.colors || {
-      primary: "#FF6B35",
-      secondary: "#2C3E50",
-      accent: "#F7F7F7",
-    },
+    colors: savedCustomization?.colors,
   });
 
   const isDirty = useMemo(() => {
@@ -158,11 +154,7 @@ export default function UnifiedStoreCustomizer({
         productCardStyle: "elevated",
         spacing: "normal",
       },
-      colors: savedCustomization?.colors || {
-        primary: "#FF6B35",
-        secondary: "#2C3E50",
-        accent: "#F7F7F7",
-      },
+      colors: savedCustomization?.colors,
     });
   };
 
@@ -226,6 +218,15 @@ export default function UnifiedStoreCustomizer({
   };
 
   const c = draftCustomization;
+
+  // Effective colors: saved override per-channel, else fall back to the chosen theme preset.
+  // This means clicking a theme card immediately changes the preview even when no overrides exist.
+  const themePreset = THEMES.find((t) => t.id === draftTheme)?.colors ?? THEMES[0].colors;
+  const effectiveColors = {
+    primary: c.colors?.primary ?? themePreset.primary,
+    secondary: c.colors?.secondary ?? themePreset.secondary,
+    accent: c.colors?.accent ?? themePreset.accent,
+  };
 
   return (
     <div className="flex h-[calc(100vh-200px)] min-h-[600px]">
@@ -347,18 +348,18 @@ export default function UnifiedStoreCustomizer({
                 <p className="text-xs text-gray-500">Override the theme preset with your brand colors.</p>
                 <ColorPicker
                   label="Primary"
-                  value={c.colors?.primary || "#FF6B35"}
-                  onChange={(v) => patchCustomization({ colors: { ...c.colors, primary: v } })}
+                  value={effectiveColors.primary}
+                  onChange={(v) => patchCustomization({ colors: { ...(c.colors ?? {}), primary: v } })}
                 />
                 <ColorPicker
                   label="Secondary"
-                  value={c.colors?.secondary || "#2C3E50"}
-                  onChange={(v) => patchCustomization({ colors: { ...c.colors, secondary: v } })}
+                  value={effectiveColors.secondary}
+                  onChange={(v) => patchCustomization({ colors: { ...(c.colors ?? {}), secondary: v } })}
                 />
                 <ColorPicker
                   label="Accent / Background"
-                  value={c.colors?.accent || "#F7F7F7"}
-                  onChange={(v) => patchCustomization({ colors: { ...c.colors, accent: v } })}
+                  value={effectiveColors.accent}
+                  onChange={(v) => patchCustomization({ colors: { ...(c.colors ?? {}), accent: v } })}
                 />
               </AccordionContent>
             </AccordionItem>

--- a/client/src/components/store/preview/StorefrontPreview.tsx
+++ b/client/src/components/store/preview/StorefrontPreview.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from "react";
+import { Monitor, Smartphone } from "lucide-react";
+import StoreViewerContent, {
+  type StoreData,
+  type StoreProduct,
+} from "@/pages/store/StoreViewerContent";
+import type { StoreLayoutCustomizationConfig } from "@shared/store/storeLayout";
+
+type Viewport = "desktop" | "mobile";
+
+interface StorefrontPreviewProps {
+  store: StoreData;
+  draftName: string;
+  draftBio: string;
+  draftTheme: string;
+  draftCustomization: StoreLayoutCustomizationConfig;
+  products: StoreProduct[];
+}
+
+export default function StorefrontPreview({
+  store,
+  draftName,
+  draftBio,
+  draftTheme,
+  draftCustomization,
+  products,
+}: StorefrontPreviewProps) {
+  const [viewport, setViewport] = useState<Viewport>("desktop");
+
+  const previewStore: StoreData = {
+    ...store,
+    name: draftName,
+    bio: draftBio,
+    theme: draftTheme,
+    layout: { version: 2, customization: draftCustomization },
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Viewport toggle */}
+      <div className="flex items-center justify-between px-4 py-2 border-b bg-gray-50 flex-shrink-0">
+        <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+          Live Preview
+        </span>
+        <div className="flex items-center gap-1 bg-white border rounded-lg p-0.5">
+          <button
+            onClick={() => setViewport("desktop")}
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+              viewport === "desktop"
+                ? "bg-orange-500 text-white shadow-sm"
+                : "text-gray-500 hover:text-gray-700"
+            }`}
+          >
+            <Monitor className="w-3.5 h-3.5" />
+            Desktop
+          </button>
+          <button
+            onClick={() => setViewport("mobile")}
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+              viewport === "mobile"
+                ? "bg-orange-500 text-white shadow-sm"
+                : "text-gray-500 hover:text-gray-700"
+            }`}
+          >
+            <Smartphone className="w-3.5 h-3.5" />
+            Mobile
+          </button>
+        </div>
+      </div>
+
+      {/* Preview area */}
+      <div className="flex-1 overflow-auto bg-gray-100 flex justify-center">
+        <div
+          className={`bg-white transition-all duration-300 ${
+            viewport === "mobile"
+              ? "max-w-[390px] w-full shadow-2xl ring-1 ring-gray-200"
+              : "w-full"
+          }`}
+        >
+          {viewport === "mobile" && (
+            <div className="flex items-center justify-center gap-1.5 py-2 bg-gray-800 rounded-t-xl">
+              <div className="w-16 h-1 bg-gray-500 rounded-full" />
+            </div>
+          )}
+          <StoreViewerContent
+            store={previewStore}
+            products={products}
+            productsLoading={false}
+            isOwner={false}
+            previewMode={true}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/store/StoreDashboard.tsx
+++ b/client/src/pages/store/StoreDashboard.tsx
@@ -4,7 +4,6 @@ import {
   Package,
   ShoppingCart,
   Sparkles,
-  Palette,
   BarChart3,
   Crown,
 } from "lucide-react";
@@ -22,10 +21,10 @@ import StoreDashboardEmptyState from "./components/StoreDashboardEmptyState";
 import StoreDashboardHeader from "./components/StoreDashboardHeader";
 import StoreDashboardProductsTab from "./components/StoreDashboardProductsTab";
 import StoreDashboardOrdersTab from "./components/StoreDashboardOrdersTab";
-import StoreDashboardCustomizeTab from "./components/StoreDashboardCustomizeTab";
 import StoreReadinessPanel from "./components/StoreReadinessPanel";
 import type { MarketplaceProduct } from "@/lib/store/marketplaceTypes";
-import StoreDashboardThemeTab from "./components/StoreDashboardThemeTab";
+import UnifiedStoreCustomizer from "@/components/store/UnifiedStoreCustomizer";
+import type { StoreProduct } from "./StoreViewerContent";
 import {
   buildSubscriptionCheckoutPayload,
   calculateTrialDaysLeft,
@@ -49,10 +48,14 @@ export default function StoreDashboard() {
   const [productsLoaded, setProductsLoaded] = useState(false);
   const [loading, setLoading] = useState(true);
   const [publishing, setPublishing] = useState(false);
-  const [selectedTheme, setSelectedTheme] = useState("modern");
   const [showPlansModal, setShowPlansModal] = useState(false);
-  const [activeTab, setActiveTab] = useState("products");
-  const [customizeInitialTab, setCustomizeInitialTab] = useState("branding");
+  const [activeTab, setActiveTab] = useState(() => {
+    // Normalize legacy tab query params at startup
+    const params = new URLSearchParams(window.location.search);
+    const tab = params.get("tab") || "products";
+    if (tab === "theme" || tab === "builder") return "customize";
+    return tab;
+  });
   const tabsRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -174,63 +177,6 @@ export default function StoreDashboard() {
     }
   };
 
-  const handleThemeChange = async (themeId: string) => {
-    setSelectedTheme(themeId);
-    if (!store?.id) return;
-    try {
-      const res = await fetch(`/api/stores/${store.id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ theme: themeId }),
-      });
-      if (res.ok) {
-        toast({ description: "Theme updated!" });
-      } else {
-        toast({
-          title: "Error",
-          description: "Failed to update theme",
-          variant: "destructive",
-        });
-      }
-    } catch {
-      toast({
-        title: "Error",
-        description: "Failed to update theme",
-        variant: "destructive",
-      });
-    }
-  };
-
-  const handleCustomizationUpdate = async (updates: any) => {
-    if (!store?.id) return;
-    try {
-      const res = await fetch(`/api/stores/${store.id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify(updates),
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setStore(data.store);
-        toast({ description: "Store customization saved!" });
-      } else {
-        toast({
-          title: "Error",
-          description: "Failed to save customization",
-          variant: "destructive",
-        });
-      }
-    } catch {
-      toast({
-        title: "Error",
-        description: "Failed to save customization",
-        variant: "destructive",
-      });
-    }
-  };
-
   const scrollToTabs = () => {
     setTimeout(() => {
       tabsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
@@ -253,7 +199,6 @@ export default function StoreDashboard() {
     }
 
     if (action === "description") {
-      setCustomizeInitialTab("branding");
       setActiveTab("customize");
       scrollToTabs();
       toast({ description: "Edit your store description in the Branding section below." });
@@ -267,10 +212,9 @@ export default function StoreDashboard() {
     }
 
     if (action === "banner") {
-      setCustomizeInitialTab("sections");
       setActiveTab("customize");
       scrollToTabs();
-      toast({ description: "Upload your banner image in the Sections tab below." });
+      toast({ description: "Upload your banner image in the Hero / Banner section below." });
       return;
     }
 
@@ -407,10 +351,6 @@ export default function StoreDashboard() {
               <Sparkles className="w-4 h-4 mr-1.5" />
               Customize
             </TabsTrigger>
-            <TabsTrigger value="theme">
-              <Palette className="w-4 h-4 mr-1.5" />
-              Theme
-            </TabsTrigger>
             <TabsTrigger value="analytics">
               <BarChart3 className="w-4 h-4 mr-1.5" />
               Analytics
@@ -436,20 +376,12 @@ export default function StoreDashboard() {
             <StoreDashboardOrdersTab recentSales={recentSales} />
           </TabsContent>
 
-          {/* Customize Tab */}
+          {/* Unified Customize Tab */}
           <TabsContent value="customize">
-            <StoreDashboardCustomizeTab
+            <UnifiedStoreCustomizer
               store={store}
-              onUpdate={handleCustomizationUpdate}
-              defaultTab={customizeInitialTab}
-            />
-          </TabsContent>
-
-          {/* Theme Tab */}
-          <TabsContent value="theme">
-            <StoreDashboardThemeTab
-              selectedTheme={selectedTheme}
-              onSelectTheme={handleThemeChange}
+              products={products as unknown as StoreProduct[]}
+              onSaved={(updatedStore) => setStore(updatedStore)}
             />
           </TabsContent>
 

--- a/client/src/pages/store/StoreDashboard.tsx
+++ b/client/src/pages/store/StoreDashboard.tsx
@@ -73,7 +73,6 @@ export default function StoreDashboard() {
         const storeData = await storeRes.json();
         const s = storeData.store;
         setStore(s);
-        if (s) setSelectedTheme(s.theme || "modern");
 
         if (s) {
           // Products

--- a/client/src/pages/store/StoreViewer.tsx
+++ b/client/src/pages/store/StoreViewer.tsx
@@ -1,50 +1,11 @@
-// client/src/pages/store/StoreViewer.tsx
 import * as React from "react";
 import { useEffect, useState } from "react";
 import { useLocation, useRoute } from "wouter";
 import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { StoreHeader } from "@/components/store/StoreHeader";
-import { ProductCard } from "@/components/store/ProductCard";
-import { ShoppingBag, Eye, Heart, MapPin, Clock } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { useUser } from "@/contexts/UserContext";
-import { THEMES } from "@/components/store/ThemeSelector";
-import { normalizeStoreLayout } from "@shared/store/storeLayout";
-
-interface StoreData {
-  id: number;
-  userId: number;
-  handle: string;
-  name: string;
-  bio: string;
-  theme: string;
-  layout: Record<string, any> | null;
-  published: boolean;
-  subscriptionTier: string;
-  createdAt: string;
-  updatedAt: string;
-  viewCount: number;
-}
-
-interface StoreProduct {
-  id: number;
-  sellerId: number;
-  name: string;
-  description: string;
-  price: string;
-  images: string[];
-  category: string;
-  inventory: number;
-  isActive: boolean;
-  createdAt: string;
-  updatedAt: string;
-  deliveryMethods: string[];
-  viewCount?: number;
-  favoriteCount?: number;
-}
+import StoreViewerContent, { type StoreData, type StoreProduct } from "./StoreViewerContent";
 
 export default function StoreViewer() {
   const [, setLocation] = useLocation();
@@ -59,85 +20,77 @@ export default function StoreViewer() {
 
   const storeHandle = params?.handle;
 
-  const fetchStore = async () => {
-    if (!storeHandle) return;
-    try {
-      setLoading(true);
-      const response = await fetch(`/api/stores/${storeHandle}`, {
-        credentials: "include",
-      });
-
-      if (!response.ok) {
-        if (response.status === 404) {
-          try {
-            const ownerRes = await fetch(`/api/stores/check-handle/${storeHandle}`);
-            if (ownerRes.ok) {
-              const checkData = await ownerRes.json();
-              if (checkData.available === false) {
-                toast({
-                  title: "Store not published",
-                  description: "This store exists but isn't published yet.",
-                  variant: "destructive",
-                });
-                setLocation("/store/dashboard");
-                return;
-              }
-            }
-          } catch {}
-          toast({
-            title: "Store not found",
-            description: "This store doesn't exist or isn't published yet.",
-            variant: "destructive",
-          });
-          setLocation("/store");
-          return;
-        }
-        throw new Error("Failed to fetch store");
-      }
-
-      const storeData = await response.json();
-      const storeObj = storeData.store ?? storeData;
-      setStore(storeObj);
-
-      if (storeObj?.id) {
-        fetch(`/api/stores/${storeObj.id}/increment-view`, { method: "PATCH" }).catch(() => {});
-      }
-    } catch (error) {
-      console.error("Error fetching store:", error);
-      toast({
-        title: "Error",
-        description: "Failed to load store. Please try again.",
-        variant: "destructive",
-      });
-      setLocation("/marketplace");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const fetchProducts = async (sellerId: string | number) => {
-    try {
-      setProductsLoading(true);
-      const response = await fetch(`/api/marketplace/sellers/${sellerId}/products`);
-      if (!response.ok) throw new Error("Failed to fetch products");
-      const data = await response.json();
-      setProducts(data.products || []);
-    } catch (error) {
-      console.error("Error fetching store products:", error);
-    } finally {
-      setProductsLoading(false);
-    }
-  };
-
   useEffect(() => {
+    if (!storeHandle) return;
+    let cancelled = false;
+
+    const fetchStore = async () => {
+      setLoading(true);
+      try {
+        const response = await fetch(`/api/stores/${storeHandle}`, { credentials: "include" });
+
+        if (!response.ok) {
+          if (response.status === 404) {
+            try {
+              const ownerRes = await fetch(`/api/stores/check-handle/${storeHandle}`);
+              if (ownerRes.ok) {
+                const checkData = await ownerRes.json();
+                if (checkData.available === false) {
+                  toast({
+                    title: "Store not published",
+                    description: "This store exists but isn't published yet.",
+                    variant: "destructive",
+                  });
+                  setLocation("/store/dashboard");
+                  return;
+                }
+              }
+            } catch {}
+            toast({
+              title: "Store not found",
+              description: "This store doesn't exist or isn't published yet.",
+              variant: "destructive",
+            });
+            setLocation("/store");
+            return;
+          }
+          throw new Error("Failed to fetch store");
+        }
+
+        const storeData = await response.json();
+        const storeObj = storeData.store ?? storeData;
+        if (cancelled) return;
+        setStore(storeObj);
+
+        if (storeObj?.id) {
+          fetch(`/api/stores/${storeObj.id}/increment-view`, { method: "PATCH" }).catch(() => {});
+        }
+      } catch {
+        toast({ title: "Error", description: "Failed to load store.", variant: "destructive" });
+        setLocation("/marketplace");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
     fetchStore();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return () => { cancelled = true; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [storeHandle]);
 
   useEffect(() => {
     const sellerId = store?.userId ?? (store as any)?.user_id;
-    if (sellerId) fetchProducts(sellerId);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    if (!sellerId) return;
+    let cancelled = false;
+
+    setProductsLoading(true);
+    fetch(`/api/marketplace/sellers/${sellerId}/products`)
+      .then((r) => r.json())
+      .then((data) => { if (!cancelled) setProducts(data.products || []); })
+      .catch(() => {})
+      .finally(() => { if (!cancelled) setProductsLoading(false); });
+
+    return () => { cancelled = true; };
   }, [store?.userId, (store as any)?.user_id]);
 
   if (!match) return null;
@@ -166,164 +119,16 @@ export default function StoreViewer() {
 
   if (!store) return null;
 
-  const isOwner = user?.id === store.userId;
-
-  // Extract customization — safe for legacy flat, Craft node-map, and v2 shapes
-  const layout = normalizeStoreLayout(store.layout).customization;
-
-  // Custom colors override the theme preset
-  const preset = THEMES.find((t) => t.id === store.theme)?.colors ?? THEMES[0].colors;
-  const themeColors = {
-    primary: layout.colors?.primary || preset.primary,
-    secondary: layout.colors?.secondary || preset.secondary,
-    accent: layout.colors?.accent || preset.accent,
-  };
-
-  // Map layout fields to what StoreHeader expects
-  const storeForHeader = {
-    ...store,
-    banner_url: layout.bannerImage || (store as any).banner_url || null,
-    logo_url: layout.logo || (store as any).logo_url || null,
-    bio: store.bio || layout.aboutContent || null,
-  };
-
-  // Dynamic grid columns
-  const gridCols: number = layout.layout?.gridColumns ?? 3;
-  const gridClass =
-    gridCols === 2
-      ? "grid-cols-1 md:grid-cols-2"
-      : gridCols === 4
-        ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-4"
-        : "grid-cols-1 md:grid-cols-3";
+  const isOwner = user?.id === store.userId || String(user?.id) === String(store.userId);
 
   return (
-    <div className="min-h-screen" style={{ backgroundColor: themeColors.accent + "22" }}>
-
-      {/* Announcement bar */}
-      {layout.announcementEnabled && layout.announcementBar && (
-        <div
-          className="text-white text-center py-2 px-4 text-sm font-medium"
-          style={{ backgroundColor: themeColors.primary }}
-        >
-          {layout.announcementBar}
-        </div>
-      )}
-
-      <StoreHeader store={storeForHeader} isOwner={isOwner} themeColors={themeColors} />
-
-      {/* About section */}
-      {layout.aboutEnabled && layout.aboutContent && (
-        <div className="max-w-6xl mx-auto px-4 pt-10 pb-2">
-          <h2 className="text-xl font-bold mb-3" style={{ color: themeColors.secondary }}>
-            {layout.aboutTitle || "About Us"}
-          </h2>
-          <p className="text-gray-700 leading-relaxed">{layout.aboutContent}</p>
-        </div>
-      )}
-
-      {/* Products */}
-      <div className="max-w-6xl mx-auto px-4 py-8">
-        <div className="flex justify-between items-center mb-6">
-          <div>
-            <h2 className="text-2xl font-bold mb-1" style={{ color: themeColors.secondary }}>
-              Products
-            </h2>
-            <p className="text-gray-600">{products.length} items available</p>
-          </div>
-          <div className="flex gap-3">
-            <Button variant="outline" onClick={() => setLocation("/marketplace")}>
-              Browse Marketplace
-            </Button>
-            {isOwner && (
-              <Button
-                onClick={() => setLocation("/store/dashboard")}
-                style={{ backgroundColor: themeColors.primary }}
-                className="text-white hover:opacity-90"
-              >
-                Manage Store
-              </Button>
-            )}
-          </div>
-        </div>
-
-        {productsLoading ? (
-          <div className={`grid ${gridClass} gap-6`}>
-            {Array.from({ length: 6 }).map((_, i) => (
-              <Card key={i}>
-                <CardContent className="p-4">
-                  <Skeleton className="h-48 w-full mb-4" />
-                  <Skeleton className="h-4 w-3/4 mb-2" />
-                  <Skeleton className="h-4 w-1/2 mb-2" />
-                  <Skeleton className="h-4 w-2/3" />
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        ) : products.length === 0 ? (
-          <Card>
-            <CardContent className="p-12 text-center">
-              <ShoppingBag className="w-16 h-16 text-gray-400 mx-auto mb-4" />
-              <h3 className="text-xl font-semibold mb-2">No products yet</h3>
-              <p className="text-gray-600 mb-4">
-                {isOwner
-                  ? "Start adding products to your store to begin selling."
-                  : "This store hasn't listed any products yet."}
-              </p>
-              {isOwner && (
-                <Button onClick={() => setLocation("/store/dashboard")}>
-                  Add Products
-                </Button>
-              )}
-            </CardContent>
-          </Card>
-        ) : (
-          <div className={`grid ${gridClass} gap-6`}>
-            {products.map((product) => (
-              <div
-                key={product.id}
-                className="relative cursor-pointer"
-                onClick={() => setLocation(`/product/${product.id}`)}
-              >
-                <ProductCard product={product as any} onAddToCart={() => {}} />
-                <div className="absolute top-3 right-3 flex gap-2">
-                  {typeof product.viewCount === "number" && (
-                    <Badge variant="secondary" className="flex items-center gap-1">
-                      <Eye className="w-3 h-3" />
-                      {product.viewCount}
-                    </Badge>
-                  )}
-                  {typeof product.favoriteCount === "number" && (
-                    <Badge variant="secondary" className="flex items-center gap-1">
-                      <Heart className="w-3 h-3" />
-                      {product.favoriteCount}
-                    </Badge>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-
-      {/* Contact / hours footer */}
-      {(layout.contactInfo?.address || layout.contactInfo?.hours) && (
-        <div className="border-t mt-8">
-          <div className="max-w-6xl mx-auto px-4 py-8 flex flex-wrap gap-6 text-sm text-gray-600">
-            {layout.contactInfo?.address && (
-              <div className="flex items-center gap-2">
-                <MapPin className="w-4 h-4 flex-shrink-0" style={{ color: themeColors.primary }} />
-                <span>{layout.contactInfo.address}</span>
-              </div>
-            )}
-            {layout.contactInfo?.hours && (
-              <div className="flex items-center gap-2">
-                <Clock className="w-4 h-4 flex-shrink-0" style={{ color: themeColors.primary }} />
-                <span>{layout.contactInfo.hours}</span>
-              </div>
-            )}
-          </div>
-        </div>
-      )}
-    </div>
+    <StoreViewerContent
+      store={store}
+      products={products}
+      productsLoading={productsLoading}
+      isOwner={isOwner}
+      previewMode={false}
+      onNavigate={setLocation}
+    />
   );
 }

--- a/client/src/pages/store/StoreViewerContent.tsx
+++ b/client/src/pages/store/StoreViewerContent.tsx
@@ -1,0 +1,209 @@
+import * as React from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { StoreHeader } from "@/components/store/StoreHeader";
+import { ProductCard } from "@/components/store/ProductCard";
+import { ShoppingBag, Eye, Heart, MapPin, Clock } from "lucide-react";
+import { THEMES } from "@/components/store/ThemeSelector";
+import { normalizeStoreLayout } from "@shared/store/storeLayout";
+
+export interface StoreData {
+  id: string | number;
+  userId: string | number;
+  handle: string;
+  name: string;
+  bio?: string | null;
+  theme?: string | null;
+  layout?: Record<string, any> | null;
+  published?: boolean;
+  viewCount?: number;
+}
+
+export interface StoreProduct {
+  id: number;
+  sellerId: number;
+  name: string;
+  description: string;
+  price: string;
+  images: string[];
+  category: string;
+  inventory: number;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+  deliveryMethods: string[];
+  viewCount?: number;
+  favoriteCount?: number;
+}
+
+interface StoreViewerContentProps {
+  store: StoreData;
+  products: StoreProduct[];
+  productsLoading?: boolean;
+  isOwner?: boolean;
+  previewMode?: boolean;
+  onNavigate?: (path: string) => void;
+}
+
+export default function StoreViewerContent({
+  store,
+  products,
+  productsLoading = false,
+  isOwner = false,
+  previewMode = false,
+  onNavigate,
+}: StoreViewerContentProps) {
+  const navigate = previewMode ? () => {} : (onNavigate ?? (() => {}));
+
+  const layout = normalizeStoreLayout(store.layout).customization;
+
+  const preset = THEMES.find((t) => t.id === store.theme)?.colors ?? THEMES[0].colors;
+  const themeColors = {
+    primary: layout.colors?.primary || preset.primary,
+    secondary: layout.colors?.secondary || preset.secondary,
+    accent: layout.colors?.accent || preset.accent,
+  };
+
+  const storeForHeader = {
+    ...store,
+    banner_url: layout.bannerImage || (store as any).banner_url || null,
+    logo_url: layout.logo || (store as any).logo_url || null,
+    bio: store.bio || layout.aboutContent || null,
+  };
+
+  const gridCols: number = layout.layout?.gridColumns ?? 3;
+  const gridClass =
+    gridCols === 2
+      ? "grid-cols-1 md:grid-cols-2"
+      : gridCols === 4
+        ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-4"
+        : "grid-cols-1 md:grid-cols-3";
+
+  return (
+    <div className="min-h-screen" style={{ backgroundColor: themeColors.accent + "22" }}>
+      {layout.announcementEnabled && layout.announcementBar && (
+        <div
+          className="text-white text-center py-2 px-4 text-sm font-medium"
+          style={{ backgroundColor: themeColors.primary }}
+        >
+          {layout.announcementBar}
+        </div>
+      )}
+
+      <StoreHeader store={storeForHeader} isOwner={isOwner} themeColors={themeColors} />
+
+      {layout.aboutEnabled && layout.aboutContent && (
+        <div className="max-w-6xl mx-auto px-4 pt-10 pb-2">
+          <h2 className="text-xl font-bold mb-3" style={{ color: themeColors.secondary }}>
+            {layout.aboutTitle || "About Us"}
+          </h2>
+          <p className="text-gray-700 leading-relaxed">{layout.aboutContent}</p>
+        </div>
+      )}
+
+      <div className="max-w-6xl mx-auto px-4 py-8">
+        <div className="flex justify-between items-center mb-6">
+          <div>
+            <h2 className="text-2xl font-bold mb-1" style={{ color: themeColors.secondary }}>
+              Products
+            </h2>
+            <p className="text-gray-600">{products.length} items available</p>
+          </div>
+          {!previewMode && (
+            <div className="flex gap-3">
+              <Button variant="outline" onClick={() => navigate("/marketplace")}>
+                Browse Marketplace
+              </Button>
+              {isOwner && (
+                <Button
+                  onClick={() => navigate("/store/dashboard")}
+                  style={{ backgroundColor: themeColors.primary }}
+                  className="text-white hover:opacity-90"
+                >
+                  Manage Store
+                </Button>
+              )}
+            </div>
+          )}
+        </div>
+
+        {productsLoading ? (
+          <div className={`grid ${gridClass} gap-6`}>
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Card key={i}>
+                <CardContent className="p-4">
+                  <Skeleton className="h-48 w-full mb-4" />
+                  <Skeleton className="h-4 w-3/4 mb-2" />
+                  <Skeleton className="h-4 w-1/2 mb-2" />
+                  <Skeleton className="h-4 w-2/3" />
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : products.length === 0 ? (
+          <Card>
+            <CardContent className="p-12 text-center">
+              <ShoppingBag className="w-16 h-16 text-gray-400 mx-auto mb-4" />
+              <h3 className="text-xl font-semibold mb-2">No products yet</h3>
+              <p className="text-gray-600 mb-4">
+                {isOwner
+                  ? "Start adding products to your store to begin selling."
+                  : "This store hasn't listed any products yet."}
+              </p>
+              {isOwner && !previewMode && (
+                <Button onClick={() => navigate("/store/dashboard")}>Add Products</Button>
+              )}
+            </CardContent>
+          </Card>
+        ) : (
+          <div className={`grid ${gridClass} gap-6`}>
+            {products.map((product) => (
+              <div
+                key={product.id}
+                className={`relative ${previewMode ? "pointer-events-none" : "cursor-pointer"}`}
+                onClick={previewMode ? undefined : () => navigate(`/product/${product.id}`)}
+              >
+                <ProductCard product={product as any} onAddToCart={() => {}} />
+                <div className="absolute top-3 right-3 flex gap-2">
+                  {typeof product.viewCount === "number" && (
+                    <Badge variant="secondary" className="flex items-center gap-1">
+                      <Eye className="w-3 h-3" />
+                      {product.viewCount}
+                    </Badge>
+                  )}
+                  {typeof product.favoriteCount === "number" && (
+                    <Badge variant="secondary" className="flex items-center gap-1">
+                      <Heart className="w-3 h-3" />
+                      {product.favoriteCount}
+                    </Badge>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {(layout.contactInfo?.address || layout.contactInfo?.hours) && (
+        <div className="border-t mt-8">
+          <div className="max-w-6xl mx-auto px-4 py-8 flex flex-wrap gap-6 text-sm text-gray-600">
+            {layout.contactInfo?.address && (
+              <div className="flex items-center gap-2">
+                <MapPin className="w-4 h-4 flex-shrink-0" style={{ color: themeColors.primary }} />
+                <span>{layout.contactInfo.address}</span>
+              </div>
+            )}
+            {layout.contactInfo?.hours && (
+              <div className="flex items-center gap-2">
+                <Clock className="w-4 h-4 flex-shrink-0" style={{ color: themeColors.primary }} />
+                <span>{layout.contactInfo.hours}</span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/store/StoreViewerContent.tsx
+++ b/client/src/pages/store/StoreViewerContent.tsx
@@ -79,7 +79,9 @@ export default function StoreViewerContent({
       ? "grid-cols-1 md:grid-cols-2"
       : gridCols === 4
         ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-4"
-        : "grid-cols-1 md:grid-cols-3";
+        : gridCols === 5
+          ? "grid-cols-2 md:grid-cols-3 lg:grid-cols-5"
+          : "grid-cols-1 md:grid-cols-3";
 
   return (
     <div className="min-h-screen" style={{ backgroundColor: themeColors.accent + "22" }}>


### PR DESCRIPTION
## Summary

Collapses the three separate Theme / Customize / Builder dashboard tabs into a single **Customize** tab backed by a new `UnifiedStoreCustomizer` component. No schema, API, or server changes.

### New files

- **`StoreViewerContent.tsx`** — Pure presentational component extracted from `StoreViewer.tsx`. Takes `store`, `products`, `productsLoading`, `isOwner`, `previewMode`, `onNavigate`. In `previewMode`: product clicks are disabled, navigation buttons hidden, no analytics side effects. Both the public storefront and the preview pane render through this same component so they can never drift apart.

- **`StoreViewer.tsx`** (rewrite) — Thin wrapper: reads handle from route, fetches store + products, fires view-count increment, renders `StoreViewerContent`.

- **`StorefrontPreview.tsx`** — Composes a synthetic `previewStore` from draft state (`draftName`, `draftBio`, `draftTheme`, `draftCustomization`) and renders `StoreViewerContent previewMode`. Desktop / Mobile segmented control at the top; Mobile constrains the canvas to `max-width: 390px` with a device-style notch bar.

- **`UnifiedStoreCustomizer.tsx`** — Left accordion panel (~420 px) + right live preview. Sections in order: Theme (4 preset cards), Branding (name, bio, logo upload), Colors (primary / secondary / accent pickers), Hero / Banner (toggle + image upload + title/subtitle), About (toggle + title + content), Announcement Bar (toggle + text), Layout (grid columns 2–5, card style, spacing), Contact & Social (phone, email, Instagram, Facebook, Twitter, address, hours). Sticky footer: **Save** (disabled until dirty) and **Discard** buttons. `beforeunload` guard fires when there are unsaved edits. Save calls `PATCH /api/stores/:id` with `{ name, bio, theme, customization }` — the same endpoint Step 1 already routes correctly.

### Modified files

- **`StoreDashboard.tsx`** — Removes Theme and Builder `TabsTrigger`/`TabsContent` entries (files stay in repo). Single Customize tab now renders `UnifiedStoreCustomizer`. Startup normalisation: if `?tab=theme` or `?tab=builder` arrives in the URL query, the initial tab resolves to `customize` so merchant bookmarks still land somewhere sensible.

## Test plan

- [ ] Dashboard shows **Products / Orders / Customize / Analytics / Subscription** — Theme and Builder tabs gone
- [ ] `?tab=theme` and `?tab=builder` query params land on Customize tab
- [ ] Edit banner title → preview updates within a render cycle
- [ ] Change primary color → announcement bar and headings reflect it in preview
- [ ] Toggle **Mobile** → preview canvas narrows to ~390 px phone frame; **Desktop** restores full width
- [ ] Make an edit → Save button enables; click Save → toast appears, Save disables again
- [ ] Reload → all edits persisted (`GET /api/stores/:handle` returns `layout.version === 2`, `layout.customization` populated, `layout.builder` preserved if it existed)
- [ ] Navigate away with unsaved changes → browser confirm prompt fires
- [ ] Public storefront URL renders identically to dashboard preview

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgEDFpQY9bXpkipn6dyR7e)_