### PR TITLE
Fix legacy store drops migration idempotency

### DIFF
--- a/migrations/008_create_store_drops.sql
+++ b/migrations/008_create_store_drops.sql
@@ -1,7 +1,3 @@
--- Migration: 008_create_store_drops
--- Created: 2026-05-31
--- Purpose: Add store_drops table for merchant follower drop notifications with click-through tracking
-
 CREATE TABLE IF NOT EXISTS store_drops (
   id          varchar PRIMARY KEY DEFAULT gen_random_uuid(),
   store_id    varchar NOT NULL REFERENCES stores(id),
@@ -13,12 +9,28 @@ CREATE TABLE IF NOT EXISTS store_drops (
   created_at  timestamp NOT NULL DEFAULT now()
 );
 
+/*
+  Migration: 008_create_store_drops
+  Created: 2026-05-31
+  Purpose: Add store_drops table for merchant follower drop notifications with click-through tracking.
+
+  Keep every executable statement before comments that describe it. The legacy
+  migration runner splits on semicolons and skips statements that start with
+  "--", so leading line comments can accidentally skip the following DDL.
+*/
+
+ALTER TABLE store_drops ADD COLUMN IF NOT EXISTS id varchar DEFAULT gen_random_uuid();
+ALTER TABLE store_drops ADD COLUMN IF NOT EXISTS store_id varchar;
+ALTER TABLE store_drops ADD COLUMN IF NOT EXISTS owner_id varchar;
+ALTER TABLE store_drops ADD COLUMN IF NOT EXISTS product_id varchar;
+ALTER TABLE store_drops ADD COLUMN IF NOT EXISTS message text;
+ALTER TABLE store_drops ADD COLUMN IF NOT EXISTS recipient_count integer NOT NULL DEFAULT 0;
+ALTER TABLE store_drops ADD COLUMN IF NOT EXISTS click_count integer NOT NULL DEFAULT 0;
+ALTER TABLE store_drops ADD COLUMN IF NOT EXISTS created_at timestamp NOT NULL DEFAULT now();
+
 COMMENT ON COLUMN store_drops.recipient_count IS 'Snapshot of follower count at drop creation time';
 COMMENT ON COLUMN store_drops.click_count IS 'Incremented each time a follower taps through the notification link';
 COMMENT ON COLUMN store_drops.product_id IS 'Nullable to allow future free-form announcement drops';
 
--- Fast lookup for merchant history page and rate-limit checks
 CREATE INDEX IF NOT EXISTS store_drops_owner_created_at_idx ON store_drops (owner_id, created_at DESC);
-
--- Allow filtering drops by store
 CREATE INDEX IF NOT EXISTS store_drops_store_id_idx ON store_drops (store_id);


### PR DESCRIPTION
### Motivation
- The legacy migration `migrations/008_create_store_drops.sql` could be skipped by the migration runner because leading `--` header lines cause the runner's split/filter logic to drop the following DDL, producing `relation "store_drops" does not exist` errors in later statements.
- Make the migration safe and idempotent so `npm run db:migrate` can continue and later migrations (including the meal planner social foundation) can be applied.

### Description
- Ensure the `CREATE TABLE IF NOT EXISTS store_drops` statement is the first executable statement in the file so the runner does not skip it.
- Replace leading `--` header usage with an in-file block comment (`/* ... */`) to avoid the runner filtering behavior, and document the reason for the block comment.
- Add guarded `ALTER TABLE store_drops ADD COLUMN IF NOT EXISTS ...` statements for each intended column to make the file safe when the table partially exists or is created elsewhere.
- Preserve schema intent and idempotency by keeping `COMMENT ON COLUMN ...` and `CREATE INDEX IF NOT EXISTS ...` statements after the table is guaranteed to exist.

### Testing
- `npm run db:migrate` — Did not complete in this environment because `DATABASE_URL` is missing; the migration runner exited before connecting, so migrations were not applied here.
- Verified via a local script that the runner’s split/filter logic now sees `CREATE TABLE IF NOT EXISTS store_drops` as the first executable statement and that subsequent guarded DDL and index statements are present and ordered correctly.
- `npm run build:client` — completed successfully.
- `npm run build:server` — completed successfully.

Additional notes: the root cause was the runner splitting SQL on semicolons and ignoring any split segment starting with `--`, which caused the CREATE TABLE statement to be skipped when header comments preceded it; the patch removes that failure mode and makes all DDL idempotent using `IF NOT EXISTS` / `ADD COLUMN IF NOT EXISTS` patterns. The target migration `server/drizzle/20260604_meal_planner_social_foundation.sql` was not applied in this environment due to the blocked `db:migrate` run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a244f80d8c08325a1342026fd05600f)