### PR TITLE
Normalize upload URLs and return root-relative upload paths

### DIFF
--- a/client/src/components/post-card.tsx
+++ b/client/src/components/post-card.tsx
@@ -8,6 +8,7 @@ import { MoreHorizontal, Plus, Minus, CalendarDays, ChevronLeft, ChevronRight } 
 import { useMutation, useQueryClient, useQuery } from "@tanstack/react-query";
 import { shareContent, getPostShareUrl } from "@/lib/share";
 import { Link } from "wouter";
+import { normalizeMediaUrl } from "@/lib/mediaUrl";
 
 // Import UI primitives from their individual modules (do not import the directory)
 import { Card } from "@/components/ui/card";
@@ -125,7 +126,7 @@ function normalizeSteps(steps: string[]): string[] {
 
 function getPostImageGallery(post: PostWithUser): string[] {
   return [post.imageUrl, ...(post.additionalImages ?? [])]
-    .map((image) => String(image ?? "").trim())
+    .map((image) => normalizeMediaUrl(image))
     .filter((image, index, images) => Boolean(image) && images.indexOf(image) === index);
 }
 
@@ -506,7 +507,7 @@ export default function PostCard({
   };
 
   const isVideo = (() => {
-    const url = post.imageUrl ?? "";
+    const url = normalizeMediaUrl(post.imageUrl);
     if (!url) return false;
     if (url.startsWith("data:video/")) return true;
     const clean = url.toLowerCase().split("?")[0];
@@ -537,7 +538,7 @@ export default function PostCard({
             <a>
               <Avatar className="w-10 h-10 cursor-pointer hover:opacity-80 transition-opacity">
                 <AvatarImage
-                  src={post.user.avatar || ""}
+                  src={normalizeMediaUrl(post.user.avatar)}
                   alt={post.user.displayName}
                 />
                 <AvatarFallback>
@@ -646,7 +647,7 @@ export default function PostCard({
       >
         {isVideo ? (
           <video
-            src={post.imageUrl}
+            src={normalizeMediaUrl(post.imageUrl)}
             controls
             muted
             playsInline

--- a/client/src/lib/mediaUrl.ts
+++ b/client/src/lib/mediaUrl.ts
@@ -1,0 +1,30 @@
+const UPLOADS_PATH_PREFIX = "/uploads/";
+
+/**
+ * Returns a browser-safe media URL for stored uploads.
+ *
+ * Older rows may contain absolute upload URLs generated from whatever host or
+ * protocol the server saw at upload time. When the app is later served from a
+ * different host, or through HTTPS behind a proxy, those absolute URLs can break
+ * feed images through stale hosts or mixed-content blocking. Uploads are served
+ * by this app, so same-app upload URLs should be rendered as root-relative
+ * paths while external images are left untouched.
+ */
+export function normalizeMediaUrl(value?: string | null): string {
+  const raw = String(value ?? "").trim();
+  if (!raw) return "";
+
+  if (raw.startsWith(UPLOADS_PATH_PREFIX)) return raw;
+  if (raw.startsWith("data:")) return raw;
+
+  try {
+    const url = new URL(raw);
+    if (url.pathname.startsWith(UPLOADS_PATH_PREFIX)) {
+      return `${url.pathname}${url.search}${url.hash}`;
+    }
+  } catch {
+    // Non-URL relative values are intentionally returned as-is.
+  }
+
+  return raw;
+}

--- a/server/routes/upload.ts
+++ b/server/routes/upload.ts
@@ -74,9 +74,7 @@ router.post("/", requireAuth, (req, res) => {
         return res.status(400).json({ ok: false, error: "No file uploaded" });
       }
 
-      const protocol = req.get('x-forwarded-proto') || req.protocol;
-      const host = req.get('x-forwarded-host') || req.get('host');
-      const fileUrl = `${protocol}://${host}${uploadUrlPath(req.file.filename)}`;
+      const fileUrl = uploadUrlPath(req.file.filename);
 
       res.json({
         ok: true,
@@ -123,14 +121,11 @@ router.post("/image", requireAuth, (req, res) => {
         return res.status(400).json({ ok: false, error: "No file uploaded" });
       }
 
-      const protocol = req.get('x-forwarded-proto') || req.protocol;
-      const host = req.get('x-forwarded-host') || req.get('host');
-
       // GIFs are saved as-is to preserve animation
       if (req.file.mimetype === 'image/gif') {
         const filename = `${randomUUID()}.gif`;
         fs.writeFileSync(path.join(UPLOADS_DIR, filename), req.file.buffer);
-        const url = `${protocol}://${host}${uploadUrlPath(filename)}`;
+        const url = uploadUrlPath(filename);
         return res.json({ ok: true, url, thumbUrl: url });
       }
 
@@ -152,8 +147,8 @@ router.post("/image", requireAuth, (req, res) => {
         .webp({ quality: 75 })
         .toFile(thumbPath);
 
-      const url = `${protocol}://${host}${uploadUrlPath(mainFilename)}`;
-      const thumbUrl = `${protocol}://${host}${uploadUrlPath(thumbFilename)}`;
+      const url = uploadUrlPath(mainFilename);
+      const thumbUrl = uploadUrlPath(thumbFilename);
 
       res.json({ ok: true, url, thumbUrl });
     } catch (error: any) {


### PR DESCRIPTION
### Motivation
- Some feed images were rendering broken because older DB rows contained absolute upload URLs (with stale host or http) that can be blocked by mixed-content or proxy changes. 
- Convert same-app upload URLs to root-relative paths and stop returning proxy-derived absolute URLs so feed media remains reachable regardless of host/protocol.

### Description
- Added `client/src/lib/mediaUrl.ts` with `normalizeMediaUrl()` to convert absolute upload URLs whose path starts with `/uploads/` into root-relative paths while leaving external URLs and data URIs untouched. 
- Updated `client/src/components/post-card.tsx` to run `normalizeMediaUrl()` for gallery images, video sources, and user avatars before rendering. 
- Changed `server/routes/upload.ts` to return root-relative upload URLs (`uploadUrlPath(...)`) instead of building absolute `protocol://host` URLs for both general uploads and image uploads. 

### Testing
- `npm run build:client` (which runs `vite build`) completed successfully. 
- `npm run check` (TypeScript type-check) failed, but the failures are from pre-existing unrelated type errors in the repo and are not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34298b057c83258ebd2e24fef8ea92)