### PR TITLE
Fix SPA fallback for nutrition creator routes

### DIFF
--- a/client/public/.htaccess
+++ b/client/public/.htaccess
@@ -1,0 +1,15 @@
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+
+  # Keep API requests on the server/API handler instead of serving the SPA shell.
+  RewriteCond %{REQUEST_URI} ^/api(?:/|$) [NC]
+  RewriteRule ^ - [L]
+
+  # Serve real files and directories directly.
+  RewriteCond %{REQUEST_FILENAME} -f [OR]
+  RewriteCond %{REQUEST_FILENAME} -d
+  RewriteRule ^ - [L]
+
+  # Fallback all client-side routes (for example /nutrition/creators) to the SPA.
+  RewriteRule ^ index.html [L]
+</IfModule>


### PR DESCRIPTION
### Motivation
- Direct navigation to `/nutrition/creators` produced a server-level 404 in production because the built client lacked an Apache/static-server fallback even though the route and CTA exist in the SPA, so the server must route non-file, non-API requests to the SPA shell.

### Description
- Add `client/public/.htaccess` containing Apache rewrite rules that preserve `/api` handling, serve real files/directories directly, and fallback to `index.html` for client routes so links like `/nutrition/creators` are served by the SPA.

### Testing
- Ran `npm run build:client` and `npm run build:server`, verified `dist/public/.htaccess` is present, and both builds completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c4500637c8325b8d80f550e442bc1)