### PR TITLE
Revert Vite manual vendor chunking

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,38 +31,6 @@ export default defineConfig(async ({ mode }) => {
     build: {
       outDir: resolve(__dirname, "dist/public"),
       emptyOutDir: true,
-      chunkSizeWarningLimit: 1000,
-      rollupOptions: {
-        output: {
-          manualChunks(id) {
-            if (!id.includes("node_modules")) {
-              return undefined;
-            }
-
-            if (/[\\/]node_modules[\\/](react|react-dom|wouter)[\\/]/.test(id)) {
-              return "vendor-react";
-            }
-
-            if (/[\\/]node_modules[\\/](recharts|d3-[^\\/]+)[\\/]/.test(id)) {
-              return "vendor-charts";
-            }
-
-            if (/[\\/]node_modules[\\/]framer-motion[\\/]/.test(id)) {
-              return "vendor-motion";
-            }
-
-            if (/[\\/]node_modules[\\/]@tanstack[\\/]react-query[\\/]/.test(id)) {
-              return "vendor-query";
-            }
-
-            if (/[\\/]node_modules[\\/](date-fns|lodash)[\\/]/.test(id)) {
-              return "vendor-utils";
-            }
-
-            return "vendor";
-          },
-        },
-      },
     },
     server: {
       fs: {


### PR DESCRIPTION
### Motivation
- Revert the recent manual Vite vendor chunk splitting added in `vite.config.ts` because it changed production bundling behavior and resulted in a white page after the prior PR.

### Description
- Removed the manual chunking configuration from `vite.config.ts` (deleted `chunkSizeWarningLimit` and the `rollupOptions.output.manualChunks` implementation) to restore the prior Vite build output.

### Testing
- Ran `npm run build:client` and confirmed the production client build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31c6d72f888325919ec8060cfb1f6d)