### PR TITLE
Hotfix: mobile Creator Analytics CTA + Start Campaign success feedback

### DIFF
--- a/client/src/components/NutritionMealPlanner.tsx
+++ b/client/src/components/NutritionMealPlanner.tsx
@@ -2340,6 +2340,7 @@ const NutritionMealPlanner = () => {
     activeCampaignProgress,
     visibleCoachInsights,
     activeCampaignId,
+    lastActivatedCampaignId,
     activateCampaign,
     clearCampaign,
     campaignActionPending,
@@ -3757,6 +3758,7 @@ const NutritionMealPlanner = () => {
               />
               <NutritionCampaignPanel
                 activeCampaignId={activeCampaignId}
+                lastActivatedCampaignId={lastActivatedCampaignId}
                 progress={activeCampaignProgress}
                 onActivateCampaign={activateCampaign}
                 onClearCampaign={clearCampaign}

--- a/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
+++ b/client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Trophy, Sparkles } from 'lucide-react';
+import { CheckCircle2, Trophy, Sparkles } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
@@ -46,6 +46,7 @@ class TimelineErrorBoundary extends React.Component<React.PropsWithChildren, { h
 
 type Props = {
   activeCampaignId: string | null;
+  lastActivatedCampaignId?: string | null;
   progress: NutritionCampaignProgress | null;
   onActivateCampaign: (campaignId: string) => void | Promise<void>;
   campaignActionPending?: boolean;
@@ -56,6 +57,7 @@ type Props = {
 
 const NutritionCampaignPanel: React.FC<Props> = ({
   activeCampaignId,
+  lastActivatedCampaignId = null,
   progress,
   onActivateCampaign,
   onClearCampaign,
@@ -134,13 +136,25 @@ const NutritionCampaignPanel: React.FC<Props> = ({
         <CardContent>
           {activeCampaign && progress ? (
             <div className="space-y-4">
+              {lastActivatedCampaignId === activeCampaign.id ? (
+                <div className="rounded-lg border border-emerald-300 bg-emerald-50 p-3 text-sm text-emerald-900" role="status" aria-live="polite">
+                  <div className="flex items-center gap-2 font-semibold">
+                    <CheckCircle2 className="h-4 w-4" />
+                    Campaign is active: {activeCampaign.title}
+                  </div>
+                  <p className="mt-1 text-xs">
+                    Started successfully from the server. Progress is now {progress.completionPct}% with {progress.completedMissions} of {progress.totalMissions} missions complete.
+                  </p>
+                </div>
+              ) : null}
+
               <CampaignHeaderSummary
                 campaign={activeCampaign}
                 progress={progress}
                 recommendation={activeRecommendation}
               />
 
-              <Progress value={progress.completionPct} />
+              <Progress value={progress.completionPct} aria-label={`${activeCampaign.title} progress`} />
 
               <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
                 {progress.missionProgress.map((item) => (

--- a/client/src/components/meal-planner/hooks/usePlannerCampaignState.ts
+++ b/client/src/components/meal-planner/hooks/usePlannerCampaignState.ts
@@ -4,6 +4,7 @@ import { fetchCampaignState, startCampaign } from '@/components/meal-planner/cam
 export const usePlannerCampaignState = (userId?: string | null) => {
   const [activeCampaignId, setActiveCampaignId] = useState<string | null>(null);
   const [activeCampaignStartedAt, setActiveCampaignStartedAt] = useState<string | null>(null);
+  const [lastActivatedCampaignId, setLastActivatedCampaignId] = useState<string | null>(null);
 
   const [campaignActionPending, setCampaignActionPending] = useState(false);
   const [campaignActionError, setCampaignActionError] = useState<string | null>(null);
@@ -16,6 +17,7 @@ export const usePlannerCampaignState = (userId?: string | null) => {
         if (!mounted) return;
         setActiveCampaignId(state.activeCampaign?.campaignId ?? null);
         setActiveCampaignStartedAt(state.activeCampaign?.startedAt ?? null);
+        setLastActivatedCampaignId(null);
       })
       .catch((error) => { if (mounted) setCampaignActionError(error instanceof Error ? error.message : 'Failed to load campaign state'); });
     return () => { mounted = false; };
@@ -28,6 +30,7 @@ export const usePlannerCampaignState = (userId?: string | null) => {
       const active = await startCampaign(campaignId);
       setActiveCampaignId(active.campaignId);
       setActiveCampaignStartedAt(active.startedAt ?? new Date().toISOString());
+      setLastActivatedCampaignId(active.campaignId);
     } catch (error) {
       setCampaignActionError(error instanceof Error ? error.message : 'Failed to start campaign');
       throw error;
@@ -39,6 +42,7 @@ export const usePlannerCampaignState = (userId?: string | null) => {
   const clearCampaign = () => {
     setActiveCampaignId(null);
     setActiveCampaignStartedAt(null);
+    setLastActivatedCampaignId(null);
 
   };
 
@@ -46,6 +50,7 @@ export const usePlannerCampaignState = (userId?: string | null) => {
     activeCampaignId,
     setActiveCampaignId,
     activeCampaignStartedAt,
+    lastActivatedCampaignId,
     setActiveCampaignStartedAt,
     activateCampaign,
     clearCampaign,

--- a/client/src/components/meal-planner/hooks/usePlannerCampaignState.ts
+++ b/client/src/components/meal-planner/hooks/usePlannerCampaignState.ts
@@ -1,10 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { fetchCampaignState, startCampaign } from '@/components/meal-planner/campaigns/api/campaignPersistenceApi';
 
 export const usePlannerCampaignState = (userId?: string | null) => {
   const [activeCampaignId, setActiveCampaignId] = useState<string | null>(null);
   const [activeCampaignStartedAt, setActiveCampaignStartedAt] = useState<string | null>(null);
   const [lastActivatedCampaignId, setLastActivatedCampaignId] = useState<string | null>(null);
+  const activationVersionRef = useRef(0);
 
   const [campaignActionPending, setCampaignActionPending] = useState(false);
   const [campaignActionError, setCampaignActionError] = useState<string | null>(null);
@@ -12,14 +13,19 @@ export const usePlannerCampaignState = (userId?: string | null) => {
   useEffect(() => {
     if (!userId) return;
     let mounted = true;
+    const loadActivationVersion = activationVersionRef.current;
     fetchCampaignState()
       .then((state) => {
-        if (!mounted) return;
+        if (!mounted || activationVersionRef.current !== loadActivationVersion) return;
         setActiveCampaignId(state.activeCampaign?.campaignId ?? null);
         setActiveCampaignStartedAt(state.activeCampaign?.startedAt ?? null);
         setLastActivatedCampaignId(null);
       })
-      .catch((error) => { if (mounted) setCampaignActionError(error instanceof Error ? error.message : 'Failed to load campaign state'); });
+      .catch((error) => {
+        if (mounted && activationVersionRef.current === loadActivationVersion) {
+          setCampaignActionError(error instanceof Error ? error.message : 'Failed to load campaign state');
+        }
+      });
     return () => { mounted = false; };
   }, [userId]);
 
@@ -28,6 +34,7 @@ export const usePlannerCampaignState = (userId?: string | null) => {
     setCampaignActionError(null);
     try {
       const active = await startCampaign(campaignId);
+      activationVersionRef.current += 1;
       setActiveCampaignId(active.campaignId);
       setActiveCampaignStartedAt(active.startedAt ?? new Date().toISOString());
       setLastActivatedCampaignId(active.campaignId);

--- a/client/src/components/meal-planner/hooks/usePlannerCampaigns.ts
+++ b/client/src/components/meal-planner/hooks/usePlannerCampaigns.ts
@@ -49,6 +49,7 @@ export const usePlannerCampaigns = ({
   const {
     activeCampaignId,
     activeCampaignStartedAt,
+    lastActivatedCampaignId,
     activateCampaign,
     clearCampaign,
     campaignActionPending,
@@ -139,6 +140,7 @@ export const usePlannerCampaigns = ({
     visibleCoachInsights,
     activeCampaignId,
     activeCampaignStartedAt,
+    lastActivatedCampaignId,
     activateCampaign,
     clearCampaign,
     campaignActionPending,

--- a/client/src/pages/nutrition/MealPlanCreator.tsx
+++ b/client/src/pages/nutrition/MealPlanCreator.tsx
@@ -380,7 +380,11 @@ export default function MealPlanCreator() {
           <p className="text-muted-foreground mt-1">Create and sell your meal plan templates</p>
         </div>
         <div className="grid w-full grid-cols-1 gap-2 sm:w-auto sm:grid-cols-2" aria-label="Creator dashboard actions">
-          <Button className="w-full justify-center" variant="outline" onClick={() => setLocation("/nutrition/analytics")}>
+          <Button className="w-full justify-center sm:hidden" variant="outline" onClick={() => setLocation("/nutrition/analytics")} aria-label="Open creator analytics">
+            <TrendingUp className="w-4 h-4 mr-2" />
+            Analytics
+          </Button>
+          <Button className="hidden w-full justify-center sm:inline-flex" variant="outline" onClick={() => setLocation("/nutrition/analytics")}>
             <TrendingUp className="w-4 h-4 mr-2" />
             Analytics
           </Button>

--- a/client/src/pages/nutrition/MealPlanCreatorStorefrontPage.tsx
+++ b/client/src/pages/nutrition/MealPlanCreatorStorefrontPage.tsx
@@ -110,8 +110,11 @@ export default function MealPlanCreatorStorefrontPage() {
             {creator.bio ? <p className="mt-3 max-w-3xl text-muted-foreground">{creator.bio}</p> : <p className="mt-3 text-muted-foreground">This creator is building a meal-planner storefront.</p>}
           </div>
           <div className="grid w-full grid-cols-1 gap-2 sm:grid-cols-2 md:w-auto md:grid-cols-1" aria-label="Creator storefront actions">
+            <Button className="w-full justify-center sm:hidden" variant="outline" onClick={() => setLocation("/nutrition/analytics")} aria-label="Open creator analytics">
+              <BarChart3 className="mr-2 h-4 w-4" />Creator Analytics
+            </Button>
             <CreatorFollowButton creatorId={creator.id} />
-            <Button className="w-full justify-center" variant="outline" onClick={() => setLocation("/nutrition/analytics")}><BarChart3 className="mr-2 h-4 w-4" />Creator Analytics</Button>
+            <Button className="hidden w-full justify-center sm:inline-flex" variant="outline" onClick={() => setLocation("/nutrition/analytics")}><BarChart3 className="mr-2 h-4 w-4" />Creator Analytics</Button>
             <Button className="w-full justify-center" variant="outline" onClick={() => document.getElementById("creator-plans")?.scrollIntoView({ behavior: "smooth" })}>Browse Plans</Button>
             <Button className="w-full justify-center" variant="outline" onClick={() => document.getElementById("creator-shared-weeks")?.scrollIntoView({ behavior: "smooth" })}>View Shared Weeks</Button>
           </div>

--- a/client/src/pages/nutrition/MealPlanDetailsPage.tsx
+++ b/client/src/pages/nutrition/MealPlanDetailsPage.tsx
@@ -219,6 +219,12 @@ export default function MealPlanDetailsPage() {
           <Card>
             <CardHeader>
               <CardTitle>Overview</CardTitle>
+              {user?.id === creator?.id ? (
+                <Button className="w-full justify-center sm:hidden" size="sm" variant="outline" onClick={() => setLocation("/nutrition/analytics")} aria-label="Open creator analytics">
+                  <BarChart3 className="mr-2 h-4 w-4" />
+                  Creator Analytics
+                </Button>
+              ) : null}
               <CardDescription>
                 {creator ? (
                   <span className="flex flex-col items-start gap-2 sm:inline-flex sm:flex-row sm:items-center">
@@ -231,12 +237,6 @@ export default function MealPlanDetailsPage() {
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
-              {user?.id === creator?.id ? (
-                <Button className="w-full justify-center sm:hidden" size="sm" variant="outline" onClick={() => setLocation("/nutrition/analytics")} aria-label="Open creator analytics">
-                  <BarChart3 className="mr-2 h-4 w-4" />
-                  Creator Analytics
-                </Button>
-              ) : null}
               {isLoading ? <div className="text-sm text-muted-foreground">Loading details…</div> : null}
 
               {blueprint ? (


### PR DESCRIPTION
### Motivation
- Mobile users could not find Creator Analytics because desktop buttons were merely reshaped instead of providing an explicit mobile CTA. 
- Starting a campaign was clickable but produced no clear, server-confirmed user-visible result after activation. 
- The intent is to make Analytics discoverable on mobile at key creator surfaces and to show deterministic feedback when a campaign is started (only after backend success). 

### Description
- Added explicit mobile-only Analytics CTAs that are always visible on small screens and keep the existing desktop Analytics buttons, routing to the real Creator Analytics route `"/nutrition/analytics"` in `Client` routes. Exact JSX locations where the mobile CTA was added: `client/src/pages/nutrition/MealPlanCreatorStorefrontPage.tsx` (header action grid around the storefront actions), `client/src/pages/nutrition/MealPlanCreator.tsx` (creator dashboard header actions), and `client/src/pages/nutrition/MealPlanDetailsPage.tsx` (Overview card header for owned meal-plans). 
- Implemented server-confirmed Start Campaign feedback by tracking the backend activation response returned from `POST /api/meal-planner/campaigns/active` (client API call in `client/src/components/meal-planner/campaigns/api/campaignPersistenceApi.ts`) and exposing the newly activated campaign id via `lastActivatedCampaignId` in the planner campaign state hooks (`usePlannerCampaignState` / `usePlannerCampaigns`). 
- Added a clear active-state banner in the campaign panel that is shown when `lastActivatedCampaignId === activeCampaign.id`, displaying a success message with the campaign title and progress / missions completed in `client/src/components/meal-planner/campaigns/NutritionCampaignPanel.tsx`. 

### Testing
- Ran `npm run build:client` and the client build completed successfully. 
- Ran `npm run build:server` and the server build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43ef6f28b48325bf3474ae08a0ebeb)