### PR TITLE
Hotfix: Mobile Creator Analytics visibility and disable non-persisted campaign CTAs

### DIFF
--- a/client/src/components/meal-planner/campaigns/components/CampaignActivationCard.tsx
+++ b/client/src/components/meal-planner/campaigns/components/CampaignActivationCard.tsx
@@ -13,7 +13,7 @@ type Props = {
   onCancel: () => void;
 };
 
-const CampaignActivationCard: React.FC<Props> = ({ campaign, recommendation, onStart, onCancel }) => (
+const CampaignActivationCard: React.FC<Props> = ({ campaign, recommendation, onCancel }) => (
   <Card className="border-emerald-300 bg-emerald-50/50">
     <CardHeader>
       <CardTitle className="flex items-center gap-2"><Wand2 className="h-4 w-4 text-emerald-700" />Activate Campaign</CardTitle>
@@ -38,7 +38,7 @@ const CampaignActivationCard: React.FC<Props> = ({ campaign, recommendation, onS
         </ul>
       </div>
       <div className="flex flex-wrap gap-2">
-        <Button onClick={onStart}>Start journey</Button>
+        <Button disabled aria-disabled="true" title="Campaign activation is coming soon because it is not backed by real persistence.">Start journey — Coming soon</Button>
         <Button variant="outline" onClick={onCancel}>Cancel</Button>
       </div>
     </CardContent>

--- a/client/src/components/meal-planner/campaigns/components/CampaignSuggestionCard.tsx
+++ b/client/src/components/meal-planner/campaigns/components/CampaignSuggestionCard.tsx
@@ -11,11 +11,11 @@ type CampaignSuggestionCardProps = {
   onToggleSaved: (campaignId: string) => void;
 };
 
+const CAMPAIGN_ACTION_UNAVAILABLE = 'Campaign actions are not available yet because they are not backed by real persistence.';
+
 const CampaignSuggestionCard: React.FC<CampaignSuggestionCardProps> = ({
   item,
   saved,
-  onSelect,
-  onToggleSaved,
 }) => {
   const { campaign, identity } = item;
 
@@ -57,18 +57,22 @@ const CampaignSuggestionCard: React.FC<CampaignSuggestionCardProps> = ({
       <Button
         className="mt-3"
         size="sm"
-        variant={item.isActive ? 'secondary' : 'default'}
-        onClick={() => onSelect(campaign.id)}
+        variant="secondary"
+        disabled
+        aria-disabled="true"
+        title={CAMPAIGN_ACTION_UNAVAILABLE}
       >
-        {item.isActive ? 'Active' : 'Start Campaign'}
+        {item.isActive ? 'Active campaign — Not available yet' : 'Start campaign — Coming soon'}
       </Button>
       <Button
         className="mt-2"
         size="sm"
         variant="outline"
-        onClick={() => onToggleSaved(campaign.id)}
+        disabled
+        aria-disabled="true"
+        title={CAMPAIGN_ACTION_UNAVAILABLE}
       >
-        {saved ? 'Saved' : 'Save Campaign'}
+        {saved ? 'Saved campaign — Not available yet' : 'Save campaign — Coming soon'}
       </Button>
     </div>
   );

--- a/client/src/pages/nutrition/MealPlanCreator.tsx
+++ b/client/src/pages/nutrition/MealPlanCreator.tsx
@@ -371,7 +371,7 @@ export default function MealPlanCreator() {
       )}
 
       {/* ── Header ── */}
-      <div className="flex items-center justify-between mb-8">
+      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-3xl font-bold flex items-center gap-2">
             <ChefHat className="w-8 h-8 text-orange-500" />
@@ -379,12 +379,12 @@ export default function MealPlanCreator() {
           </h1>
           <p className="text-muted-foreground mt-1">Create and sell your meal plan templates</p>
         </div>
-        <div className="flex gap-2">
-          <Button variant="outline" onClick={() => setLocation("/nutrition/analytics")}>
+        <div className="grid w-full grid-cols-1 gap-2 sm:w-auto sm:grid-cols-2">
+          <Button className="w-full justify-center" variant="outline" onClick={() => setLocation("/nutrition/analytics")}>
             <TrendingUp className="w-4 h-4 mr-2" />
             Analytics
           </Button>
-          <Button onClick={() => setShowCreateForm(!showCreateForm)}>
+          <Button className="w-full justify-center" onClick={() => setShowCreateForm(!showCreateForm)}>
             <Plus className="w-4 h-4 mr-2" />
             Create New Plan
           </Button>

--- a/client/src/pages/nutrition/MealPlanCreatorStorefrontPage.tsx
+++ b/client/src/pages/nutrition/MealPlanCreatorStorefrontPage.tsx
@@ -94,7 +94,7 @@ export default function MealPlanCreatorStorefrontPage() {
   const topSavedPlans = [...plans].sort((a, b) => Number(b.social?.saveCount || 0) - Number(a.social?.saveCount || 0)).slice(0, 3);
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 p-6">
+    <div className="mx-auto max-w-6xl space-y-6 p-4 sm:p-6">
       <Card>
         <CardContent className="flex flex-col gap-5 p-6 md:flex-row md:items-center">
           <Avatar className="h-24 w-24">
@@ -109,11 +109,11 @@ export default function MealPlanCreatorStorefrontPage() {
             <p className="mt-1 text-sm text-muted-foreground">@{creator.username} • {creator.followerCount || 0} followers</p>
             {creator.bio ? <p className="mt-3 max-w-3xl text-muted-foreground">{creator.bio}</p> : <p className="mt-3 text-muted-foreground">This creator is building a meal-planner storefront.</p>}
           </div>
-          <div className="flex flex-col gap-2">
+          <div className="grid w-full grid-cols-1 gap-2 sm:grid-cols-2 md:w-auto md:grid-cols-1">
             <CreatorFollowButton creatorId={creator.id} />
-            <Button variant="outline" onClick={() => setLocation("/nutrition/analytics")}><BarChart3 className="mr-2 h-4 w-4" />Creator Analytics</Button>
-            <Button variant="outline" onClick={() => document.getElementById("creator-plans")?.scrollIntoView({ behavior: "smooth" })}>Browse Plans</Button>
-            <Button variant="outline" onClick={() => document.getElementById("creator-shared-weeks")?.scrollIntoView({ behavior: "smooth" })}>View Shared Weeks</Button>
+            <Button className="w-full justify-center" variant="outline" onClick={() => setLocation("/nutrition/analytics")}><BarChart3 className="mr-2 h-4 w-4" />Creator Analytics</Button>
+            <Button className="w-full justify-center" variant="outline" onClick={() => document.getElementById("creator-plans")?.scrollIntoView({ behavior: "smooth" })}>Browse Plans</Button>
+            <Button className="w-full justify-center" variant="outline" onClick={() => document.getElementById("creator-shared-weeks")?.scrollIntoView({ behavior: "smooth" })}>View Shared Weeks</Button>
           </div>
         </CardContent>
       </Card>

--- a/client/src/pages/nutrition/MealPlanDetailsPage.tsx
+++ b/client/src/pages/nutrition/MealPlanDetailsPage.tsx
@@ -221,11 +221,11 @@ export default function MealPlanDetailsPage() {
               <CardTitle>Overview</CardTitle>
               <CardDescription>
                 {creator ? (
-                  <span className="inline-flex items-center gap-2">
+                  <span className="flex flex-col items-start gap-2 sm:inline-flex sm:flex-row sm:items-center">
                     <User className="w-4 h-4" />
                     By <CreatorProfileLink creatorId={creator.id}>{creator.displayName || creator.username}</CreatorProfileLink>
                     <CreatorFollowButton creatorId={creator.id} compact />
-                    {user?.id === creator.id ? <Button size="sm" variant="outline" onClick={() => setLocation("/nutrition/analytics")}><BarChart3 className="mr-1 h-3.5 w-3.5" />Analytics</Button> : null}
+                    {user?.id === creator.id ? <Button className="w-full justify-center sm:w-auto" size="sm" variant="outline" onClick={() => setLocation("/nutrition/analytics")}><BarChart3 className="mr-1 h-3.5 w-3.5" />Analytics</Button> : null}
                   </span>
                 ) : null}
               </CardDescription>


### PR DESCRIPTION
### Motivation
- Creator Analytics controls were present in the UI but used desktop-inline layouts and could be squeezed out or hidden on narrow/mobile screens so analytics was not obvious on mobile. 
- Several campaign CTAs (`Start`, `Save`, activation `Start journey`) exposed local-only or non-persisted behavior that made the UI appear actionable when no real backend persistence or route existed. 
- This is a focused, additive hotfix to make the UI honest: surface Analytics on mobile and disable CTAs that can't perform real actions (no fake backend behavior added). 

### Description
- Make Analytics buttons responsive and clearly visible on mobile by converting the creator action areas to mobile-first grid/stack layouts and full-width action buttons in `MealPlanCreatorStorefrontPage`, `MealPlanCreator`, and `MealPlanDetailsPage`. 
- Disable non-persisted campaign CTAs in the campaign suggestion card: `Start` is disabled and labeled `Start campaign — Coming soon`, and `Save` is disabled and labeled `Save campaign — Coming soon`/`Saved campaign — Not available yet`; these buttons include `aria-disabled` and explanatory `title` text. 
- Prevent the campaign activation confirmation from invoking a local-only start by disabling the `Start journey` button and labeling it `Start journey — Coming soon`. 
- No backend routes, persistence, ads, billing, or unrelated major feature changes were added or removed; changes are UI-only and intentionally conservative. 
- Files changed: `client/src/pages/nutrition/MealPlanCreatorStorefrontPage.tsx`, `client/src/pages/nutrition/MealPlanCreator.tsx`, `client/src/pages/nutrition/MealPlanDetailsPage.tsx`, `client/src/components/meal-planner/campaigns/components/CampaignSuggestionCard.tsx`, and `client/src/components/meal-planner/campaigns/components/CampaignActivationCard.tsx`. 

### Testing
- Ran `npm run build:client` and the client build completed successfully (Vite production build completed). 
- Ran `npm run build:server` and the server build completed successfully (esbuild bundle created). 
- No automated unit tests were added or modified as this is a targeted hotfix to layout/CTA state behavior; both builds succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d8ebd91ac8325a71f71de0cb4e26c)