### PR TITLE
Fix nutrition campaign CTAs

### DIFF
--- a/client/src/components/nutrition/campaigns/CampaignCard.tsx
+++ b/client/src/components/nutrition/campaigns/CampaignCard.tsx
@@ -46,9 +46,9 @@ export default function CampaignCard({ campaign, featured = false }: { campaign:
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem>Preview weekly layout</DropdownMenuItem>
-              <DropdownMenuItem>Compare macros</DropdownMenuItem>
-              <DropdownMenuItem>Share campaign</DropdownMenuItem>
+              <DropdownMenuItem disabled>Preview weekly layout — Coming soon</DropdownMenuItem>
+              <DropdownMenuItem disabled>Compare macros — Coming soon</DropdownMenuItem>
+              <DropdownMenuItem disabled>Share campaign — Coming soon</DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
@@ -112,9 +112,9 @@ export default function CampaignCard({ campaign, featured = false }: { campaign:
             <span className="inline-flex items-center gap-1"><GitFork className="h-4 w-4" /> {compactNumber(campaign.remixes)} remixes</span>
           </div>
           <div className="flex gap-2">
-            <Button variant="outline" className="rounded-full">Preview</Button>
-            <Button className="rounded-full bg-slate-950 text-white hover:bg-emerald-700">
-              <GitFork className="mr-2 h-4 w-4" /> Remix
+            <Button variant="outline" className="rounded-full" disabled title="Campaign previews are coming soon.">Preview — Coming soon</Button>
+            <Button className="rounded-full bg-slate-950 text-white hover:bg-emerald-700" disabled title="Campaign remixing is coming soon.">
+              <GitFork className="mr-2 h-4 w-4" /> Remix — Coming soon
             </Button>
           </div>
         </div>

--- a/client/src/components/nutrition/campaigns/CampaignHero.tsx
+++ b/client/src/components/nutrition/campaigns/CampaignHero.tsx
@@ -1,4 +1,5 @@
 import { ArrowRight, BarChart3, Flame, GitFork, Sparkles, Users } from "lucide-react";
+import { Link } from "wouter";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -34,11 +35,11 @@ export default function CampaignHero({ campaigns }: { campaigns: NutritionCampai
             </p>
           </div>
           <div className="flex flex-wrap gap-3">
-            <Button size="lg" className="rounded-full bg-white text-slate-950 shadow-xl hover:bg-emerald-50">
-              Explore campaigns <ArrowRight className="ml-2 h-4 w-4" />
+            <Button size="lg" asChild className="rounded-full bg-white text-slate-950 shadow-xl hover:bg-emerald-50">
+              <a href="#nutrition-campaign-grid">Explore campaigns <ArrowRight className="ml-2 h-4 w-4" /></a>
             </Button>
-            <Button size="lg" variant="outline" className="rounded-full border-white/30 bg-white/10 text-white hover:bg-white/20 hover:text-white">
-              View creator playbooks
+            <Button size="lg" variant="outline" asChild className="rounded-full border-white/30 bg-white/10 text-white hover:bg-white/20 hover:text-white">
+              <Link href="/nutrition/creators">View creator playbooks</Link>
             </Button>
           </div>
           <div className="flex flex-wrap gap-2">

--- a/client/src/components/nutrition/campaigns/CampaignSaveButton.tsx
+++ b/client/src/components/nutrition/campaigns/CampaignSaveButton.tsx
@@ -1,22 +1,21 @@
-import { useState } from "react";
-import { Bookmark, Check } from "lucide-react";
+import { Bookmark } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-export default function CampaignSaveButton({ initialSaved = false, className }: { initialSaved?: boolean; className?: string }) {
-  const [saved, setSaved] = useState(initialSaved);
-
+export default function CampaignSaveButton({ className }: { initialSaved?: boolean; className?: string }) {
   return (
     <Button
       type="button"
       size="sm"
-      variant={saved ? "default" : "secondary"}
-      className={cn("gap-2 rounded-full shadow-sm", saved ? "bg-emerald-600 text-white hover:bg-emerald-700" : "bg-white/90 hover:bg-white", className)}
-      onClick={() => setSaved((current) => !current)}
+      variant="secondary"
+      className={cn("gap-2 rounded-full bg-white/90 shadow-sm hover:bg-white", className)}
+      disabled
+      aria-disabled="true"
+      title="Saving nutrition campaigns is coming soon."
     >
-      {saved ? <Check className="h-4 w-4" /> : <Bookmark className="h-4 w-4" />}
-      {saved ? "Saved" : "Save"}
+      <Bookmark className="h-4 w-4" />
+      Save — Coming soon
     </Button>
   );
 }

--- a/client/src/pages/nutrition/campaigns/NutritionCampaignFeedPage.tsx
+++ b/client/src/pages/nutrition/campaigns/NutritionCampaignFeedPage.tsx
@@ -53,8 +53,8 @@ function SectionHeader({ eyebrow, title, description }: { eyebrow: string; title
         <h2 className="mt-2 text-2xl font-black tracking-tight text-slate-950 sm:text-3xl">{title}</h2>
         <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">{description}</p>
       </div>
-      <Button variant="ghost" className="w-fit gap-2 rounded-full text-emerald-700 hover:text-emerald-800">
-        View all <ArrowRight className="h-4 w-4" />
+      <Button variant="ghost" className="w-fit gap-2 rounded-full text-emerald-700 hover:text-emerald-800" disabled title="Expanded campaign collections are coming soon.">
+        View all — Coming soon <ArrowRight className="h-4 w-4" />
       </Button>
     </div>
   );
@@ -148,7 +148,7 @@ export default function NutritionCampaignFeedPage() {
           </Card>
         </section>
 
-        <section className="space-y-5">
+        <section id="nutrition-campaign-grid" className="space-y-5 scroll-mt-6">
           <SectionHeader
             eyebrow="Discovery feed"
             title="Main Feed Grid"


### PR DESCRIPTION
### Motivation
- The nutrition campaign feed included several UI-only CTAs (save, preview, remix, dropdown actions, and section-level "View all") that appeared clickable but had no real backend or route behavior. 
- Per the safety constraints, these controls must either perform a real action, route to an existing page/modal, show a clear "Coming soon" disabled state, or be removed. 
- The change aims to make the campaign surface honest and safe without inventing backend behavior, billing, or promotion logic.

### Description
- Wired hero CTAs: `Explore campaigns` now anchors to the campaign grid and `View creator playbooks` routes to the existing creators discovery at `/nutrition/creators` by updating `CampaignHero.tsx`. 
- Disabled frontend-only campaign actions and labeled them as Coming Soon: campaign save, preview, remix, and dropdown items are now disabled with clear copy/tooltip instead of toggling a fake local state by updating `CampaignSaveButton.tsx` and `CampaignCard.tsx`. 
- Disabled the section-level `View all` CTA and added an anchor target for the campaign grid by updating `NutritionCampaignFeedPage.tsx`. 
- No backend endpoints were added; existing meal-plan social and marketplace endpoints were left intact and verified rather than faked. 
- Files changed: `client/src/components/nutrition/campaigns/CampaignHero.tsx`, `client/src/components/nutrition/campaigns/CampaignCard.tsx`, `client/src/components/nutrition/campaigns/CampaignSaveButton.tsx`, `client/src/pages/nutrition/campaigns/NutritionCampaignFeedPage.tsx`.

### Testing
- Ran `npm run build:client` and the client bundle built successfully (Vite production build completed). 
- Ran `npm run build:server` and the server bundle built successfully (esbuild completed). 
- No automated test suites were modified; both build steps completed without errors (warnings about chunk sizes were present but non-blocking).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c428d09c083259af481ba294204d4)