### PR TITLE
Allow uploads directory override with UPLOADS_DIR env var

### DIFF
--- a/server/lib/uploads-dir.ts
+++ b/server/lib/uploads-dir.ts
@@ -1,24 +1,32 @@
 /**
  * Single source of truth for the uploads directory path.
  *
- * Path calculation (stable regardless of process.cwd()):
- *   server/lib/uploads-dir.ts  (this file, or server/dist/index.js in the esbuild bundle)
- *   ../   → server/
- *   ../../ → project root  (= domain root on the Plesk server, sibling of httpdocs)
- *   ../../uploads → project-root/uploads/
+ * Prefer an explicit UPLOADS_DIR in production so Plesk deployments can pin the
+ * canonical home-level uploads folder even when the Node app is launched from
+ * httpdocs or from a bundled server/dist entrypoint. Without an override, infer
+ * the repository/domain root from this module location:
  *
- * In the esbuild bundle (server/dist/index.js), import.meta.url resolves to
- * server/dist/index.js, so ../.. from server/dist/ also lands at the project root —
- * the path is consistent between `tsx` (dev) and the compiled bundle (prod).
+ *   server/lib/uploads-dir.ts  (dev, tsx)          → ../../uploads
+ *   server/dist/index.js       (prod, esbuild)     → ../../uploads
+ *
+ * If the compiled server is deployed under httpdocs/server/dist but the real
+ * upload files live beside httpdocs, set UPLOADS_DIR=/path/to/account/uploads.
  */
 import { fileURLToPath } from "url";
 import path from "path";
 import { mkdirSync, existsSync } from "fs";
 
-export const UPLOADS_DIR: string = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "../../uploads"
-);
+function resolveUploadsDir(): string {
+  const configuredDir = process.env.UPLOADS_DIR?.trim();
+
+  if (configuredDir) {
+    return path.resolve(configuredDir);
+  }
+
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../uploads");
+}
+
+export const UPLOADS_DIR: string = resolveUploadsDir();
 
 // Ensure the directory exists at import time so every module can rely on it.
 if (!existsSync(UPLOADS_DIR)) {


### PR DESCRIPTION
### Motivation
- Fix a class of broken image path issues on Plesk/httpdocs deployments where the Node process may be launched from under `httpdocs` (or from a bundled `server/dist`) while the canonical `uploads/` folder lives at the account/home level, so deployments can pin the correct uploads folder explicitly.

### Description
- Add `resolveUploadsDir()` that uses `process.env.UPLOADS_DIR` when present and otherwise falls back to resolving `../../uploads` relative to this module (`server/lib/uploads-dir.ts`).
- Export `UPLOADS_DIR` from the resolver and keep the import-time `mkdirSync`/`existsSync` logic so the directory is created if missing.
- Update file header comments to document the Plesk/httpdocs deployment case and the fallback behavior.

### Testing
- `npm run build:server` completed successfully and produced `server/dist/index.js`.
- `npm run check` (`tsc`) failed due to existing unrelated TypeScript errors across client/server code and not from this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a342f4edc548325b06a7c99168eb23a)