### PR TITLE
Unify uploads directory and fix stale-upload race conditions in media handlers

### DIFF
--- a/client/src/pages/clubs/[id].tsx
+++ b/client/src/pages/clubs/[id].tsx
@@ -223,6 +223,8 @@ export default function ClubPage() {
   const [newPostImageFile, setNewPostImageFile] = useState<File | null>(null);
   const [newPostImagePreview, setNewPostImagePreview] = useState<string>("");
   const [newPostMediaKind, setNewPostMediaKind] = useState<MediaKind>("");
+  const [isNewPostUploading, setIsNewPostUploading] = useState(false);
+  const newPostSelectToken = useRef(0);
 
   // Recipe fields
   const [recipeTitle, setRecipeTitle] = useState("");
@@ -321,7 +323,7 @@ export default function ClubPage() {
   const isMember = !!stats?.isMember;
   const isAdmin = !!stats?.isAdmin;
 
-  const handleNewPostMediaChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleNewPostMediaChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
@@ -340,12 +342,44 @@ export default function ClubPage() {
       return;
     }
 
+    const token = ++newPostSelectToken.current;
     setNewPostMediaKind(kind);
     setNewPostImageFile(file);
+    setNewPostImagePreview("");
 
     const reader = new FileReader();
-    reader.onload = () => setNewPostImagePreview(String(reader.result || ""));
+    reader.onload = () => {
+      if (newPostSelectToken.current !== token) return;
+      setNewPostImagePreview(String(reader.result || ""));
+    };
     reader.readAsDataURL(file);
+
+    setIsNewPostUploading(true);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const res = await fetch(kind === "video" ? "/api/upload" : "/api/upload/image", {
+        method: "POST",
+        credentials: "include",
+        body: fd,
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err?.error ?? "Upload failed");
+      }
+      const data = await res.json();
+      if (newPostSelectToken.current !== token) return;
+      setNewPostImagePreview(data.url);
+    } catch (err: any) {
+      if (newPostSelectToken.current !== token) return;
+      setNewPostImagePreview("");
+      setNewPostImageFile(null);
+      setNewPostMediaKind("");
+      toast({ variant: "destructive", description: err.message || "Upload failed" });
+    } finally {
+      if (newPostSelectToken.current === token) setIsNewPostUploading(false);
+      e.target.value = "";
+    }
   };
 
   // Join / Leave
@@ -1194,9 +1228,9 @@ export default function ClubPage() {
                       <Button
                         type="button"
                         onClick={() => createClubPostMutation.mutate()}
-                        disabled={createClubPostMutation.isPending}
+                        disabled={createClubPostMutation.isPending || isNewPostUploading}
                       >
-                        {createClubPostMutation.isPending ? "Posting..." : "Post"}
+                        {isNewPostUploading ? "Uploading..." : createClubPostMutation.isPending ? "Posting..." : "Post"}
                       </Button>
                     </div>
                   </>

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { Link } from "wouter";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
@@ -145,6 +145,9 @@ export default function SettingsPage() {
   });
 
   const [isSaving, setIsSaving] = useState(false);
+  const avatarSelectToken = useRef(0);
+  const [avatarPreview, setAvatarPreview] = useState(user?.avatar || "");
+  const [isAvatarUploading, setIsAvatarUploading] = useState(false);
 
   const [accountType, setAccountType] = useState<"personal" | "business">(user?.isChef ? "business" : "personal");
 
@@ -2485,6 +2488,15 @@ function SubscriptionSettingsPanel() {
       return;
     }
 
+    if (isAvatarUploading) {
+      toast({
+        title: "Avatar upload in progress",
+        description: "Please wait for your profile picture to finish uploading before saving.",
+        variant: "destructive",
+      });
+      return;
+    }
+
     setIsSaving(true);
     try {
       const response = await fetch(`/api/users/${user.id}`, {
@@ -2665,8 +2677,8 @@ function SubscriptionSettingsPanel() {
                   <Label>Profile Picture</Label>
                   <div className="flex items-center gap-4 mt-2">
                     <div className="w-20 h-20 rounded-full bg-gray-200 flex items-center justify-center overflow-hidden">
-                      {profile.avatar ? (
-                        <img src={profile.avatar} alt="Avatar" className="w-full h-full object-cover" />
+                      {avatarPreview || profile.avatar ? (
+                        <img src={avatarPreview || profile.avatar} alt="Avatar" className="w-full h-full object-cover" />
                       ) : (
                         <User size={32} className="text-gray-400" />
                       )}
@@ -2676,23 +2688,48 @@ function SubscriptionSettingsPanel() {
                         type="button"
                         variant="outline"
                         onClick={() => document.getElementById("avatar-upload")?.click()}
+                        disabled={isAvatarUploading}
                       >
                         <Upload size={16} className="mr-2" />
-                        Upload Photo
+                        {isAvatarUploading ? "Uploading..." : "Upload Photo"}
                       </Button>
                       <input
                         id="avatar-upload"
                         type="file"
                         accept="image/*"
                         className="hidden"
-                        onChange={(e) => {
+                        onChange={async (e) => {
                           const file = e.target.files?.[0];
-                          if (file) {
-                            const reader = new FileReader();
-                            reader.onloadend = () => {
-                              setProfile({ ...profile, avatar: reader.result as string });
-                            };
-                            reader.readAsDataURL(file);
+                          if (!file) return;
+                          const token = ++avatarSelectToken.current;
+                          const prevAvatar = profile.avatar;
+                          setIsAvatarUploading(true);
+                          const reader = new FileReader();
+                          reader.onloadend = () => {
+                            if (avatarSelectToken.current !== token) return;
+                            setAvatarPreview(reader.result as string);
+                          };
+                          reader.readAsDataURL(file);
+                          try {
+                            const fd = new FormData();
+                            fd.append("file", file);
+                            const res = await fetch("/api/upload/image", {
+                              method: "POST",
+                              credentials: "include",
+                              body: fd,
+                            });
+                            if (!res.ok) throw new Error("Upload failed");
+                            const data = await res.json();
+                            if (avatarSelectToken.current !== token) return;
+                            setAvatarPreview(data.url);
+                            setProfile((p) => ({ ...p, avatar: data.url }));
+                          } catch {
+                            if (avatarSelectToken.current !== token) return;
+                            setAvatarPreview(prevAvatar);
+                            setProfile((p) => ({ ...p, avatar: prevAvatar }));
+                          } finally {
+                            if (avatarSelectToken.current === token) setIsAvatarUploading(false);
+                            e.target.value = "";
                           }
                         }}
                       />
@@ -2733,9 +2770,9 @@ function SubscriptionSettingsPanel() {
                   <p className="text-xs text-gray-500 mt-1">{profile.bio.length}/500 characters</p>
                 </div>
 
-                <Button onClick={handleSaveProfile} className="bg-orange-500 hover:bg-orange-600" disabled={isSaving}>
+                <Button onClick={handleSaveProfile} className="bg-orange-500 hover:bg-orange-600" disabled={isSaving || isAvatarUploading}>
                   <Save size={16} className="mr-2" />
-                  {isSaving ? "Saving..." : "Save Profile"}
+                  {isAvatarUploading ? "Uploading avatar..." : isSaving ? "Saving..." : "Save Profile"}
                 </Button>
               </CardContent>
             </Card>

--- a/client/src/pages/social/create-post.tsx
+++ b/client/src/pages/social/create-post.tsx
@@ -226,21 +226,46 @@ export default function CreatePost() {
 
   const [showCamera, setShowCamera] = useState(false);
 
-  const handleCameraCapture = (dataUrl: string, type: "image" | "video") => {
+  const handleCameraCapture = async (dataUrl: string, type: "image" | "video") => {
     const kind: MediaKind = type;
-    // For bite/clip, feed the capture into the bite media state
     if (formData.postType === "bite" || formData.postType === "clip") {
+      const token = ++biteSelectToken.current;
       setBiteMediaType(type);
-      setBiteMediaUrl(dataUrl);
+      setBiteMediaUrl("");
+      setBiteMediaPreview(dataUrl);
+      setIsBiteUploading(true);
+      try {
+        const url = await uploadMediaUrl(dataUrl);
+        if (biteSelectToken.current !== token) return;
+        setBiteMediaUrl(url);
+      } catch {
+        if (biteSelectToken.current !== token) return;
+        setBiteMediaPreview("");
+        setBiteMediaUrl("");
+        toast({ variant: "destructive", description: "Upload failed" });
+      } finally {
+        if (biteSelectToken.current === token) setIsBiteUploading(false);
+      }
       return;
     }
+    const token = ++imageSelectToken.current;
     setMediaPreview(dataUrl);
     setMediaKind(kind);
-    setFormData((prev) => ({
-      ...prev,
-      imageUrl: dataUrl,
-      additionalImages: [],
-    }));
+    setFormData((prev) => ({ ...prev, imageUrl: "", additionalImages: [] }));
+    setIsUploading(true);
+    try {
+      const url = await uploadMediaUrl(dataUrl);
+      if (imageSelectToken.current !== token) return;
+      setFormData((prev) => ({ ...prev, imageUrl: url, additionalImages: [] }));
+    } catch {
+      if (imageSelectToken.current !== token) return;
+      setMediaPreview("");
+      setMediaKind("");
+      setFormData((prev) => ({ ...prev, imageUrl: "", additionalImages: [] }));
+      toast({ variant: "destructive", description: "Upload failed" });
+    } finally {
+      if (imageSelectToken.current === token) setIsUploading(false);
+    }
   };
 
   // Bite / Clip state
@@ -252,22 +277,57 @@ export default function CreatePost() {
     "video",
   );
   const [biteSubmitting, setBiteSubmitting] = useState(false);
+  const imageSelectToken = useRef(0);
+  const biteSelectToken = useRef(0);
+  const [biteMediaPreview, setBiteMediaPreview] = useState("");
+  const [isUploading, setIsUploading] = useState(false);
+  const [isBiteUploading, setIsBiteUploading] = useState(false);
 
-  const handleBiteFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleBiteFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    setBiteMediaType(file.type.startsWith("video/") ? "video" : "image");
+    const token = ++biteSelectToken.current;
+    const isVideo = file.type.startsWith("video/");
+    setBiteMediaType(isVideo ? "video" : "image");
+    setBiteMediaUrl("");
+    setBiteMediaPreview("");
     const reader = new FileReader();
-    reader.onloadend = () => setBiteMediaUrl(reader.result as string);
+    reader.onloadend = () => {
+      if (biteSelectToken.current !== token) return;
+      setBiteMediaPreview(reader.result as string);
+    };
     reader.readAsDataURL(file);
+    setIsBiteUploading(true);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const res = await fetch(isVideo ? "/api/upload" : "/api/upload/image", {
+        method: "POST",
+        credentials: "include",
+        body: fd,
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err?.error ?? "Upload failed");
+      }
+      const data = await res.json();
+      if (biteSelectToken.current !== token) return;
+      setBiteMediaUrl(data.url);
+    } catch (err: any) {
+      if (biteSelectToken.current !== token) return;
+      setBiteMediaPreview("");
+      setBiteMediaUrl("");
+      toast({ variant: "destructive", description: err.message || "Upload failed" });
+    } finally {
+      if (biteSelectToken.current === token) setIsBiteUploading(false);
+      e.target.value = "";
+    }
   };
 
   const handleBiteSubmit = async () => {
     if (!user?.id || !biteMediaUrl) return;
     setBiteSubmitting(true);
     try {
-      toast({ description: "Uploading media…" });
-      const storedUrl = await uploadMediaUrl(biteMediaUrl);
       const expiresAt =
         biteExpiry === "permanent"
           ? new Date(Date.now() + 100 * 365 * 24 * 60 * 60 * 1000).toISOString()
@@ -278,7 +338,7 @@ export default function CreatePost() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           userId: user.id,
-          imageUrl: storedUrl,
+          imageUrl: biteMediaUrl,
           mediaType: biteMediaType,
           caption: formData.caption || undefined,
           expiresAt,
@@ -542,7 +602,7 @@ export default function CreatePost() {
     setFormData((prev) => ({ ...prev, [field]: value }));
   };
 
-  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? []);
     if (!files.length) return;
 
@@ -568,58 +628,80 @@ export default function CreatePost() {
       return;
     }
 
-    const readFileAsDataUrl = (file: File) =>
-      new Promise<string>((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onloadend = () => resolve(reader.result as string);
-        reader.onerror = () => reject(new Error(`Failed to read ${file.name}`));
-        reader.readAsDataURL(file);
-      });
+    const token = ++imageSelectToken.current;
+    const firstFile = files[0];
+    const kind: MediaKind = firstFile.type.startsWith("video/") ? "video" : "image";
 
-    Promise.all(files.map(readFileAsDataUrl))
-      .then((results) => {
-        const firstFile = files[0];
-        const kind: MediaKind = firstFile.type.startsWith("video/")
-          ? "video"
-          : "image";
+    setMediaFile(firstFile);
+    setMediaKind(kind);
+    setFormData((prev) => ({ ...prev, imageUrl: "", additionalImages: [] }));
 
-        setMediaFile(firstFile);
-        setMediaPreview(results[0] ?? "");
-        setMediaKind(kind);
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      if (imageSelectToken.current !== token) return;
+      setMediaPreview(reader.result as string);
+    };
+    reader.readAsDataURL(firstFile);
 
-        if (kind === "video") {
-          setFormData((prev) => ({
-            ...prev,
-            imageUrl: results[0] ?? "",
-            additionalImages: [],
-          }));
-          return;
-        }
-
-        const [{ imageUrl, additionalImages }] = [
-          splitPostImages(
-            results.map((url, index) => ({ id: `${index}-${url}`, url })),
-          ),
-        ];
-
-        setFormData((prev) => ({
-          ...prev,
-          imageUrl,
-          additionalImages,
-        }));
-      })
-      .catch((error: Error) => {
-        toast({
-          variant: "destructive",
-          description: error.message || "Failed to load selected files",
+    setIsUploading(true);
+    try {
+      if (kind === "video") {
+        const fd = new FormData();
+        fd.append("file", firstFile);
+        const res = await fetch("/api/upload", {
+          method: "POST",
+          credentials: "include",
+          body: fd,
         });
-      })
-      .finally(() => {
-        e.target.value = "";
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err?.error ?? "Video upload failed");
+        }
+        const data = await res.json();
+        if (imageSelectToken.current !== token) return;
+        setFormData((prev) => ({ ...prev, imageUrl: data.url, additionalImages: [] }));
+      } else {
+        const urls = await Promise.all(
+          files.map(async (file) => {
+            const fd = new FormData();
+            fd.append("file", file);
+            const res = await fetch("/api/upload/image", {
+              method: "POST",
+              credentials: "include",
+              body: fd,
+            });
+            if (!res.ok) {
+              const err = await res.json().catch(() => ({}));
+              throw new Error(err?.error ?? `Failed to upload ${file.name}`);
+            }
+            return (await res.json()).url as string;
+          }),
+        );
+        if (imageSelectToken.current !== token) return;
+        const [{ imageUrl, additionalImages }] = [
+          splitPostImages(urls.map((url, index) => ({ id: `${index}-${url}`, url }))),
+        ];
+        setFormData((prev) => ({ ...prev, imageUrl, additionalImages }));
+      }
+    } catch (error: any) {
+      if (imageSelectToken.current !== token) return;
+      setMediaPreview("");
+      setMediaKind("");
+      setMediaFile(null);
+      setFormData((prev) => ({ ...prev, imageUrl: "", additionalImages: [] }));
+      toast({
+        variant: "destructive",
+        description: error.message || "Failed to upload file",
       });
+    } finally {
+      if (imageSelectToken.current === token) setIsUploading(false);
+      e.target.value = "";
+    }
   };
 
   const clearMedia = () => {
+    ++imageSelectToken.current;
+    setIsUploading(false);
     setMediaFile(null);
     setMediaPreview("");
     setMediaKind("");
@@ -755,6 +837,8 @@ export default function CreatePost() {
     }));
   };
 
+  const bitePreviewSrc = biteMediaPreview || biteMediaUrl;
+
   return (
     <div className="max-w-2xl mx-auto px-4 py-6">
       <Card className="w-full">
@@ -820,17 +904,17 @@ export default function CreatePost() {
                   onChange={handleBiteFileSelect}
                 />
                 <div className="w-full aspect-video bg-muted rounded-xl overflow-hidden border-2 border-dashed border-border">
-                  {biteMediaUrl && biteMediaType === "video" ? (
+                  {bitePreviewSrc && biteMediaType === "video" ? (
                     <video
-                      src={biteMediaUrl}
+                      src={bitePreviewSrc}
                       className="w-full h-full object-cover"
                       controls
                       muted
                       playsInline
                     />
-                  ) : biteMediaUrl ? (
+                  ) : bitePreviewSrc ? (
                     <img
-                      src={biteMediaUrl}
+                      src={bitePreviewSrc}
                       alt="Preview"
                       className="w-full h-full object-cover"
                     />
@@ -1574,16 +1658,18 @@ export default function CreatePost() {
               <Button
                 type="submit"
                 className="w-full"
-                disabled={createPostMutation.isPending || biteSubmitting}
+                disabled={createPostMutation.isPending || biteSubmitting || isUploading || isBiteUploading}
                 data-testid="button-submit-post"
               >
-                {createPostMutation.isPending || biteSubmitting
-                  ? "Posting..."
-                  : formData.postType === "bite"
-                    ? "Share Bite"
-                    : formData.postType === "clip"
-                      ? "Share Clip"
-                      : "Post"}
+                {isUploading || isBiteUploading
+                  ? "Uploading..."
+                  : createPostMutation.isPending || biteSubmitting
+                    ? "Posting..."
+                    : formData.postType === "bite"
+                      ? "Share Bite"
+                      : formData.postType === "clip"
+                        ? "Share Clip"
+                        : "Post"}
               </Button>
             )}
           </form>

--- a/server/app.ts
+++ b/server/app.ts
@@ -13,6 +13,7 @@ import routes from "./routes";
 import { setupGoogleOAuth } from "./services/google-oauth.service";
 import { setupFacebookOAuth } from "./services/facebook-oauth.service";
 import { setupTikTokOAuth } from "./services/tiktok-oauth.service";
+import { UPLOADS_DIR } from "./lib/uploads-dir";
 
 // Define __dirname for ES modules
 const __filename = fileURLToPath(import.meta.url);
@@ -75,11 +76,8 @@ app.get("/api", (_req, res) => {
   });
 });
 
-// Serve uploaded files
-const uploadsDir = path.resolve(process.cwd(), "uploads");
-if (!fs.existsSync(uploadsDir)) {
-  fs.mkdirSync(uploadsDir, { recursive: true });
-}
+// Serve uploaded files — UPLOADS_DIR is the canonical absolute path shared by
+// all write sites (routes/upload.ts, lib/data-uri.ts, routes/auth.ts, etc.).
 const uploadContentTypes: Record<string, string> = {
   ".mp4": "video/mp4",
   ".mov": "video/quicktime",
@@ -88,7 +86,7 @@ const uploadContentTypes: Record<string, string> = {
 
 app.use(
   "/uploads",
-  express.static(uploadsDir, {
+  express.static(UPLOADS_DIR, {
     maxAge: "365d",
     immutable: true,
     setHeaders: (res, filePath) => {

--- a/server/lib/data-uri.ts
+++ b/server/lib/data-uri.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "crypto";
 import path from "path";
 import fs from "fs/promises";
-import { existsSync, mkdirSync } from "fs";
+import { UPLOADS_DIR, uploadUrlPath } from "./uploads-dir";
 
 const MIME_TO_EXT: Record<string, string> = {
   "image/jpeg": "jpg",
@@ -29,13 +29,8 @@ export async function persistDataUri(value: string): Promise<string> {
 
   const ext = MIME_TO_EXT[mime] ?? "bin";
   const filename = `${randomUUID()}.${ext}`;
-  const uploadsDir = path.join(process.cwd(), "uploads");
 
-  if (!existsSync(uploadsDir)) {
-    mkdirSync(uploadsDir, { recursive: true });
-  }
+  await fs.writeFile(path.join(UPLOADS_DIR, filename), buffer);
 
-  await fs.writeFile(path.join(uploadsDir, filename), buffer);
-
-  return `/uploads/${filename}`;
+  return uploadUrlPath(filename);
 }

--- a/server/lib/uploads-dir.ts
+++ b/server/lib/uploads-dir.ts
@@ -1,0 +1,31 @@
+/**
+ * Single source of truth for the uploads directory path.
+ *
+ * Path calculation (stable regardless of process.cwd()):
+ *   server/lib/uploads-dir.ts  (this file, or server/dist/index.js in the esbuild bundle)
+ *   ../   → server/
+ *   ../../ → project root  (= domain root on the Plesk server, sibling of httpdocs)
+ *   ../../uploads → project-root/uploads/
+ *
+ * In the esbuild bundle (server/dist/index.js), import.meta.url resolves to
+ * server/dist/index.js, so ../.. from server/dist/ also lands at the project root —
+ * the path is consistent between `tsx` (dev) and the compiled bundle (prod).
+ */
+import { fileURLToPath } from "url";
+import path from "path";
+import { mkdirSync, existsSync } from "fs";
+
+export const UPLOADS_DIR: string = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../uploads"
+);
+
+// Ensure the directory exists at import time so every module can rely on it.
+if (!existsSync(UPLOADS_DIR)) {
+  mkdirSync(UPLOADS_DIR, { recursive: true });
+}
+
+/** Returns the URL path for a filename stored in UPLOADS_DIR. */
+export function uploadUrlPath(filename: string): string {
+  return `/uploads/${filename}`;
+}

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -16,6 +16,7 @@ import {
   passwordChangeLimiter,
   verifyEmailLimiter,
 } from "../middleware/rate-limit";
+import { UPLOADS_DIR, uploadUrlPath } from "../lib/uploads-dir";
 
 const RAW_SECRET =
   process.env.JWT_SECRET || process.env.SESSION_SECRET || "";
@@ -23,24 +24,15 @@ const JWT_SECRET = RAW_SECRET.trim() || "CHEFSIRE_DEV_FALLBACK_SECRET";
 
 const router = Router();
 
-// Configure multer for avatar uploads
+// Configure multer for avatar uploads — writes to UPLOADS_DIR (canonical absolute path)
 const avatarStorage = multer.diskStorage({
-  destination: (req, file, cb) => {
-    const uploadDir = path.join(process.cwd(), 'uploads');
-    try {
-      if (!fs.existsSync(uploadDir)) {
-        fs.mkdirSync(uploadDir, { recursive: true });
-      }
-      cb(null, uploadDir);
-    } catch (error) {
-      console.error('[UPLOAD] Failed to create uploads directory:', error);
-      cb(error as Error, uploadDir);
-    }
+  destination: (_req, _file, cb) => {
+    cb(null, UPLOADS_DIR);
   },
-  filename: (req, file, cb) => {
+  filename: (_req, file, cb) => {
     const uniqueName = `avatar-${randomUUID()}${path.extname(file.originalname)}`;
     cb(null, uniqueName);
-  }
+  },
 });
 
 const avatarUpload = multer({
@@ -109,7 +101,7 @@ router.post("/auth/signup", signupLimiter, avatarUpload.single('avatar'), async 
     const hashedPassword = await bcrypt.hash(password, 10);
 
     // Handle avatar URL (if file was uploaded, it will be in /uploads)
-    const avatarUrl = avatarFile ? `/uploads/${avatarFile.filename}` : null;
+    const avatarUrl = avatarFile ? uploadUrlPath(avatarFile.filename) : null;
 
     // Create user
     const newUser = await storage.createUser({

--- a/server/routes/reviews.ts
+++ b/server/routes/reviews.ts
@@ -15,9 +15,11 @@ import {
 import { eq, desc, and, sql, inArray } from "drizzle-orm";
 import multer from "multer";
 import path from "path";
+import fs from "fs";
 import { requireAuth } from "../middleware/auth";
 import { RecipeService } from "../services/recipe.service";
 import { sendRecipeReviewNotification } from "../services/notification-service";
+import { UPLOADS_DIR, uploadUrlPath } from "../lib/uploads-dir";
 
 const router = Router();
 
@@ -217,12 +219,17 @@ async function resolveRecipeIdentityForReview(recipeId: string): Promise<Resolve
   };
 }
 
-// Multer config for review photos
+// Multer config for review photos — writes to UPLOADS_DIR/reviews/ (absolute, canonical path)
+const reviewsSubdir = path.join(UPLOADS_DIR, "reviews");
+if (!fs.existsSync(reviewsSubdir)) {
+  fs.mkdirSync(reviewsSubdir, { recursive: true });
+}
+
 const multerStorage = multer.diskStorage({
-  destination: (req, file, cb) => {
-    cb(null, "uploads/reviews/");
+  destination: (_req, _file, cb) => {
+    cb(null, reviewsSubdir);
   },
-  filename: (req, file, cb) => {
+  filename: (_req, file, cb) => {
     const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
     cb(null, `review-${uniqueSuffix}${path.extname(file.originalname)}`);
   },
@@ -706,7 +713,7 @@ router.post(
       // Create photo record
       const photoData: InsertRecipeReviewPhoto = {
         reviewId,
-        photoUrl: `/uploads/reviews/${req.file.filename}`,
+        photoUrl: uploadUrlPath(`reviews/${req.file.filename}`),
         caption: caption || null,
       };
 

--- a/server/routes/upload.ts
+++ b/server/routes/upload.ts
@@ -5,28 +5,19 @@ import { randomUUID } from "crypto";
 import { requireAuth } from "../middleware";
 import fs from "fs";
 import sharp from "sharp";
+import { UPLOADS_DIR, uploadUrlPath } from "../lib/uploads-dir";
 
 const router = Router();
 
-// Configure multer for general file uploads (disk storage)
+// Configure multer for general file uploads (disk storage → UPLOADS_DIR)
 const storage = multer.diskStorage({
-  destination: (req, file, cb) => {
-    const uploadDir = path.join(process.cwd(), 'uploads');
-
-    try {
-      if (!fs.existsSync(uploadDir)) {
-        fs.mkdirSync(uploadDir, { recursive: true });
-      }
-      cb(null, uploadDir);
-    } catch (error) {
-      console.error('[UPLOAD] Failed to create uploads directory:', error);
-      cb(error as Error, uploadDir);
-    }
+  destination: (_req, _file, cb) => {
+    cb(null, UPLOADS_DIR);
   },
-  filename: (req, file, cb) => {
+  filename: (_req, file, cb) => {
     const uniqueName = `${randomUUID()}${path.extname(file.originalname)}`;
     cb(null, uniqueName);
-  }
+  },
 });
 
 const upload = multer({
@@ -34,7 +25,7 @@ const upload = multer({
   limits: {
     fileSize: 100 * 1024 * 1024, // 100MB
   },
-  fileFilter: (req, file, cb) => {
+  fileFilter: (_req, file, cb) => {
     const allowedTypes = [
       'application/pdf',
       'application/msword',
@@ -59,7 +50,7 @@ const upload = multer({
     } else {
       cb(new Error('Invalid file type. Only PDF, DOC, Excel, videos, images, and ZIP files are allowed.'));
     }
-  }
+  },
 });
 
 // POST /api/upload - General file upload (videos, docs, etc.)
@@ -85,14 +76,14 @@ router.post("/", requireAuth, (req, res) => {
 
       const protocol = req.get('x-forwarded-proto') || req.protocol;
       const host = req.get('x-forwarded-host') || req.get('host');
-      const fileUrl = `${protocol}://${host}/uploads/${req.file.filename}`;
+      const fileUrl = `${protocol}://${host}${uploadUrlPath(req.file.filename)}`;
 
       res.json({
         ok: true,
         url: fileUrl,
         filename: req.file.originalname,
         size: req.file.size,
-        mimetype: req.file.mimetype
+        mimetype: req.file.mimetype,
       });
     } catch (error: any) {
       console.error("Error processing upload:", error);
@@ -132,28 +123,22 @@ router.post("/image", requireAuth, (req, res) => {
         return res.status(400).json({ ok: false, error: "No file uploaded" });
       }
 
-      const uploadsDir = path.join(process.cwd(), 'uploads');
-      if (!fs.existsSync(uploadsDir)) {
-        fs.mkdirSync(uploadsDir, { recursive: true });
-      }
-
       const protocol = req.get('x-forwarded-proto') || req.protocol;
       const host = req.get('x-forwarded-host') || req.get('host');
 
       // GIFs are saved as-is to preserve animation
       if (req.file.mimetype === 'image/gif') {
         const filename = `${randomUUID()}.gif`;
-        const filepath = path.join(uploadsDir, filename);
-        fs.writeFileSync(filepath, req.file.buffer);
-        const url = `${protocol}://${host}/uploads/${filename}`;
+        fs.writeFileSync(path.join(UPLOADS_DIR, filename), req.file.buffer);
+        const url = `${protocol}://${host}${uploadUrlPath(filename)}`;
         return res.json({ ok: true, url, thumbUrl: url });
       }
 
       const uuid = randomUUID();
       const mainFilename = `${uuid}.webp`;
       const thumbFilename = `${uuid}_thumb.webp`;
-      const mainPath = path.join(uploadsDir, mainFilename);
-      const thumbPath = path.join(uploadsDir, thumbFilename);
+      const mainPath = path.join(UPLOADS_DIR, mainFilename);
+      const thumbPath = path.join(UPLOADS_DIR, thumbFilename);
 
       await sharp(req.file.buffer)
         .rotate()
@@ -167,8 +152,8 @@ router.post("/image", requireAuth, (req, res) => {
         .webp({ quality: 75 })
         .toFile(thumbPath);
 
-      const url = `${protocol}://${host}/uploads/${mainFilename}`;
-      const thumbUrl = `${protocol}://${host}/uploads/${thumbFilename}`;
+      const url = `${protocol}://${host}${uploadUrlPath(mainFilename)}`;
+      const thumbUrl = `${protocol}://${host}${uploadUrlPath(thumbFilename)}`;
 
       res.json({ ok: true, url, thumbUrl });
     } catch (error: any) {

--- a/server/scripts/migrate-base64-images.ts
+++ b/server/scripts/migrate-base64-images.ts
@@ -7,11 +7,11 @@
 import "dotenv/config";
 import path from "path";
 import fs from "fs/promises";
-import { existsSync, mkdirSync } from "fs";
 import { randomUUID } from "crypto";
 import { db } from "../db";
 import { posts, recipes, stories } from "../../shared/schema";
 import { sql, like, or } from "drizzle-orm";
+import { UPLOADS_DIR } from "../lib/uploads-dir";
 
 const MIME_TO_EXT: Record<string, string> = {
   "image/jpeg": "jpg",
@@ -24,14 +24,6 @@ const MIME_TO_EXT: Record<string, string> = {
   "video/quicktime": "mov",
 };
 
-const uploadsDir = path.join(process.cwd(), "uploads");
-
-async function ensureUploadsDir() {
-  if (!existsSync(uploadsDir)) {
-    mkdirSync(uploadsDir, { recursive: true });
-  }
-}
-
 async function saveDataUri(dataUri: string): Promise<{ url: string; bytes: number }> {
   const match = dataUri.match(/^data:([^;]+);base64,([\s\S]+)$/);
   if (!match) throw new Error("Invalid data URI format");
@@ -40,7 +32,7 @@ async function saveDataUri(dataUri: string): Promise<{ url: string; bytes: numbe
   const buffer = Buffer.from(base64, "base64");
   const ext = MIME_TO_EXT[mime] ?? "bin";
   const filename = `${randomUUID()}.${ext}`;
-  const filepath = path.join(uploadsDir, filename);
+  const filepath = path.join(UPLOADS_DIR, filename);
 
   await fs.writeFile(filepath, buffer);
 
@@ -139,8 +131,7 @@ async function migrateStories() {
 }
 
 async function main() {
-  console.log("Starting base64 image migration...");
-  await ensureUploadsDir();
+  console.log(`Starting base64 image migration... (writing to ${UPLOADS_DIR})`);
 
   await migratePosts();
   await migrateRecipes();


### PR DESCRIPTION
### Motivation
- Ensure a single canonical uploads directory is used by the server to avoid mismatched write/read locations and to make path behavior stable between dev and bundled builds.
- Prevent stale base64 or prior `/uploads` URLs from being persisted when a user selects a new file but the new upload is still in-flight or fails.
- Make client upload flows robust to out-of-order FileReader/fetch responses by cancelling outdated callbacks.

### Description
- Add `server/lib/uploads-dir.ts` as the single source-of-truth `UPLOADS_DIR` and helper `uploadUrlPath`, ensure the dir exists at import time, and use it for static serving in `server/app.ts`.
- Replace ad-hoc `process.cwd()/uploads` usage with `UPLOADS_DIR` and `uploadUrlPath` everywhere the server writes or returns uploaded filenames (`server/lib/data-uri.ts`, `server/routes/upload.ts`, `server/routes/auth.ts`, `server/routes/reviews.ts`, `server/scripts/migrate-base64-images.ts`).
- Update client-side media handlers to separate preview (data: URLs) from committed upload URLs, add per-selection token refs and `isUploading` flags to cancel stale callbacks, and block submit/save while uploads are pending (changes in `client/src/pages/social/create-post.tsx`, `client/src/pages/clubs/[id].tsx`, `client/src/pages/settings.tsx`).
- Add UX improvements for avatar uploads on settings: `avatarPreview`, `isAvatarUploading`, disabled upload/save buttons while uploading, and restore previous avatar on upload failure (`client/src/pages/settings.tsx`).

### Testing
- Ran `git diff --check` with no reported problems (local static checks passed). 
- Kicked off TypeScript compilation via `npm run check` (tsc) but it did not complete within the environment timeout, so full type-check results are incomplete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31850531b8832597682d30d2826609)