### PR TITLE
Validate data-URI MIME before R2 upload and cap R2 memory uploads to 25MB

### DIFF
--- a/server/lib/data-uri.ts
+++ b/server/lib/data-uri.ts
@@ -28,12 +28,13 @@ export async function persistDataUri(value: string): Promise<string> {
     throw new Error("Data URI exceeds 25MB limit");
   }
 
-  const ext = MIME_TO_EXT[mime] ?? "bin";
-  const filename = `${randomUUID()}.${ext}`;
+  const safeExt = MIME_TO_EXT[mime];
+  const contentType = safeExt ? mime : "application/octet-stream";
+  const filename = `${randomUUID()}.${safeExt ?? "bin"}`;
 
   if (isR2Configured()) {
     const key = `posts/${filename}`;
-    await uploadToR2(key, buffer, mime);
+    await uploadToR2(key, buffer, contentType);
     return publicUrl(key);
   }
 

--- a/server/routes/upload.ts
+++ b/server/routes/upload.ts
@@ -9,6 +9,8 @@ import { UPLOADS_DIR, uploadUrlPath } from "../lib/uploads-dir";
 import { isR2Configured, publicUrl, uploadToR2 } from "../lib/r2";
 
 const router = Router();
+const GENERAL_UPLOAD_LIMIT_BYTES = 100 * 1024 * 1024;
+const R2_MEMORY_UPLOAD_LIMIT_BYTES = 25 * 1024 * 1024;
 
 // Configure multer for general file uploads (disk storage → UPLOADS_DIR)
 const storage = multer.diskStorage({
@@ -24,7 +26,7 @@ const storage = multer.diskStorage({
 const localUpload = multer({
   storage,
   limits: {
-    fileSize: 100 * 1024 * 1024, // 100MB
+    fileSize: GENERAL_UPLOAD_LIMIT_BYTES, // 100MB
   },
   fileFilter: (_req, file, cb) => {
     const allowedTypes = [
@@ -54,11 +56,13 @@ const localUpload = multer({
   },
 });
 
-// POST /api/upload - General file upload (videos, docs, etc.)
+// R2 uploads still use memoryStorage because the current upload path accepts a Multer
+// buffer before PutObject; cap this substantially below the disk-backed 100MB limit so
+// concurrent uploads cannot retain multiple near-100MB files in the Node heap.
 const memoryUpload = multer({
   storage: multer.memoryStorage(),
   limits: {
-    fileSize: 100 * 1024 * 1024, // 100MB
+    fileSize: R2_MEMORY_UPLOAD_LIMIT_BYTES, // 25MB
   },
   fileFilter: (_req, file, cb) => {
     const allowedTypes = [
@@ -119,7 +123,8 @@ router.post("/", requireAuth, (req, res) => {
 
       if (err instanceof multer.MulterError) {
         if (err.code === 'LIMIT_FILE_SIZE') {
-          return res.status(400).json({ ok: false, error: "File is too large. Maximum size is 100MB." });
+          const maxSize = isR2Configured() ? "25MB" : "100MB";
+          return res.status(400).json({ ok: false, error: `File is too large. Maximum size is ${maxSize}.` });
         }
         return res.status(400).json({ ok: false, error: `Upload error: ${err.message}` });
       }


### PR DESCRIPTION
### Motivation
- Prevent client-supplied data URIs with unsafe MIME types (e.g. `data:text/html`) from being uploaded to R2 with an active/renderable `Content-Type` and served as executable content.  
- Reduce memory pressure from the R2-backed upload path where Multer's `memoryStorage()` could buffer large files into the Node heap and risk OOM during concurrent uploads.

### Description
- In `server/lib/data-uri.ts` validate the decoded MIME against the existing `MIME_TO_EXT` map and only preserve the original MIME/extension when it is present in the map; otherwise use `application/octet-stream` as the `ContentType` and `.bin` as the extension for both R2 and local-disk fallback.  
- In `server/routes/upload.ts` introduce `GENERAL_UPLOAD_LIMIT_BYTES` (100MB) and `R2_MEMORY_UPLOAD_LIMIT_BYTES` (25MB), keep the disk-backed path at 100MB, and reduce the R2 memory-backed Multer limit to 25MB.  
- Update the size-limit error message to reflect `25MB` for R2 and `100MB` for local-disk uploads.  
- Preserved existing upload filters, local-disk fallback, and `isR2Configured()` routing behavior.  
- Chosen stability fix (b): kept the existing Multer memory-buffer flow but lowered the memory-backed cap to 25MB because wrapping the already-buffered Multer buffer with multipart streaming would not remove the initial heap buffering without a larger refactor.

### Testing
- Ran `git diff --check` which passed.  
- Ran `npm run check` (TypeScript type check), which completed but surfaced the repository’s pre-existing TypeScript errors unrelated to these changes; no new type errors were introduced by this PR.  
- Changes were confirmed in the diff for `server/lib/data-uri.ts` and `server/routes/upload.ts` and committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a368ce2d18c83258ae9fdff22f99983)