### PR TITLE
Eliminate base64 media storage: move to compressed file uploads

### DIFF
--- a/client/src/components/create-post-modal.tsx
+++ b/client/src/components/create-post-modal.tsx
@@ -48,6 +48,37 @@ interface CreatePostModalProps {
   onOpenChange: (open: boolean) => void;
 }
 
+async function uploadImageFile(file: File): Promise<{ url: string; thumbUrl: string }> {
+  const fd = new FormData();
+  fd.append("file", file);
+  const res = await fetch("/api/upload/image", {
+    method: "POST",
+    credentials: "include",
+    body: fd,
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || `Upload failed (${res.status})`);
+  }
+  return res.json();
+}
+
+async function uploadVideoFile(file: File): Promise<string> {
+  const fd = new FormData();
+  fd.append("file", file);
+  const res = await fetch("/api/upload", {
+    method: "POST",
+    credentials: "include",
+    body: fd,
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || `Upload failed (${res.status})`);
+  }
+  const data = await res.json();
+  return data.url as string;
+}
+
 export default function CreatePostModal({ open, onOpenChange }: CreatePostModalProps) {
   const { toast } = useToast();
   const { user } = useUser();
@@ -55,6 +86,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
 
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string>("");
+  const [isUploading, setIsUploading] = useState(false);
 
   const [postType, setPostType] = useState<PostType>("post");
 
@@ -131,36 +163,67 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
 
     setImageFile(null);
     setImagePreview("");
+    setIsUploading(false);
 
     setBiteExpiry("24h");
     setBiteMediaUrl("");
     setBiteMediaType("video");
   };
 
-  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
     setImageFile(file);
 
+    // Show local preview immediately
     const reader = new FileReader();
-    reader.onloadend = () => {
-      const result = reader.result as string;
-      setImagePreview(result);
-      // NOTE: demo uses base64 as imageUrl; in production upload to storage/CDN
-      setImageUrl(result);
-    };
+    reader.onloadend = () => setImagePreview(reader.result as string);
     reader.readAsDataURL(file);
+
+    // Upload the actual file to the server
+    setIsUploading(true);
+    try {
+      const { url } = await uploadImageFile(file);
+      setImageUrl(url);
+    } catch (err: any) {
+      toast({ variant: "destructive", description: `Image upload failed: ${err.message}` });
+      setImageFile(null);
+      setImagePreview("");
+      setImageUrl("");
+    } finally {
+      setIsUploading(false);
+    }
   };
 
-  const handleBiteFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleBiteFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+
     const isVideo = file.type.startsWith("video/");
     setBiteMediaType(isVideo ? "video" : "image");
+
+    // Show a local preview while uploading
     const reader = new FileReader();
     reader.onloadend = () => setBiteMediaUrl(reader.result as string);
     reader.readAsDataURL(file);
+
+    setIsUploading(true);
+    try {
+      let url: string;
+      if (isVideo) {
+        url = await uploadVideoFile(file);
+      } else {
+        const result = await uploadImageFile(file);
+        url = result.url;
+      }
+      setBiteMediaUrl(url);
+    } catch (err: any) {
+      toast({ variant: "destructive", description: `Upload failed: ${err.message}` });
+      setBiteMediaUrl("");
+    } finally {
+      setIsUploading(false);
+    }
   };
 
   const buildRecipePayload = () => {
@@ -263,6 +326,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
           body: JSON.stringify({
             userId: user!.id,
             imageUrl: biteMediaUrl,
+            mediaType: biteMediaType,
             caption: caption.trim() || undefined,
             expiresAt,
           }),
@@ -314,6 +378,8 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
   const removeInstruction = (idx: number) =>
     setInstructions((prev) => (prev.length <= 1 ? prev : prev.filter((_, i) => i !== idx)));
 
+  const isSubmitDisabled = isUploading || createPostMutation.isPending;
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md max-h-[90vh] overflow-y-auto">
@@ -333,6 +399,9 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
                   alt="Preview"
                   className="w-full max-h-48 object-cover rounded-lg mx-auto"
                 />
+                {isUploading && (
+                  <p className="text-xs text-muted-foreground animate-pulse">Uploading…</p>
+                )}
                 <Button
                   type="button"
                   variant="outline"
@@ -445,6 +514,10 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
                   </div>
                 )}
               </div>
+
+              {isUploading && (
+                <p className="text-xs text-muted-foreground text-center animate-pulse">Uploading…</p>
+              )}
 
               {/* Expiry / Permanent toggle */}
               <div className="flex items-center gap-3 p-3 bg-muted/40 rounded-lg">
@@ -680,9 +753,9 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
           <Button
             type="submit"
             className="w-full bg-primary text-primary-foreground hover:opacity-90"
-            disabled={createPostMutation.isPending}
+            disabled={isSubmitDisabled}
           >
-            {createPostMutation.isPending ? "Sharing..." : postType === "recipe" ? "Share Recipe" : postType === "review" ? "Share Review" : postType === "bite" ? "Share Bite" : postType === "clip" ? "Share Clip" : "Share Post"}
+            {isUploading ? "Uploading…" : createPostMutation.isPending ? "Sharing..." : postType === "recipe" ? "Share Recipe" : postType === "review" ? "Share Review" : postType === "bite" ? "Share Bite" : postType === "clip" ? "Share Clip" : "Share Post"}
           </Button>
         </form>
       </DialogContent>

--- a/client/src/components/create-post-modal.tsx
+++ b/client/src/components/create-post-modal.tsx
@@ -58,7 +58,7 @@ async function uploadImageFile(file: File): Promise<{ url: string; thumbUrl: str
   });
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
-    throw new Error(body.error || `Upload failed (${res.status})`);
+    throw new Error((body as any).error || `Upload failed (${res.status})`);
   }
   return res.json();
 }
@@ -73,10 +73,10 @@ async function uploadVideoFile(file: File): Promise<string> {
   });
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
-    throw new Error(body.error || `Upload failed (${res.status})`);
+    throw new Error((body as any).error || `Upload failed (${res.status})`);
   }
   const data = await res.json();
-  return data.url as string;
+  return (data as any).url as string;
 }
 
 export default function CreatePostModal({ open, onOpenChange }: CreatePostModalProps) {
@@ -84,14 +84,16 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
   const { user } = useUser();
   const queryClient = useQueryClient();
 
+  // Post image flow
   const [imageFile, setImageFile] = useState<File | null>(null);
-  const [imagePreview, setImagePreview] = useState<string>("");
-  const [isUploading, setIsUploading] = useState(false);
+  const [imagePreview, setImagePreview] = useState<string>("");  // local data URI for preview only
+  const [imageUrl, setImageUrl] = useState<string>("");          // confirmed /uploads/... URL
+  const postSelectToken = useRef(0);
 
+  const [isUploading, setIsUploading] = useState(false);
   const [postType, setPostType] = useState<PostType>("post");
 
   const [caption, setCaption] = useState("");
-  const [imageUrl, setImageUrl] = useState("");
   const [tags, setTags] = useState("");
 
   // Recipe fields
@@ -115,7 +117,9 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
   const [biteExpiry, setBiteExpiry] = useState<"24h" | "permanent">("24h");
   const [showGoLive, setShowGoLive] = useState(false);
   const biteFileRef = useRef<HTMLInputElement>(null);
-  const [biteMediaUrl, setBiteMediaUrl] = useState<string>("");
+  const biteSelectToken = useRef(0);
+  const [biteMediaUrl, setBiteMediaUrl] = useState<string>("");         // confirmed /uploads/... URL
+  const [biteMediaPreview, setBiteMediaPreview] = useState<string>(""); // local data URI for preview only
   const [biteMediaType, setBiteMediaType] = useState<"image" | "video">("video");
 
   const cleanedTags = useMemo(
@@ -167,45 +171,66 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
 
     setBiteExpiry("24h");
     setBiteMediaUrl("");
+    setBiteMediaPreview("");
     setBiteMediaType("video");
   };
 
+  // Post image handler — FileReader writes only to imagePreview (data URI, for instant display).
+  // imageUrl is set only from a successful /api/upload/image response.
+  // A per-selection token guards against stale FileReader or fetch callbacks overwriting
+  // state after the user has already selected a different file.
   const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
-    setImageFile(file);
+    const token = ++postSelectToken.current;
 
-    // Show local preview immediately
+    setImageFile(file);
+    setImagePreview("");
+    setImageUrl("");
+
     const reader = new FileReader();
-    reader.onloadend = () => setImagePreview(reader.result as string);
+    reader.onloadend = () => {
+      if (postSelectToken.current !== token) return;
+      setImagePreview(reader.result as string);
+    };
     reader.readAsDataURL(file);
 
-    // Upload the actual file to the server
     setIsUploading(true);
     try {
       const { url } = await uploadImageFile(file);
+      if (postSelectToken.current !== token) return;
       setImageUrl(url);
     } catch (err: any) {
+      if (postSelectToken.current !== token) return;
       toast({ variant: "destructive", description: `Image upload failed: ${err.message}` });
       setImageFile(null);
       setImagePreview("");
       setImageUrl("");
     } finally {
-      setIsUploading(false);
+      if (postSelectToken.current === token) setIsUploading(false);
     }
   };
 
+  // Bite / Clip handler — FileReader writes only to biteMediaPreview (data URI, for instant display).
+  // biteMediaUrl is set only from a successful upload response.
+  // The token ref guards against races when the user picks a second file before the first upload finishes.
   const handleBiteFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
+    const token = ++biteSelectToken.current;
     const isVideo = file.type.startsWith("video/");
-    setBiteMediaType(isVideo ? "video" : "image");
 
-    // Show a local preview while uploading
+    setBiteMediaType(isVideo ? "video" : "image");
+    setBiteMediaUrl("");
+    setBiteMediaPreview("");
+
     const reader = new FileReader();
-    reader.onloadend = () => setBiteMediaUrl(reader.result as string);
+    reader.onloadend = () => {
+      if (biteSelectToken.current !== token) return;
+      setBiteMediaPreview(reader.result as string);
+    };
     reader.readAsDataURL(file);
 
     setIsUploading(true);
@@ -217,12 +242,15 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
         const result = await uploadImageFile(file);
         url = result.url;
       }
+      if (biteSelectToken.current !== token) return;
       setBiteMediaUrl(url);
     } catch (err: any) {
+      if (biteSelectToken.current !== token) return;
       toast({ variant: "destructive", description: `Upload failed: ${err.message}` });
       setBiteMediaUrl("");
+      setBiteMediaPreview("");
     } finally {
-      setIsUploading(false);
+      if (biteSelectToken.current === token) setIsUploading(false);
     }
   };
 
@@ -271,6 +299,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
     }
 
     if (postType === "bite" || postType === "clip") {
+      // Validate against biteMediaUrl, not biteMediaPreview — URL is set only after a successful upload
       if (!biteMediaUrl) {
         toast({ variant: "destructive", description: "Please pick a video or photo" });
         return false;
@@ -325,7 +354,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             userId: user!.id,
-            imageUrl: biteMediaUrl,
+            imageUrl: biteMediaUrl,   // always a confirmed /uploads/... URL
             mediaType: biteMediaType,
             caption: caption.trim() || undefined,
             expiresAt,
@@ -380,6 +409,10 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
 
   const isSubmitDisabled = isUploading || createPostMutation.isPending;
 
+  // The preview src for bites: use the local data URI while uploading for instant feedback;
+  // fall back to biteMediaUrl for cases where no file was selected (e.g. URL pasted externally).
+  const bitePreviewSrc = biteMediaPreview || biteMediaUrl;
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md max-h-[90vh] overflow-y-auto">
@@ -407,9 +440,11 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
                   variant="outline"
                   size="sm"
                   onClick={() => {
+                    ++postSelectToken.current; // invalidate any in-flight upload
                     setImageFile(null);
                     setImagePreview("");
                     setImageUrl("");
+                    setIsUploading(false);
                   }}
                 >
                   <X className="h-4 w-4 mr-1" />
@@ -502,10 +537,10 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
                 className="w-full aspect-video bg-gray-100 dark:bg-gray-800 rounded-xl flex items-center justify-center cursor-pointer overflow-hidden border-2 border-dashed border-gray-300 dark:border-gray-600 hover:border-primary transition-colors"
                 onClick={() => biteFileRef.current?.click()}
               >
-                {biteMediaUrl && biteMediaType === "video" ? (
-                  <video src={biteMediaUrl} className="w-full h-full object-cover rounded-xl" controls muted playsInline />
-                ) : biteMediaUrl ? (
-                  <img src={biteMediaUrl} alt="Preview" className="w-full h-full object-cover rounded-xl" />
+                {bitePreviewSrc && biteMediaType === "video" ? (
+                  <video src={bitePreviewSrc} className="w-full h-full object-cover rounded-xl" controls muted playsInline />
+                ) : bitePreviewSrc ? (
+                  <img src={bitePreviewSrc} alt="Preview" className="w-full h-full object-cover rounded-xl" />
                 ) : (
                   <div className="flex flex-col items-center gap-2 text-gray-400">
                     <Video className="w-8 h-8" />

--- a/client/src/pages/social/feed.tsx
+++ b/client/src/pages/social/feed.tsx
@@ -220,7 +220,7 @@ function SimpleRecipeCard({
     <Card className="overflow-hidden">
       <div className="relative cursor-pointer" onClick={() => onCardClick?.(post)}>
         {post.imageUrl ? (
-          <img src={post.imageUrl} alt={post.caption || "Recipe"} className="w-full h-64 object-cover" />
+          <img src={post.imageUrl} alt={post.caption || "Recipe"} className="w-full h-64 object-cover" loading="lazy" decoding="async" />
         ) : (
           <div className="w-full h-64 bg-gray-200 flex items-center justify-center">
             <Heart className="w-8 h-8 text-gray-400" />
@@ -473,7 +473,7 @@ export default function Feed() {
                   className="flex space-x-3 cursor-pointer hover:bg-muted/50 p-2 rounded-lg transition-colors"
                   data-testid={`trending-recipe-${recipe.id}`}
                 >
-                  <img src={recipe.post.imageUrl} alt={recipe.title} className="w-12 h-12 rounded-lg object-cover flex-shrink-0" />
+                  <img src={recipe.post.imageUrl} alt={recipe.title} className="w-12 h-12 rounded-lg object-cover flex-shrink-0" loading="lazy" decoding="async" />
                   <div className="flex-1">
                     <p className="text-sm font-medium">{recipe.title}</p>
                     <p className="text-xs text-muted-foreground">
@@ -542,7 +542,7 @@ export default function Feed() {
                 {selectedPost.imageUrl?.includes("video") || selectedPost.imageUrl?.includes(".mp4") ? (
                   <video src={selectedPost.imageUrl} controls className="w-full h-full object-contain" />
                 ) : (
-                  <img src={selectedPost.imageUrl} alt={selectedPost.caption || "Post"} className="w-full h-full object-contain" />
+                  <img src={selectedPost.imageUrl} alt={selectedPost.caption || "Post"} className="w-full h-full object-contain" loading="lazy" decoding="async" />
                 )}
               </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
         "react-icons": "^5.4.0",
         "react-resizable-panels": "^2.1.7",
         "recharts": "^2.15.2",
+        "sharp": "^0.35.1",
         "socket.io": "^4.8.1",
         "socket.io-client": "^4.8.1",
         "square": "^43.2.0",
@@ -1321,6 +1322,16 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild-kit/core-utils": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.3.2.tgz",
@@ -2222,6 +2233,506 @@
       "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
       "peerDependencies": {
         "react-hook-form": "^7.0.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.1.tgz",
+      "integrity": "sha512-T15JRWOubQ3f5+GxnWeIvo47u5qV0M9HBgJhT+f2gE1e9e6OhR6K73Re52Hm80qWcu1DNb3GweKmpr/MnuP2Ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.0"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.1.tgz",
+      "integrity": "sha512-t1CPD0cr7XCHjwUj6tQ5MC0pCi866I+gUW6zbUX4aFPnKd1DFBtk0M+gWcjX8VeEzgfCNiSiNTVFZ6b7kvdbnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.0"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.1.tgz",
+      "integrity": "sha512-MBSQXqNPThW9EcZ905H6N4sEdX5EwZEYzGx5EBq9ncDCGJALMiY1xPFJxNdzuB1iBjLOpIfxajM6YxdvwmQSLA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-EKbmBKtyTH+GPFDRw2TgK2oV6hyxxlJVIar4hoTYSNmIwipgMFdxPQqR392GmfdsPGWga0mCFN1cCKjRb9cljw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-Pl2OmOvrJ42adUllESxBsG54PfXLo1OYg9i3c5/5Ln/qJ0gZuTM9YMhQJPIbXqwidLRc/c2zuHt4RsrymmNv7A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.0.tgz",
+      "integrity": "sha512-A8UpHoUDW4DwnXoV6+q3C1s7QLRAHtPDEjWuNZjwHMyoCNZnm0GeNN8ls9f/bsEYTRQRW96C/n34XJQHJ2fT7A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.0.tgz",
+      "integrity": "sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.0.tgz",
+      "integrity": "sha512-WOpkVxAjFd369iaIzEgNRreFD+gWdUMIGD5zplhNKNeqS6mm5dac3q2AFyCBmzYoAdouzZvRBgxy4z8QHZb4/A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.0.tgz",
+      "integrity": "sha512-DRWw0mOHusrCCuw2rqP87oLg6PGlkomVDFqw2hIwsSfwWpu4k3XLcBPaKKl6ct/GtL/cwNkgwjV/tc0Mqht3VA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.0.tgz",
+      "integrity": "sha512-9APy+nFWhHS+kzLgWZfLcyrUd7YqnAQVa4BPOo4xkoHpdoktOAPG4cEr9+Jpl0TtqfVmcMJimNL5qNTyyOHZNA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.0.tgz",
+      "integrity": "sha512-y9RNUYDe2A1UAdhLyfeOodGRszQdaEoe4nfOpp/sNVPl2CWIcUyFaDoCh4vPLPxu19803j2naLqZup2WxDXCLA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.0.tgz",
+      "integrity": "sha512-cC1wkC0Mlucd0KSiGrLkJnB/ZqPvZCntc/Lk7ZnYO5ZSbF2euNek4Xvxafojq+wN1q/W0eprdpUIjUr/EV2PBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.0.tgz",
+      "integrity": "sha512-LiYMhUZicB1QG//+RvmYZpXJO8fYRENfp+MZUCnG9aw+AKvGAy9gPaCnuwsPcBFs8EV66M0NNxj9VHcNklE8zw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.1.tgz",
+      "integrity": "sha512-jygmR02PpCYypt7xB7nst1vqjZp/BpRA/Kf9nK7qRponJ/KrLPaZWEG4G15z1d2FZ6XqI+T0350ha3RSnKx24A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.0"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.1.tgz",
+      "integrity": "sha512-ErCRyGU7LeoaFBZ0xW8hhLlXzhAg80sc4vxePB86qvtEvW1jEhhmbiNBP4oEzZfPMnu6HwHXfzD2W2kBU+RnCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.0"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.1.tgz",
+      "integrity": "sha512-LUWZ2+r2UoLCd8j0RLCwQ4gL6w47+Y7igxtVnPIDXOOEjV86LpBkAHq5VpJeg+GHbw0KN/JWlPJOdZjyZnFqFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.0"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.1.tgz",
+      "integrity": "sha512-i7x6J3mwF4JgT0sM4V4WlAWdJ0bucPtA9rzO1bTji1n5qgBq/W5nn87RvOQPleuuxahNoLdTngByD8/vDDLArw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.0"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.1.tgz",
+      "integrity": "sha512-0zSaTUjTF0kIWTSYxD4EG/nvCU4jez53+3RdURtoY3HvbXtIQ98W90JnrGz/oLRFuEnfIy9+7xeq883euc0ZWw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.0"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.1.tgz",
+      "integrity": "sha512-NbJD4mWdeyrNQKluO/tR/wBDOelcowSVGNBWxI0e3ZtlXc6F/UOVKDj1MLD4zl3oHTuvKW3s+MA9N54YTldAYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.0"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.1.tgz",
+      "integrity": "sha512-VoW2sQCWI+0YIKQEmWJ8vzaQjTg9wIyfkFpvEfAS2h43X6iHu7GTk1hhOgB4IpSzCHe8UwQZIcx7b81VTaOrJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.0"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.1.tgz",
+      "integrity": "sha512-LjBoSd/c5JU0/K5MwzDMlgsSRP2bPn98JQGFFQAOLQ0bU/1z4ekxUdSKY9BmlwSh/cA+OrvpgsWqfZyYfVHBRw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.0"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.1.tgz",
+      "integrity": "sha512-PCQUoQdZyE8tp3HpbevuihfUmgSP4qWI0FGEPWoeXqaS+cUrFfemabHQiebUmUmlUhCuNnQMxGrQ+CPqK4hnxg==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.0"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.1.tgz",
+      "integrity": "sha512-xU2ml2bU2OPxYVvW2A6ae4M1g5QKyhKG06P4FAt+YEaFQQO0919Qx+XxIZEUuWTMoDViLpMws2/dQwoe/VcA6A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.1.tgz",
+      "integrity": "sha512-IkmHwuFhYpd3bTsN5SAahjwhiAcyXPooBt8vEUgxY3T0IP70sSJ0nU1xiPzZY8AH/OB1XpV3j8aZSVSOSfTbdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.1.tgz",
+      "integrity": "sha512-wQahqCi9MD8Yxzg4gVM4fNrZxh+r6vD55PyIg+WJPaM5ZRUyF35iQpwJCuma3r6viU9/8Pxlc+XHV+woVa6nCQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.1.tgz",
+      "integrity": "sha512-WzBtkYtZHATLPe8XRharxZXxQ9cdLrQWHiwxt+BJ5rBsisQrKeeV86ErxPSVhcG6xCEuNhs0SqLpWr7XDa2k6w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -6115,12 +6626,10 @@
       "license": "MIT"
     },
     "node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
@@ -10150,6 +10659,62 @@
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
       "license": "MIT"
+    },
+    "node_modules/sharp": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.1.tgz",
+      "integrity": "sha512-lW979AMi+ESidzMv/Lnv+F9bknzLyxLqFI05Sm433vOeRcltgxQmXpnfOOFIAlKtwXU/ksupm2srQoFCkR214g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.1",
+        "@img/sharp-darwin-x64": "0.35.1",
+        "@img/sharp-freebsd-wasm32": "0.35.1",
+        "@img/sharp-libvips-darwin-arm64": "1.3.0",
+        "@img/sharp-libvips-darwin-x64": "1.3.0",
+        "@img/sharp-libvips-linux-arm": "1.3.0",
+        "@img/sharp-libvips-linux-arm64": "1.3.0",
+        "@img/sharp-libvips-linux-ppc64": "1.3.0",
+        "@img/sharp-libvips-linux-riscv64": "1.3.0",
+        "@img/sharp-libvips-linux-s390x": "1.3.0",
+        "@img/sharp-libvips-linux-x64": "1.3.0",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.0",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.0",
+        "@img/sharp-linux-arm": "0.35.1",
+        "@img/sharp-linux-arm64": "0.35.1",
+        "@img/sharp-linux-ppc64": "0.35.1",
+        "@img/sharp-linux-riscv64": "0.35.1",
+        "@img/sharp-linux-s390x": "0.35.1",
+        "@img/sharp-linux-x64": "0.35.1",
+        "@img/sharp-linuxmusl-arm64": "0.35.1",
+        "@img/sharp-linuxmusl-x64": "0.35.1",
+        "@img/sharp-webcontainers-wasm32": "0.35.1",
+        "@img/sharp-win32-arm64": "0.35.1",
+        "@img/sharp-win32-ia32": "0.35.1",
+        "@img/sharp-win32-x64": "0.35.1"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "audit:content": "npm run audit:drink-canonical && npm run audit:pet-food-pages",
     "merge:substitutions": "tsx server/scripts/merge-substitutions.ts",
     "db:seed:subs:dry-run": "tsx server/scripts/dry-run-substitutions-import.ts",
-    "db:seed:subs:verify": "tsx server/scripts/verify-substitutions-seed.ts"
+    "db:seed:subs:verify": "tsx server/scripts/verify-substitutions-seed.ts",
+    "db:migrate:images": "tsx server/scripts/migrate-base64-images.ts"
   },
   "dependencies": {
     "@craftjs/core": "^0.2.12",
@@ -135,6 +136,7 @@
     "react-icons": "^5.4.0",
     "react-resizable-panels": "^2.1.7",
     "recharts": "^2.15.2",
+    "sharp": "^0.35.1",
     "socket.io": "^4.8.1",
     "socket.io-client": "^4.8.1",
     "square": "^43.2.0",

--- a/server/app.ts
+++ b/server/app.ts
@@ -31,14 +31,14 @@ app.use(cors({
   origin: process.env.CLIENT_URL || true, // Allow configured origin or all origins in dev
 }));
 app.use(express.json({
-  limit: "50mb",
+  limit: "2mb",
   verify: (req, _res, buf) => {
     (req as Request & { rawBody?: string }).rawBody = buf.toString("utf8");
   },
 }));
 app.use(express.urlencoded({
   extended: true,
-  limit: "50mb",
+  limit: "2mb",
   verify: (req, _res, buf) => {
     (req as Request & { rawBody?: string }).rawBody = buf.toString("utf8");
   },
@@ -89,6 +89,8 @@ const uploadContentTypes: Record<string, string> = {
 app.use(
   "/uploads",
   express.static(uploadsDir, {
+    maxAge: "365d",
+    immutable: true,
     setHeaders: (res, filePath) => {
       const contentType = uploadContentTypes[path.extname(filePath).toLowerCase()];
       if (contentType) {

--- a/server/lib/data-uri.ts
+++ b/server/lib/data-uri.ts
@@ -1,0 +1,41 @@
+import { randomUUID } from "crypto";
+import path from "path";
+import fs from "fs/promises";
+import { existsSync, mkdirSync } from "fs";
+
+const MIME_TO_EXT: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "image/svg+xml": "svg",
+  "video/mp4": "mp4",
+  "video/webm": "webm",
+  "video/quicktime": "mov",
+};
+
+export async function persistDataUri(value: string): Promise<string> {
+  if (!value.startsWith("data:")) return value;
+
+  const match = value.match(/^data:([^;]+);base64,([\s\S]+)$/);
+  if (!match) return value;
+
+  const [, mime, base64] = match;
+  const buffer = Buffer.from(base64, "base64");
+
+  if (buffer.length > 25 * 1024 * 1024) {
+    throw new Error("Data URI exceeds 25MB limit");
+  }
+
+  const ext = MIME_TO_EXT[mime] ?? "bin";
+  const filename = `${randomUUID()}.${ext}`;
+  const uploadsDir = path.join(process.cwd(), "uploads");
+
+  if (!existsSync(uploadsDir)) {
+    mkdirSync(uploadsDir, { recursive: true });
+  }
+
+  await fs.writeFile(path.join(uploadsDir, filename), buffer);
+
+  return `/uploads/${filename}`;
+}

--- a/server/routes/bites.ts
+++ b/server/routes/bites.ts
@@ -6,6 +6,7 @@ import { storage } from "../storage";
 import { db } from "../db";
 import { requireAuth } from "../middleware";
 import { stories, users, notifications } from "../../shared/schema";
+import { persistDataUri } from "../lib/data-uri";
 
 const r = Router();
 
@@ -165,6 +166,10 @@ r.post("/", async (req, res) => {
     });
 
     const data = schema.parse(req.body);
+
+    // Safety net: persist any stray data URIs to disk
+    data.imageUrl = await persistDataUri(data.imageUrl);
+
     const expiresAt = data.expiresAt
       ? new Date(data.expiresAt)
       : new Date(Date.now() + 24 * 60 * 60 * 1000); // 24h default

--- a/server/routes/posts.ts
+++ b/server/routes/posts.ts
@@ -4,6 +4,7 @@ import { storage } from "../storage";
 import { asyncHandler, ErrorFactory } from "../middleware/error-handler";
 import { validateRequest, CommonSchemas } from "../middleware/validation";
 import { requireAuth } from "../middleware/auth";
+import { persistDataUri } from "../lib/data-uri";
 
 const r = Router();
 
@@ -120,6 +121,13 @@ r.post("/", async (req, res) => {
     // If it's a recipe post, enforce recipe payload
     if (body.isRecipe && !body.recipe) {
       return res.status(400).json({ message: "Recipe details are required for recipe posts" });
+    }
+
+    // Safety net: persist any stray data URIs to disk
+    body.imageUrl = await persistDataUri(body.imageUrl);
+    body.additionalImages = await Promise.all(body.additionalImages.map(persistDataUri));
+    if (body.recipe?.imageUrl) {
+      body.recipe.imageUrl = await persistDataUri(body.recipe.imageUrl);
     }
 
     const created = await storage.createPost({

--- a/server/routes/upload.ts
+++ b/server/routes/upload.ts
@@ -4,15 +4,15 @@ import path from "path";
 import { randomUUID } from "crypto";
 import { requireAuth } from "../middleware";
 import fs from "fs";
+import sharp from "sharp";
 
 const router = Router();
 
-// Configure multer for file uploads
+// Configure multer for general file uploads (disk storage)
 const storage = multer.diskStorage({
   destination: (req, file, cb) => {
     const uploadDir = path.join(process.cwd(), 'uploads');
 
-    // Create uploads directory if it doesn't exist
     try {
       if (!fs.existsSync(uploadDir)) {
         fs.mkdirSync(uploadDir, { recursive: true });
@@ -35,7 +35,6 @@ const upload = multer({
     fileSize: 100 * 1024 * 1024, // 100MB
   },
   fileFilter: (req, file, cb) => {
-    // Allow specific file types
     const allowedTypes = [
       'application/pdf',
       'application/msword',
@@ -63,13 +62,12 @@ const upload = multer({
   }
 });
 
-// POST /api/upload - Upload a file
+// POST /api/upload - General file upload (videos, docs, etc.)
 router.post("/", requireAuth, (req, res) => {
   upload.single('file')(req, res, (err) => {
     if (err) {
       console.error("Upload error:", err);
 
-      // Handle Multer errors specifically
       if (err instanceof multer.MulterError) {
         if (err.code === 'LIMIT_FILE_SIZE') {
           return res.status(400).json({ ok: false, error: "File is too large. Maximum size is 100MB." });
@@ -77,7 +75,6 @@ router.post("/", requireAuth, (req, res) => {
         return res.status(400).json({ ok: false, error: `Upload error: ${err.message}` });
       }
 
-      // Handle file filter errors
       return res.status(400).json({ ok: false, error: err.message || "Invalid file type" });
     }
 
@@ -86,8 +83,6 @@ router.post("/", requireAuth, (req, res) => {
         return res.status(400).json({ ok: false, error: "No file uploaded" });
       }
 
-      // Generate full URL for the uploaded file
-      // Check for forwarded headers (when behind proxy like Plesk)
       const protocol = req.get('x-forwarded-proto') || req.protocol;
       const host = req.get('x-forwarded-host') || req.get('host');
       const fileUrl = `${protocol}://${host}/uploads/${req.file.filename}`;
@@ -102,6 +97,83 @@ router.post("/", requireAuth, (req, res) => {
     } catch (error: any) {
       console.error("Error processing upload:", error);
       res.status(500).json({ ok: false, error: error.message || "Failed to process upload" });
+    }
+  });
+});
+
+// Memory-storage multer for image processing (25MB limit, images only)
+const imageMemoryUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: 25 * 1024 * 1024, // 25MB
+  },
+  fileFilter: (_req, file, cb) => {
+    const allowed = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+    if (allowed.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error('Only JPEG, PNG, WebP, and GIF images are accepted.'));
+    }
+  },
+});
+
+// POST /api/upload/image - Compressed image upload with thumbnail
+router.post("/image", requireAuth, (req, res) => {
+  imageMemoryUpload.single('file')(req, res, async (err) => {
+    if (err) {
+      if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE') {
+        return res.status(400).json({ ok: false, error: "Image is too large. Maximum size is 25MB." });
+      }
+      return res.status(400).json({ ok: false, error: err.message || "Invalid image" });
+    }
+
+    try {
+      if (!req.file) {
+        return res.status(400).json({ ok: false, error: "No file uploaded" });
+      }
+
+      const uploadsDir = path.join(process.cwd(), 'uploads');
+      if (!fs.existsSync(uploadsDir)) {
+        fs.mkdirSync(uploadsDir, { recursive: true });
+      }
+
+      const protocol = req.get('x-forwarded-proto') || req.protocol;
+      const host = req.get('x-forwarded-host') || req.get('host');
+
+      // GIFs are saved as-is to preserve animation
+      if (req.file.mimetype === 'image/gif') {
+        const filename = `${randomUUID()}.gif`;
+        const filepath = path.join(uploadsDir, filename);
+        fs.writeFileSync(filepath, req.file.buffer);
+        const url = `${protocol}://${host}/uploads/${filename}`;
+        return res.json({ ok: true, url, thumbUrl: url });
+      }
+
+      const uuid = randomUUID();
+      const mainFilename = `${uuid}.webp`;
+      const thumbFilename = `${uuid}_thumb.webp`;
+      const mainPath = path.join(uploadsDir, mainFilename);
+      const thumbPath = path.join(uploadsDir, thumbFilename);
+
+      await sharp(req.file.buffer)
+        .rotate()
+        .resize({ width: 1600, withoutEnlargement: true })
+        .webp({ quality: 80 })
+        .toFile(mainPath);
+
+      await sharp(req.file.buffer)
+        .rotate()
+        .resize({ width: 480, withoutEnlargement: true })
+        .webp({ quality: 75 })
+        .toFile(thumbPath);
+
+      const url = `${protocol}://${host}/uploads/${mainFilename}`;
+      const thumbUrl = `${protocol}://${host}/uploads/${thumbFilename}`;
+
+      res.json({ ok: true, url, thumbUrl });
+    } catch (error: any) {
+      console.error("Error processing image upload:", error);
+      res.status(500).json({ ok: false, error: error.message || "Failed to process image" });
     }
   });
 });

--- a/server/scripts/migrate-base64-images.ts
+++ b/server/scripts/migrate-base64-images.ts
@@ -1,0 +1,156 @@
+/**
+ * Migrate existing base64 data URIs in posts, recipes, and stories to
+ * on-disk files under /uploads. Idempotent — rows already migrated are skipped.
+ *
+ * Usage: npm run db:migrate:images
+ */
+import "dotenv/config";
+import path from "path";
+import fs from "fs/promises";
+import { existsSync, mkdirSync } from "fs";
+import { randomUUID } from "crypto";
+import { db } from "../db";
+import { posts, recipes, stories } from "../../shared/schema";
+import { sql, like, or } from "drizzle-orm";
+
+const MIME_TO_EXT: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "image/svg+xml": "svg",
+  "video/mp4": "mp4",
+  "video/webm": "webm",
+  "video/quicktime": "mov",
+};
+
+const uploadsDir = path.join(process.cwd(), "uploads");
+
+async function ensureUploadsDir() {
+  if (!existsSync(uploadsDir)) {
+    mkdirSync(uploadsDir, { recursive: true });
+  }
+}
+
+async function saveDataUri(dataUri: string): Promise<{ url: string; bytes: number }> {
+  const match = dataUri.match(/^data:([^;]+);base64,([\s\S]+)$/);
+  if (!match) throw new Error("Invalid data URI format");
+
+  const [, mime, base64] = match;
+  const buffer = Buffer.from(base64, "base64");
+  const ext = MIME_TO_EXT[mime] ?? "bin";
+  const filename = `${randomUUID()}.${ext}`;
+  const filepath = path.join(uploadsDir, filename);
+
+  await fs.writeFile(filepath, buffer);
+
+  return { url: `/uploads/${filename}`, bytes: buffer.length };
+}
+
+async function migratePosts() {
+  if (!db) throw new Error("Database not configured");
+
+  const rows = await db
+    .select({ id: posts.id, imageUrl: posts.imageUrl, additionalImages: posts.additionalImages })
+    .from(posts)
+    .where(
+      or(
+        like(posts.imageUrl, "data:%"),
+        sql`${posts.additionalImages}::text LIKE '%data:%'`
+      )!
+    );
+
+  console.log(`[posts] Found ${rows.length} rows with base64 data`);
+
+  for (const row of rows) {
+    let changed = false;
+    let newImageUrl = row.imageUrl;
+    let newAdditionalImages = (row.additionalImages as string[]) ?? [];
+
+    if (row.imageUrl.startsWith("data:")) {
+      const { url, bytes } = await saveDataUri(row.imageUrl);
+      console.log(`  [posts] id=${row.id} image_url -> ${url} (${(bytes / 1024).toFixed(1)} KB)`);
+      newImageUrl = url;
+      changed = true;
+    }
+
+    const migratedAdditional = await Promise.all(
+      newAdditionalImages.map(async (img) => {
+        if (!img.startsWith("data:")) return img;
+        const { url, bytes } = await saveDataUri(img);
+        console.log(`  [posts] id=${row.id} additional_image -> ${url} (${(bytes / 1024).toFixed(1)} KB)`);
+        changed = true;
+        return url;
+      })
+    );
+
+    if (changed) {
+      await db
+        .update(posts)
+        .set({
+          imageUrl: newImageUrl,
+          additionalImages: migratedAdditional,
+        })
+        .where(sql`${posts.id} = ${row.id}`);
+    }
+  }
+}
+
+async function migrateRecipes() {
+  if (!db) throw new Error("Database not configured");
+
+  const rows = await db
+    .select({ id: recipes.id, imageUrl: recipes.imageUrl })
+    .from(recipes)
+    .where(like(recipes.imageUrl!, "data:%"));
+
+  console.log(`[recipes] Found ${rows.length} rows with base64 data`);
+
+  for (const row of rows) {
+    if (!row.imageUrl?.startsWith("data:")) continue;
+    const { url, bytes } = await saveDataUri(row.imageUrl);
+    console.log(`  [recipes] id=${row.id} image_url -> ${url} (${(bytes / 1024).toFixed(1)} KB)`);
+    await db
+      .update(recipes)
+      .set({ imageUrl: url })
+      .where(sql`${recipes.id} = ${row.id}`);
+  }
+}
+
+async function migrateStories() {
+  if (!db) throw new Error("Database not configured");
+
+  const rows = await db
+    .select({ id: stories.id, imageUrl: stories.imageUrl })
+    .from(stories)
+    .where(like(stories.imageUrl, "data:%"));
+
+  console.log(`[stories/bites] Found ${rows.length} rows with base64 data`);
+
+  for (const row of rows) {
+    if (!row.imageUrl.startsWith("data:")) continue;
+    const { url, bytes } = await saveDataUri(row.imageUrl);
+    console.log(`  [stories] id=${row.id} image_url -> ${url} (${(bytes / 1024).toFixed(1)} KB)`);
+    await db
+      .update(stories)
+      .set({ imageUrl: url })
+      .where(sql`${stories.id} = ${row.id}`);
+  }
+}
+
+async function main() {
+  console.log("Starting base64 image migration...");
+  await ensureUploadsDir();
+
+  await migratePosts();
+  await migrateRecipes();
+  await migrateStories();
+
+  console.log("Migration complete.");
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
- Add POST /api/upload/image using sharp: resizes to 1600px webp (q80),
  generates 480px thumbnail (q75), preserves GIF animation as-is
- Update create-post-modal: upload files to /api/upload/image before
  submit; local FileReader only for instant preview; isUploading state
  disables submit and shows "Uploading…" indicator; videos use existing
  /api/upload route; no data URIs ever stored
- Add server/lib/data-uri.ts: persistDataUri() safety net persists any
  stray base64 data URIs arriving in JSON to disk files
- Apply persistDataUri in posts.ts (imageUrl, additionalImages,
  recipe.imageUrl) and bites.ts (imageUrl) before DB insert
- Add server/scripts/migrate-base64-images.ts: idempotent migration of
  existing base64 rows in posts, recipes, and stories tables; add
  db:migrate:images npm script
- server/app.ts: add maxAge=365d + immutable to /uploads static, reduce
  express.json/urlencoded limits from 50mb to 2mb
- feed.tsx: add loading="lazy" decoding="async" to all <img> elements

https://claude.ai/code/session_01QovRoZYHPxFMNWaq2Kj7MN