### PR TITLE
Add Vite vendor chunk splitting

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,38 @@ export default defineConfig(async ({ mode }) => {
     build: {
       outDir: resolve(__dirname, "dist/public"),
       emptyOutDir: true,
+      chunkSizeWarningLimit: 1000,
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (!id.includes("node_modules")) {
+              return undefined;
+            }
+
+            if (/[\\/]node_modules[\\/](react|react-dom|wouter)[\\/]/.test(id)) {
+              return "vendor-react";
+            }
+
+            if (/[\\/]node_modules[\\/](recharts|d3-[^\\/]+)[\\/]/.test(id)) {
+              return "vendor-charts";
+            }
+
+            if (/[\\/]node_modules[\\/]framer-motion[\\/]/.test(id)) {
+              return "vendor-motion";
+            }
+
+            if (/[\\/]node_modules[\\/]@tanstack[\\/]react-query[\\/]/.test(id)) {
+              return "vendor-query";
+            }
+
+            if (/[\\/]node_modules[\\/](date-fns|lodash)[\\/]/.test(id)) {
+              return "vendor-utils";
+            }
+
+            return "vendor";
+          },
+        },
+      },
     },
     server: {
       fs: {


### PR DESCRIPTION
### Motivation
- Reduce per-route bundle duplication and improve long-term caching by extracting large shared libraries into stable vendor chunks.
- Provide explicit, stable chunk names for heavy libraries so updates to app routes don’t invalidate unrelated caches.

### Description
- Added `build.chunkSizeWarningLimit: 1000` to quiet oversized chunk warnings while keeping `outDir` and `emptyOutDir` unchanged.
- Added `build.rollupOptions.output.manualChunks` as a function that routes modules with `id.includes("node_modules")` into named vendor chunks for React/router (`vendor-react`), Recharts and `d3-*` (`vendor-charts`), Framer Motion (`vendor-motion`), `@tanstack/react-query` (`vendor-query`), `date-fns`/`lodash` (`vendor-utils`), and a fallback `vendor` for all other `node_modules` packages.
- Left `root`, `resolve.alias`, and `server.fs` settings untouched and preserved the existing build output paths.

### Testing
- Ran `npm run build` and the build completed successfully without errors.
- Verified emitted vendor chunk files in `dist/public/assets` including `vendor-react`, `vendor-charts`, `vendor-query`, `vendor-utils`, and a generic `vendor` chunk via `find dist/public/assets -name 'vendor-*.js'`.
- Confirmed `recharts` content appears only in the `vendor-charts` chunk by scanning built assets for `recharts`/`Recharts` markers, and no route page chunk contained `recharts` outside `vendor-charts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31ba5fff40832582891c6d1e26f2b7)