### PR TITLE
Fix R2 upload MIME safety and streaming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1073.0",
+        "@aws-sdk/lib-storage": "^3.1073.0",
         "@craftjs/core": "^0.2.12",
         "@hookform/resolvers": "^3.10.0",
         "@jridgewell/trace-mapping": "^0.3.25",
@@ -1309,6 +1310,36 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage": {
+      "version": "3.1073.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1073.0.tgz",
+      "integrity": "sha512-Mi+GuoeXGnAalKAdR2Tb/qLo46I/54P0diJDh6Io+lsGucTC4dE6MyrvLXPbS632iosGBKWuHY0J+Hkk05tCJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "buffer": "5.6.0",
+        "events": "3.3.0",
+        "stream-browserify": "3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-s3": "^3.1073.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage/node_modules/buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
@@ -11584,6 +11615,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/stream-browserify/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/streamsearch": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1073.0",
+    "@aws-sdk/lib-storage": "^3.1073.0",
     "@craftjs/core": "^0.2.12",
     "@hookform/resolvers": "^3.10.0",
     "@jridgewell/trace-mapping": "^0.3.25",

--- a/server/lib/data-uri.ts
+++ b/server/lib/data-uri.ts
@@ -28,12 +28,14 @@ export async function persistDataUri(value: string): Promise<string> {
     throw new Error("Data URI exceeds 25MB limit");
   }
 
-  const ext = MIME_TO_EXT[mime] ?? "bin";
+  const mappedExt = MIME_TO_EXT[mime];
+  const contentType = mappedExt ? mime : "application/octet-stream";
+  const ext = mappedExt ?? "bin";
   const filename = `${randomUUID()}.${ext}`;
 
   if (isR2Configured()) {
     const key = `posts/${filename}`;
-    await uploadToR2(key, buffer, mime);
+    await uploadToR2(key, buffer, contentType);
     return publicUrl(key);
   }
 

--- a/server/lib/r2.ts
+++ b/server/lib/r2.ts
@@ -1,4 +1,6 @@
+import fs from "fs";
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { Upload } from "@aws-sdk/lib-storage";
 
 const requiredEnvVars = [
   "R2_ENDPOINT",
@@ -22,18 +24,38 @@ export const r2Client = new S3Client({
   forcePathStyle: true,
 });
 
-export async function uploadToR2(key: string, body: Buffer, contentType: string): Promise<string> {
+function r2Bucket(): string {
   const bucket = process.env.R2_BUCKET;
   if (!bucket) {
     throw new Error("R2_BUCKET is required to upload media");
   }
 
+  return bucket;
+}
+
+export async function uploadToR2(key: string, body: Buffer, contentType: string): Promise<string> {
   await r2Client.send(new PutObjectCommand({
-    Bucket: bucket,
+    Bucket: r2Bucket(),
     Key: key,
     Body: body,
     ContentType: contentType,
   }));
+
+  return key;
+}
+
+export async function uploadFileToR2(key: string, filePath: string, contentType: string): Promise<string> {
+  const upload = new Upload({
+    client: r2Client,
+    params: {
+      Bucket: r2Bucket(),
+      Key: key,
+      Body: fs.createReadStream(filePath),
+      ContentType: contentType,
+    },
+  });
+
+  await upload.done();
 
   return key;
 }

--- a/server/routes/upload.ts
+++ b/server/routes/upload.ts
@@ -1,16 +1,46 @@
 import { Router } from "express";
 import multer from "multer";
+import os from "os";
 import path from "path";
 import { randomUUID } from "crypto";
 import { requireAuth } from "../middleware";
 import fs from "fs";
 import sharp from "sharp";
 import { UPLOADS_DIR, uploadUrlPath } from "../lib/uploads-dir";
-import { isR2Configured, publicUrl, uploadToR2 } from "../lib/r2";
+import { isR2Configured, publicUrl, uploadFileToR2, uploadToR2 } from "../lib/r2";
 
 const router = Router();
 
-// Configure multer for general file uploads (disk storage → UPLOADS_DIR)
+const GENERAL_UPLOAD_LIMIT_BYTES = 100 * 1024 * 1024; // 100MB
+
+const allowedGeneralUploadTypes = [
+  'application/pdf',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'video/mp4',
+  'video/quicktime',
+  'video/x-msvideo',
+  'video/webm',
+  'video/ogg',
+  'application/zip',
+  'application/epub+zip',
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+];
+
+function generalUploadFileFilter(_req: Express.Request, file: Express.Multer.File, cb: multer.FileFilterCallback) {
+  if (allowedGeneralUploadTypes.includes(file.mimetype)) {
+    cb(null, true);
+  } else {
+    cb(new Error('Invalid file type. Only PDF, DOC, Excel, videos, images, and ZIP files are allowed.'));
+  }
+}
+
+// Configure multer for general local file uploads (disk storage → UPLOADS_DIR)
 const storage = multer.diskStorage({
   destination: (_req, _file, cb) => {
     cb(null, UPLOADS_DIR);
@@ -24,69 +54,42 @@ const storage = multer.diskStorage({
 const localUpload = multer({
   storage,
   limits: {
-    fileSize: 100 * 1024 * 1024, // 100MB
+    fileSize: GENERAL_UPLOAD_LIMIT_BYTES,
   },
-  fileFilter: (_req, file, cb) => {
-    const allowedTypes = [
-      'application/pdf',
-      'application/msword',
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      'application/vnd.ms-excel',
-      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      'video/mp4',
-      'video/quicktime',
-      'video/x-msvideo',
-      'video/webm',
-      'video/ogg',
-      'application/zip',
-      'application/epub+zip',
-      'image/jpeg',
-      'image/png',
-      'image/gif',
-      'image/webp',
-    ];
-
-    if (allowedTypes.includes(file.mimetype)) {
-      cb(null, true);
-    } else {
-      cb(new Error('Invalid file type. Only PDF, DOC, Excel, videos, images, and ZIP files are allowed.'));
-    }
-  },
+  fileFilter: generalUploadFileFilter,
 });
 
-// POST /api/upload - General file upload (videos, docs, etc.)
-const memoryUpload = multer({
-  storage: multer.memoryStorage(),
+const r2TempUpload = multer({
+  storage: multer.diskStorage({
+    destination: (_req, _file, cb) => {
+      cb(null, os.tmpdir());
+    },
+    filename: (_req, file, cb) => {
+      cb(null, `chefsire-upload-${randomUUID()}${path.extname(file.originalname)}`);
+    },
+  }),
   limits: {
-    fileSize: 100 * 1024 * 1024, // 100MB
+    fileSize: GENERAL_UPLOAD_LIMIT_BYTES,
   },
-  fileFilter: (_req, file, cb) => {
-    const allowedTypes = [
-      'application/pdf',
-      'application/msword',
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      'application/vnd.ms-excel',
-      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      'video/mp4',
-      'video/quicktime',
-      'video/x-msvideo',
-      'video/webm',
-      'video/ogg',
-      'application/zip',
-      'application/epub+zip',
-      'image/jpeg',
-      'image/png',
-      'image/gif',
-      'image/webp',
-    ];
-
-    if (allowedTypes.includes(file.mimetype)) {
-      cb(null, true);
-    } else {
-      cb(new Error('Invalid file type. Only PDF, DOC, Excel, videos, images, and ZIP files are allowed.'));
-    }
-  },
+  fileFilter: generalUploadFileFilter,
 });
+
+function tempUploadPath(file?: Express.Multer.File): string | undefined {
+  return file && 'path' in file ? file.path : undefined;
+}
+
+async function cleanupTempUpload(file?: Express.Multer.File) {
+  const filePath = tempUploadPath(file);
+  if (!filePath) return;
+
+  try {
+    await fs.promises.unlink(filePath);
+  } catch (error: any) {
+    if (error?.code !== 'ENOENT') {
+      console.warn("Failed to delete temp upload:", error);
+    }
+  }
+}
 
 function extensionForUpload(file: Express.Multer.File): string {
   const ext = path.extname(file.originalname);
@@ -112,9 +115,14 @@ function extensionForUpload(file: Express.Multer.File): string {
 
 // POST /api/upload - General file upload (videos, docs, etc.)
 router.post("/", requireAuth, (req, res) => {
-  const middleware = isR2Configured() ? memoryUpload : localUpload;
+  const usingR2 = isR2Configured();
+  const middleware = usingR2 ? r2TempUpload : localUpload;
   middleware.single('file')(req, res, async (err) => {
     if (err) {
+      if (usingR2) {
+        await cleanupTempUpload(req.file);
+      }
+
       console.error("Upload error:", err);
 
       if (err instanceof multer.MulterError) {
@@ -134,9 +142,9 @@ router.post("/", requireAuth, (req, res) => {
 
       let fileUrl: string;
 
-      if (isR2Configured()) {
+      if (usingR2) {
         const key = `posts/${randomUUID()}${extensionForUpload(req.file)}`;
-        await uploadToR2(key, req.file.buffer, req.file.mimetype);
+        await uploadFileToR2(key, req.file.path, req.file.mimetype);
         fileUrl = publicUrl(key);
       } else {
         fileUrl = uploadUrlPath(req.file.filename);
@@ -152,6 +160,10 @@ router.post("/", requireAuth, (req, res) => {
     } catch (error: any) {
       console.error("Error processing upload:", error);
       res.status(500).json({ ok: false, error: error.message || "Failed to process upload" });
+    } finally {
+      if (usingR2) {
+        await cleanupTempUpload(req.file);
+      }
     }
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent persisted data-URI content from being stored with a client-supplied active MIME (e.g. `text/html`) that could be served as active content from the public R2 domain.
- Avoid buffering large general uploads (videos/PDF/ZIP) in Node heap to eliminate OOM risk during concurrent large uploads while preserving the 100MB limit.

### Description
- Harden `persistDataUri()` in `server/lib/data-uri.ts` to validate the decoded MIME against `MIME_TO_EXT` and map unknown MIME types to `application/octet-stream` with `.bin` extension, and pass the safe `contentType` into `uploadToR2` (local disk fallback uses the `.bin` filename).
- Add `uploadFileToR2(key, filePath, contentType)` to `server/lib/r2.ts` using `@aws-sdk/lib-storage`'s `Upload` with `fs.createReadStream(filePath)` for multipart streaming, while keeping existing buffer-based `uploadToR2()` for image/data-URI flows.
- Change the general `/api/upload` route in `server/routes/upload.ts` to, when `isR2Configured()` is true, accept uploads via `multer.diskStorage()` into an OS temp dir, stream the temp file to R2 via `uploadFileToR2()`, and delete the temp file on middleware-error and in a `finally` cleanup; keep the 100MB `GENERAL_UPLOAD_LIMIT_BYTES` limit and the local-disk fallback behavior unchanged.
- Leave the `/api/upload/image` route unchanged using `multer.memoryStorage()` with the 25MB limit so `sharp` still receives buffers.
- Add runtime dependency `@aws-sdk/lib-storage` in `package.json` to enable multipart streaming to R2.

### Testing
- Built the server with `npm run build:server` and the build completed successfully.
- Installed `@aws-sdk/lib-storage` with `npm i @aws-sdk/lib-storage` and recorded the dependency update in `package.json`/`package-lock.json`.
- Ran type checks with `npm run check`; the run surface showed the repository's pre-existing TypeScript errors unrelated to the modified files, and no new type errors were introduced in `server/lib/r2.ts`, `server/lib/data-uri.ts`, or `server/routes/upload.ts` as verified by filtering the `tsc` output for those files.
- Performed a local smoke test for `persistDataUri()` using `npx tsx` which verified that `data:text/html` is persisted as a `.bin` with `application/octet-stream` and `data:image/jpeg` persists as `.jpg`/`image/jpeg` (test script exercised the local-disk fallback and passed).
- Verified the general upload flow was changed to use temp-file streaming to R2 (manual inspection and smoke-run of build artifacts); image upload route remains memory-buffered and unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36b166eb688325beb7935c32148b06)